### PR TITLE
Issue/logger output missing class name 1000684

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/DefaultLogger.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/DefaultLogger.scala
@@ -5,6 +5,13 @@ import org.eclipse.core.runtime.Status
 import org.eclipse.core.runtime.IStatus
 import scala.util.control.ControlThrowable
 
+private[util] object DefaultLogger {
+  def apply(clazz: Class[_]): Logger = {
+   val name = if(clazz.isAnonymousClass()) clazz.getName else clazz.getSimpleName
+   new DefaultLogger(name)
+  }
+}
+
 /**
  * The `DefaultLogger` is a minimal implementation of a logger. 
  * On the one hand, calling {{{info}}} or {{{debug}}} will output 
@@ -18,7 +25,7 @@ import scala.util.control.ControlThrowable
  * [In the future the default logger should become somewhat more robust and
  * easy to configure, using Log4J or similar seem a good solution.
  */
-private[util] object DefaultLogger extends Logger {
+private class DefaultLogger(name: String) extends Logger {
   private object Category extends Enumeration {
     val INFO, DEBUG, ERROR = Value
   }
@@ -30,7 +37,6 @@ private[util] object DefaultLogger extends Logger {
 
   private def log(message: String, cat: Value = INFO) = {
     val printer = if (cat eq ERROR) System.err else System.out
-    val name = if (getClass().isAnonymousClass) getClass.getName else getClass.getSimpleName
 
     printer.format("[%s] %s%n", name, message)
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/HasLogger.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/HasLogger.scala
@@ -5,5 +5,8 @@ package scala.tools.eclipse.util
  * Clients are allowed to inject a different logger.
  */
 trait HasLogger {
-  protected[this] val logger: Logger = DefaultLogger
+  protected[this] val logger: Logger = {
+    val clazz = this.getClass
+    DefaultLogger(clazz)
+  }
 }


### PR DESCRIPTION
Fixed #1000684. When calling a logger's method, the name of the class is now correctly added to the outputted message.
