### PR TITLE
Stop resetting compilers when the classpath invalid

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -401,10 +401,14 @@ class ScalaProject(val underlying: IProject) extends HasLogger {
   def classpathHasChanged() {
     classpathCheckLock.synchronized {
       try {
-        resetCompilers()
         // mark as in progress
         classpathHasBeenChecked= false
         checkClasspath()
+        if (classpathValid) {
+          // no point to reset the compilers on an invalid classpath,
+          // it would not work anyway
+          resetCompilers()
+        }
       }
     }
   }


### PR DESCRIPTION
Re #1000631. Modified so the compilers are not reset when the classpath is invalid.

The reset in this case is useless, generates log and was making the tests fail on trully
headless systems.

Please review.
