### PR TITLE
Created a new indenter strategy that will automatically add a closing bracket

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
@@ -34,6 +34,7 @@ import scala.tools.eclipse.util.ReflectionUtils
 import scala.tools.eclipse.lexical._
 import scala.tools.eclipse.formatter.ScalaFormattingStrategy
 import scala.tools.eclipse.properties.ScalaSyntaxClasses
+import scala.tools.eclipse.ui.AutoCloseBracketStrategy
 
 class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceStore: IPreferenceStore, editor: ITextEditor)
    extends JavaSourceViewerConfiguration(JavaPlugin.getDefault.getJavaTextTools.getColorManager, store, editor, IJavaPartitions.JAVA_PARTITIONING) {
@@ -120,7 +121,7 @@ class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceSto
          case IJavaPartitions.JAVA_STRING =>
             Array(new SmartSemicolonAutoEditStrategy(partitioning), new JavaStringAutoIndentStrategy(partitioning))
          case IJavaPartitions.JAVA_CHARACTER | IDocument.DEFAULT_CONTENT_TYPE =>
-            Array(new SmartSemicolonAutoEditStrategy(partitioning), new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, new JdtPreferenceProvider(getProject)))
+            Array(new SmartSemicolonAutoEditStrategy(partitioning), new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, new JdtPreferenceProvider(getProject)), new AutoCloseBracketStrategy)
          case _ =>
             Array(new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, new JdtPreferenceProvider(getProject)))
       }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/AutoCloseBracketStrategy.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/AutoCloseBracketStrategy.scala
@@ -1,0 +1,16 @@
+package scala.tools.eclipse.ui
+
+import org.eclipse.jface.text.DocumentCommand
+import org.eclipse.jface.text.IAutoEditStrategy
+import org.eclipse.jface.text.IDocument
+
+/** Automatically adds a matching closing bracket whenever the user enters a left bracket. */
+class AutoCloseBracketStrategy extends IAutoEditStrategy {
+  def customizeDocumentCommand(document: IDocument, command: DocumentCommand) {
+    if (command.text == "{") {
+      command.text = command.text + "}"
+      command.caretOffset = command.offset + 1
+      command.shiftsCaret = false
+    }
+  }
+}


### PR DESCRIPTION
Created a new indenter strategy that will automatically add a closing bracket every time the user enters a left bracket (the caret's position is set in-between brackets).
This strategy is only applied if the text partitioning that is being indented is either a 'IJavaPartitions.JAVA_CHARACTER' or a 'IDocument.DEFAULT_CONTENT_TYPE' (this because we want things like IJavaPartitions.JAVA_DOC or IJavaPartitions.JAVA_MULTI_LINE_COMMENT not to be affected by this strategy. Check class 'ScalaSourceViewerConfiguration' for more details).
Fixed #1000688.
