### PR TITLE
Textual oracles used for comparing structure builder results are now OS agnostic

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/BaseTestOracle.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/BaseTestOracle.scala
@@ -1,0 +1,9 @@
+package scala.tools.eclipse.structurebuilder
+
+private[structurebuilder] trait BaseTestOracle {
+  final def expectedFragment = makeOSAgnostic(oracle).trim
+  
+  private def makeOSAgnostic(text: String): String = text.replaceAll("\\r\\n","\n")
+  
+  protected def oracle: String
+}

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/T1000568TestOracle.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/T1000568TestOracle.scala
@@ -1,7 +1,7 @@
 package scala.tools.eclipse.structurebuilder
 
-object T1000568TestOracle {
-  lazy val expectedFragment = """
+object T1000568TestOracle extends BaseTestOracle {
+  override protected lazy val oracle = """
 Entity.scala [in t1000568 [in src [in simple-structure-builder]]]
   package t1000568
   class Entity
@@ -11,5 +11,5 @@ ExtensionTester.java [in t1000568 [in src [in simple-structure-builder]]]
   package t1000568
   class ExtensionTester
     void doSomething()
-""".trim
+"""
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/T1000586TestOracle.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/T1000586TestOracle.scala
@@ -1,12 +1,12 @@
 package scala.tools.eclipse.structurebuilder
 
-object T1000586TestOracle {
-  lazy val expectedFragment = """
+object T1000586TestOracle extends BaseTestOracle {
+  override protected lazy val oracle = """
 Foo.scala [in t1000586 [in src [in simple-structure-builder]]]
   package t1000586
   class Foo
     Foo()
     t1000586.Foo[] getFoos()
     scala.Option<t1000586.Foo[]> getFoos2()
-""".trim
+"""
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/T1000711TestOracle.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/T1000711TestOracle.scala
@@ -1,7 +1,7 @@
 package scala.tools.eclipse.structurebuilder
 
-object T1000711TestOracle {
-  lazy val expectedFragment = """
+object T1000711TestOracle extends BaseTestOracle {
+  override protected lazy val oracle = """
 Nested.scala [in t1000711 [in src [in simple-structure-builder]]]
   package t1000711
   class Nested$
@@ -47,5 +47,5 @@ Nested.scala [in t1000711 [in src [in simple-structure-builder]]]
       class C$
         t1000711.Nested.A.C MODULE$
         C$()
-""".trim
+"""
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/TraitsTestOracle.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/TraitsTestOracle.scala
@@ -1,7 +1,7 @@
 package scala.tools.eclipse.structurebuilder
 
-object TraitsTestOracle {
-  lazy val expectedFragment = """
+object TraitsTestOracle extends BaseTestOracle {
+  override protected lazy val oracle = """
 T1.scala [in traits [in src [in simple-structure-builder]]]
   package traits
   interface T1
@@ -72,5 +72,5 @@ C1.scala [in traits [in src [in simple-structure-builder]]]
         $anon()
         void run()
     int localMethod(int)
-    long localVals(int)""".trim
+    long localVals(int)"""
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
@@ -63,7 +63,7 @@ class NewApplicationWizard extends BasicNewResourceWizard with HasLogger {
   }
 
   private def createSource(applicationName: String, pkg: IPackageFragment): String = {
-    val appExists = try { Class.forName("scala.App"); true } catch { case _ ⇒ false }
+    val appExists = try { Class.forName("scala.App"); true } catch { case _ => false }
     val packageDeclaration = if (pkg.isDefaultPackage) "" else "package " + pkg.getElementName + "\n\n"
     val objectTemplate = if (appExists) TEMPLATE_WITH_APP else TEMPLATE_WITHOUT_APP
     val unformatted = packageDeclaration + objectTemplate.format(applicationName)


### PR DESCRIPTION
Tests should pass on both Windows and OSX. Fixed #1000732.
