### PR TITLE
Issue/no open editor cause npe 1000741

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/jcompiler/AbstractMethodVerifierTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/jcompiler/AbstractMethodVerifierTest.scala
@@ -50,13 +50,39 @@ object AbstractMethodVerifierTest extends TestProjectSetup("jcompiler") {
         }
       }
     }
+
+    def verifyThat(expectedProblem: String) = new {
+      def is = new {
+        def reported = {
+          //when
+          val unit = compilationUnit(path2unit)
+          
+          val owner = new WorkingCopyOwner() {
+            override def getProblemRequestor(unit: ICompilationUnit): IProblemRequestor = {
+              new IProblemRequestor {
+                override def acceptProblem(problem: IProblem) {
+                  //verify
+                  assertEquals(expectedProblem, problem.toString())
+                }
+                def beginReporting() {}
+                def endReporting() {}
+                def isActive(): Boolean = true
+              }
+            }
+          }
+          
+          //then
+          // this will trigger the java reconciler so that the problems will be reported in the ProblemReporter
+          unit.getWorkingCopy(owner, new NullProgressMonitor)
+        }
+      }
+    }
   }
 
   private def no: VerificationMode = never()
   private def one: VerificationMode = times(1)
 }
 
-@Ignore
 class AbstractMethodVerifierTest {
   import AbstractMethodVerifierTest._
 
@@ -88,5 +114,42 @@ class AbstractMethodVerifierTest {
   @Test
   def javaClassExtendingAbstractScalaClassWithMixedDeferredAndConcreteMembersWithSameSignature_JavaEditorShouldNotReportErrorsForUnimplementedDeferredMethod_t1000670_2() {
     whenOpening("t1000670_2/JFoo.java").verifyThat(no).errors.are.reported
+  }
+
+  @Test
+  def scalaMethodVerifierProvider_isNotExecutedOnJavaSources_t1000660() {
+    val expectedProblem = "Pb(400) The type ScalaTest must implement the inherited abstract method Runnable.run()"
+
+    whenOpening("t1000660/ScalaTest.java").verifyThat(expectedProblem).is.reported
+  }
+  
+  @Test
+  def t1000741() {
+    whenOpening("t1000741/FooImpl.java").verifyThat(no).errors.are.reported
+  }
+    
+  @Test
+  def protectedScalaEntitiesNeedToBeExposedToJDTAsPublic_t1000751() {
+    whenOpening("t1000751/J.java").verifyThat(no).errors.are.reported
+  }
+  
+  @Test
+  def scalaAnyRefNeedToBeMappedIntoJavaLangObject_ToBeCorrectlyExposedToJDT_1000752() {
+    whenOpening("t1000752/J.java").verifyThat(no).errors.are.reported
+  }
+  
+  @Test
+  def scalaArrayNeedToBeMappedIntoJavaArray_ToBeCorrectlyExposedToJDT_t1000752_1() {
+    whenOpening("t1000752_1/J.java").verifyThat(no).errors.are.reported
+  }
+  
+  @Test
+  def simplifiedExampleFromAkkaSources_ThatWasCausingWrongErrorsToBeReportedInTheJavaEditor_t1000752_2() {
+    whenOpening("t1000752_2/JavaAPITestActor.java").verifyThat(no).errors.are.reported
+  }
+  
+  @Test
+  def wideningAccessModifiersOfInherithedMethod_t1000752_3() {
+    whenOpening("t1000752_3/J.java").verifyThat(no).errors.are.reported
   }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000660/ScalaTest.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000660/ScalaTest.java
@@ -1,0 +1,7 @@
+package t1000660;
+
+public class ScalaTest implements Runnable {
+  // The Runnable interface contains one abstract method `run`. Therefore, 
+  // we expect an error to be reported because we don't provide the implementation
+  // of the method.
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/AFoo.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/AFoo.scala
@@ -1,0 +1,3 @@
+package t1000741
+
+abstract class AFoo extends TFoo

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/FooImpl.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/FooImpl.java
@@ -1,0 +1,4 @@
+package t1000741;
+
+
+public class FooImpl extends AFoo implements IFoo {}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/IFoo.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/IFoo.java
@@ -1,0 +1,5 @@
+package t1000741;
+
+public interface IFoo {
+	void foo();
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/TFoo.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000741/TFoo.scala
@@ -1,0 +1,5 @@
+package t1000741
+
+trait TFoo extends IFoo {
+  def foo() {}
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000751/J.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000751/J.java
@@ -1,0 +1,3 @@
+package t1000751;
+
+public class J extends ATop {}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000751/Top.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000751/Top.scala
@@ -1,0 +1,9 @@
+package t1000751
+
+trait Top {
+  protected def foo
+}
+
+abstract class ATop extends Top {
+  final protected def foo {}
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752/J.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752/J.java
@@ -1,0 +1,3 @@
+package t1000752;
+
+public class J extends ATop {}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752/Top.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752/Top.scala
@@ -1,0 +1,7 @@
+package t1000752
+
+trait Top {
+  def loggable(self: AnyRef) {}
+}
+
+abstract class ATop extends Top {}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_1/J.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_1/J.java
@@ -1,0 +1,3 @@
+package t1000752_1;
+
+public class J extends ATop {}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_1/Top.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_1/Top.scala
@@ -1,0 +1,7 @@
+package t1000752_1
+
+trait Top {
+  def loggable(self: Array[String]) {}
+}
+
+abstract class ATop extends Top {}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/Actor.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/Actor.scala
@@ -1,0 +1,57 @@
+package t1000752_2
+
+object Actor {
+  type Receive = PartialFunction[Any, Unit]
+}
+
+trait Actor {
+  import Actor._
+
+  type Receive = Actor.Receive
+  
+  trait MessageDispatcher
+
+  def loggable(self: AnyRef)(r: Receive): Receive = null
+
+  def someSelf: Some[ActorRef with ScalaActorRef] = Some(null)
+  
+  def optionSelf: Option[ActorRef with ScalaActorRef] = someSelf 
+
+  implicit def self = someSelf.get
+
+  @inline
+  final def sender: ActorRef = null
+
+  def receiveTimeout: Option[Long] = None
+
+  def receiveTimeout_=(timeout: Option[Long]) {}
+
+  def children: Iterable[ActorRef] = null
+
+  def dispatcher: MessageDispatcher = null
+
+  protected def receive: Receive
+
+  def preStart() {}
+  
+  def postStop() {}
+
+  def preRestart(reason: Throwable, message: Option[Any]) { postStop() }
+
+  def postRestart(reason: Throwable) { preStart() }
+
+  def unhandled(message: Any) {}
+  
+  def become(behavior: Receive, discardOld: Boolean = true) { }
+
+  def unbecome() { }
+
+  def watch(subject: ActorRef): ActorRef = self startsMonitoring subject
+
+  def unwatch(subject: ActorRef): ActorRef = self stopsMonitoring subject
+
+  private[this] final def apply(msg: Any) {}
+  
+  private val processingBehavior = receive
+}
+

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/ActorRef.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/ActorRef.scala
@@ -1,0 +1,45 @@
+package t1000752_2
+
+abstract class ActorRef extends Serializable {
+  scalaRef: ScalaActorRef ⇒
+
+  def name: String
+  
+  def address: String
+  
+  def compareTo(other: ActorRef) = this.address compareTo other.address
+  
+  def tell(msg: Any): Unit = this.!(msg)
+  
+  def tell(msg: Any, sender: ActorRef): Unit
+  
+  def ask(message: AnyRef, timeout: Long): Future[AnyRef] = ?(message, timeout).asInstanceOf[Future[AnyRef]]
+  
+  def forward(message: Any) = tell(message, null)
+  
+  def suspend(): Unit
+  
+  def resume(): Unit
+  
+  def stop(): Unit
+  
+  def isShutdown: Boolean
+  
+  def startsMonitoring(subject: ActorRef): ActorRef //TODO FIXME REMOVE THIS
+  
+  def stopsMonitoring(subject: ActorRef): ActorRef //TODO FIXME REMOVE THIS
+  
+  override def equals(that: Any): Boolean = {
+    that.isInstanceOf[ActorRef] &&
+      that.asInstanceOf[ActorRef].address == address
+  }
+  
+  override def toString = "Actor[%s]".format(address)
+}
+
+trait ScalaActorRef { ref: ActorRef ⇒
+  def !(message: Any)(implicit sender: ActorRef = null): Unit = ref.tell(message, sender)
+  def ?(message: Any)(implicit timeout: Any): Future[Any]
+  def ?(message: Any, timeout: Any)(implicit ignore: Int = 0): Future[Any] = ?(message)(timeout)
+}
+

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/Future.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/Future.scala
@@ -1,0 +1,3 @@
+package t1000752_2
+
+trait Future[+T]

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/JavaAPITestActor.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/JavaAPITestActor.java
@@ -1,0 +1,7 @@
+package t1000752_2;
+
+public class JavaAPITestActor extends UntypedActor {
+    public void onReceive(Object msg) {
+        getSender().tell("got it!");
+    }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/UntypedActor.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_2/UntypedActor.scala
@@ -1,0 +1,43 @@
+package t1000752_2
+
+abstract class UntypedActor extends Actor {
+  trait Procedure[+T]
+  
+  @throws(classOf[Exception])
+  def onReceive(message: Any): Unit
+
+  def getSelf(): ActorRef = self
+
+  def getSender(): ActorRef = sender
+
+  def getReceiveTimeout: Option[Long] = receiveTimeout
+
+  def setReceiveTimeout(timeout: Long): Unit = receiveTimeout = Some(timeout)
+
+  def getChildren(): java.lang.Iterable[ActorRef] = {
+    null
+  }
+
+  def getDispatcher(): MessageDispatcher = dispatcher
+
+  def become(behavior: Procedure[Any]): Unit = become(behavior, false)
+
+  def become(behavior: Procedure[Any], discardOld: Boolean): Unit =
+    super.become(null, discardOld)
+
+  override def preStart() {}
+
+  override def postStop() {}
+
+  override def preRestart(reason: Throwable, lastMessage: Option[Any]) {}
+
+  override def postRestart(reason: Throwable) {}
+
+  override def unhandled(msg: Any) {
+    throw new Exception
+  }
+
+  final protected def receive = {
+    case msg ⇒ onReceive(msg)
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_3/J.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_3/J.java
@@ -1,0 +1,3 @@
+package t1000752_3;
+
+public class J extends ATop {}

--- a/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_3/Top.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/jcompiler/src/t1000752_3/Top.scala
@@ -1,0 +1,9 @@
+package t1000752_3
+
+trait Top {
+  protected def foo(t: Array[String])
+}
+
+abstract class ATop extends Top {
+  override def foo(t: Array[String]) {}
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -59,9 +59,8 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with HasLogger { self : Scal
     var jdtMods = 0
     if(owner.hasFlag(Flags.PRIVATE))
       jdtMods = jdtMods | ClassFileConstants.AccPrivate
-    else if(owner.hasFlag(Flags.PROTECTED))
-      jdtMods = jdtMods | ClassFileConstants.AccProtected
     else
+      // protected entities need to be exposed as public to match scala compiler's behavior.
       jdtMods = jdtMods | ClassFileConstants.AccPublic
     
     if(owner.hasFlag(Flags.ABSTRACT) || owner.hasFlag(Flags.DEFERRED))
@@ -109,9 +108,8 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with HasLogger { self : Scal
     var jdtMods = 0
     if(owner.hasFlag(Flags.PRIVATE))
       jdtMods = jdtMods | ClassFileConstants.AccPrivate
-    else if(owner.hasFlag(Flags.PROTECTED))
-      jdtMods = jdtMods | ClassFileConstants.AccProtected
     else
+      // protected entities need to be exposed as public to match scala compiler's behavior.
       jdtMods = jdtMods | ClassFileConstants.AccPublic
     
     if(owner.hasFlag(Flags.ABSTRACT) || owner.hasFlag(Flags.DEFERRED))

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/jcompiler/ScalaMethodVerifierProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/jcompiler/ScalaMethodVerifierProvider.scala
@@ -11,6 +11,7 @@ import scala.tools.eclipse.util.HasLogger
 import scala.tools.eclipse.util.Utils
 import org.eclipse.ui.IEditorInput
 import org.eclipse.ui.IFileEditorInput
+import org.eclipse.core.resources.IFile
 
 /**
  * <p>
@@ -40,28 +41,52 @@ import org.eclipse.ui.IFileEditorInput
 class ScalaMethodVerifierProvider extends IMethodVerifierProvider with HasLogger {
   import ScalaMethodVerifierProvider.JDTMethodVerifierCarryOnMsg
 
-  /** Get the active project via the Eclipse UI workbench. */
-  private def getActiveScalaProject: Option[ScalaProject] = {
-    def getScalaProject(input: IEditorInput): Option[ScalaProject] = input match {
-      case fei: IFileEditorInput => ScalaPlugin.plugin.asScalaProject(fei.getFile.getProject)
-      case _ => None
-    }
-    ScalaPlugin.getWorkbenchWindow flatMap { workbench =>
-      val editorPart = workbench.getActivePage().getActiveEditor()
-      getScalaProject(editorPart.getEditorInput())
-    }
-  }
-  
   /** Checks that `abstractMethod` is a non-deferred member of a Scala Trait. */
   def isConcreteTraitMethod(abstractMethod: MethodBinding): Boolean = {
     Utils.tryExecute {
-      getActiveScalaProject match {
-        case Some(scalaProject) => 
-          isConcreteTraitMethod(abstractMethod, scalaProject)
-              
-        case None => false
-      }
+      // get the file containing the declaration of the abstract method
+      val maybeFile = getFile(abstractMethod)
+
+      maybeFile.map {file =>
+        val fileExtension = file.getFullPath().getFileExtension()
+
+        /* If it is a Scala source file, then we need to check if the source belongs to a Scala
+         * Project and if that is the case check if the passed `abstractMethod` is a concrete 
+         * method defined in a trait.
+         * 
+         * Java sources do not need to be considered because if the `abstractMethod` belongs to 
+         * a Java source, then the method is abstract by definition.
+         * 
+         * Class binaries are also ignored because we know the Scala mix-in phase has been executed. 
+         */
+        (fileExtension == "scala") && {
+          val project = file.getProject
+
+          logger.debug("Found definition for `%s` in file `%s` of project `%s`".format(abstractMethod, file.getFullPath(), project.getName()))
+
+          ScalaPlugin.plugin.asScalaProject(project) match {
+            case Some(scalaProject) =>
+              isConcreteTraitMethod(abstractMethod, scalaProject)
+
+            case None => false
+          }
+        }
+      }.getOrElse(false)
     }(orElse = false)
+  }
+
+  private def getFile(abstractMethod: MethodBinding): Option[IFile] = {
+    /* File name containing the abstractMethod definition. 
+     * Note that the returned path contains includes the project's folder where the file resides. */
+    val fileName = Option(abstractMethod.declaringClass.getFileName())
+    
+    fileName.map {name => 
+      val qualifiedFileName = name.mkString
+
+      // File containing the `abstractMethod` definition. From a file we can find the project the file belongs to.
+      val fileName = Path.fromOSString(qualifiedFileName)
+      ResourcesPlugin.getWorkspace().getRoot().getFile(fileName)
+    }
   }
 
   private def isConcreteTraitMethod(abstractMethod: MethodBinding, project: ScalaProject): Boolean = {
@@ -75,14 +100,14 @@ class ScalaMethodVerifierProvider extends IMethodVerifierProvider with HasLogger
 
             def haveSameTpeParams(abstractMethod: MethodBinding, method: Symbol) = {
               val fps = m.paramss.flatten
-              
+
               val javaSig = javaSigOf(method)
-              
+
               // mapping Scala params' types to be Java conform, so that comparison
               // with `abstractMethod` is meaningful
               val paramsTypeSigs =
-                if(javaSig.isDefined) javaSig.paramsType.map(_.mkString)
-                else fps.map(s => s.info.typeSymbol.fullName).toArray
+                if (javaSig.isDefined) javaSig.paramsType.map(_.mkString)
+                else fps.map(s => mapType(s.info.finalResultType)).toArray
 
               if (abstractMethod.parameters.length == paramsTypeSigs.size) {
                 val pairedParams = paramsTypeSigs.zip(abstractMethod.parameters.map(_.readableName().mkString))
@@ -117,7 +142,7 @@ class ScalaMethodVerifierProvider extends IMethodVerifierProvider with HasLogger
             }
           }
         }
-        
+
         def isConcreteMethod(methodOwner: Symbol, abstractMethod: MethodBinding) = {
           // Checks if `methodOwner`'s contain a non-deferred (i.e. concrete) member that matches `abstractMethod` definition
           val methodSymbol = findMethodSymbol(methodOwner, abstractMethod)


### PR DESCRIPTION
Ticket Re #1000741 raised the question of whether we needed an open editor to check if the MethodBinding passed to the ScalaMethodVerifierProvider is indeed abstract. The answer is no, and I updated the code accordingly.

I would like to merge this in both master and release/scala-ide-2.0.x. Further, if we have a new RC for 2.0, it might be good to merge it there as well.
