### PR TITLE
Refactoring: Use Utils.tryExecute instead of ScalaPlugin.check/checkOrElse 

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/Nature.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/Nature.scala
@@ -7,13 +7,12 @@
 package scala.tools.eclipse
 
 import scala.collection.mutable.ArrayBuffer
-
 import org.eclipse.core.resources.{ ICommand, IProject, IProjectNature, IResource }
 import org.eclipse.jdt.core.{ IClasspathEntry, IJavaProject, JavaCore }
 import org.eclipse.jdt.launching.JavaRuntime
 import org.eclipse.core.runtime.Path
-
 import ScalaPlugin.plugin 
+import scala.tools.eclipse.util.Utils
 
 object Nature {
   
@@ -60,7 +59,7 @@ class Nature extends IProjectNature {
     
     updateBuilders(project, List(JavaCore.BUILDER_ID, plugin.oldBuilderId), plugin.builderId)
     
-    plugin check {
+    Utils tryExecute {
       Nature.addScalaLibAndSave(getProject)
     }
   }
@@ -71,7 +70,7 @@ class Nature extends IProjectNature {
 
     updateBuilders(project, List(plugin.builderId, plugin.oldBuilderId), JavaCore.BUILDER_ID)
 
-    plugin check {
+    Utils tryExecute {
       val jp = JavaCore.create(getProject)
       Nature.removeScalaLib(jp)
       jp.save(null, true)
@@ -79,7 +78,7 @@ class Nature extends IProjectNature {
   }
   
   private def updateBuilders(project: IProject, buildersToRemove: List[String], builderToAdd: String) {
-    plugin.check {
+    Utils tryExecute {
       val description = project.getDescription
       val previousCommands = description.getBuildSpec
       val filteredCommands = previousCommands.filterNot(buildersToRemove contains _.getBuilderName)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
@@ -30,6 +30,7 @@ import org.eclipse.jdt.ui.PreferenceConstants
 import org.eclipse.core.resources.IResourceDelta
 import scala.tools.eclipse.util.HasLogger
 import org.osgi.framework.Bundle
+import scala.tools.eclipse.util.Utils
 
 object ScalaPlugin {
   var plugin: ScalaPlugin = _
@@ -302,31 +303,12 @@ class ScalaPlugin extends AbstractUIPlugin with IResourceChangeListener with IEl
   }
 
   
-  def bundlePath = check {
+  def bundlePath = Utils.tryExecute {
     val bundle = getBundle
     val bpath = bundle.getEntry("/")
     val rpath = FileLocator.resolve(bpath)
     rpath.getPath
   }.getOrElse("unresolved")
-
-  final def check[T](f: => T) =
-    try {
-      Some(f)
-    } catch {
-      case e: Throwable =>
-        logger.error(e)
-        None
-    }
-
-  final def checkOrElse[T](f: => T, msgIfError: String): Option[T] = {
-    try {
-      Some(f)
-    } catch {
-      case e: Throwable =>
-        logger.error(msgIfError, e)
-        None
-    }
-  }
 
   /** Is the file buildable by the Scala plugin? In other words, is it a
    *  Java or Scala source file?

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -33,6 +33,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot
 import org.eclipse.core.runtime.jobs.Job
 import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Status
+import scala.tools.eclipse.util.Utils
 
 trait BuildSuccessListener {
   def buildSuccessful(): Unit
@@ -119,7 +120,7 @@ class ScalaProject private (val underlying: IProject) extends HasLogger {
                "Add the Scala library to the classpath of project %s?") 
               .format(msg, underlying.getName))
           if (doAdd) {
-            plugin check {
+            Utils tryExecute {
               Nature.addScalaLibAndSave(underlying)
             }
           }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
@@ -30,6 +30,7 @@ import scala.collection.mutable
 import scala.tools.eclipse.javaelements.{ ScalaSourceFile, ScalaCompilationUnit }
 import scala.tools.eclipse.markoccurrences.{ ScalaOccurrencesFinder, Occurrences }
 import scala.tools.eclipse.semicolon._
+import scala.tools.eclipse.util.Utils
 
 class ScalaSourceFileEditor extends CompilationUnitEditor with ScalaEditor {
 
@@ -130,8 +131,8 @@ class ScalaSourceFileEditor extends CompilationUnitEditor with ScalaEditor {
 
       case _ =>
         // TODO: pop up a dialog explaining what needs to be fixed or fix it ourselves
-        thePlugin checkOrElse (adaptable.asInstanceOf[ScalaSourceFile], // trigger the exception, so as to get a diagnostic stack trace 
-          "Could not recompute occurrence annotations: configuration problem")
+        Utils tryExecute (adaptable.asInstanceOf[ScalaSourceFile], // trigger the exception, so as to get a diagnostic stack trace 
+          msgIfError = Some("Could not recompute occurrence annotations: configuration problem"))
     }
   }
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/RunDiagnosticAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/RunDiagnosticAction.scala
@@ -4,9 +4,9 @@ package actions
 import org.eclipse.jface.action.IAction
 import org.eclipse.jface.viewers.{ ISelection, IStructuredSelection }
 import org.eclipse.ui.{ IObjectActionDelegate, IWorkbenchPart, IWorkbenchWindowActionDelegate, IWorkbenchWindow, PlatformUI }
-
 import scala.tools.eclipse.ScalaPlugin.plugin
 import scala.tools.eclipse.javaelements.JDTUtils
+import scala.tools.eclipse.util.Utils
 
 class RunDiagnosticAction extends IObjectActionDelegate with IWorkbenchWindowActionDelegate {
   private var parentWindow: IWorkbenchWindow = null
@@ -23,7 +23,7 @@ class RunDiagnosticAction extends IObjectActionDelegate with IWorkbenchWindowAct
 	def selectionChanged(action: IAction, selection: ISelection) {  }
   
   def run(action: IAction) { 
-    plugin check {
+    Utils tryExecute {
       action.getId match {
         case RUN_DIAGNOSTICS =>
           val shell = if (parentWindow == null) ScalaPlugin.getShell else parentWindow.getShell        

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/ToggleScalaNatureAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/ToggleScalaNatureAction.scala
@@ -12,6 +12,7 @@ import org.eclipse.jface.viewers.{ ISelection, IStructuredSelection }
 import org.eclipse.core.runtime.Platform
 import org.eclipse.ui.{ IObjectActionDelegate, IWorkbenchPart }
 import ScalaPlugin.plugin
+import scala.tools.eclipse.util.Utils
 
 object ToggleScalaNatureAction {
   val PDE_PLUGIN_NATURE = "org.eclipse.pde.PluginNature" /* == org.eclipse.pde.internal.core.natures.PDE.PLUGIN_NATURE */
@@ -26,7 +27,7 @@ class ToggleScalaNatureAction extends AbstractPopupAction {
   }
   
   private def toggleScalaNature(project: IProject) =
-    plugin check {
+    Utils tryExecute {
       if (project.hasNature(plugin.natureId) || project.hasNature(plugin.oldNatureId)) {
         doIfPdePresent(project) { ScalaLibraryPluginDependencyUtils.removeScalaLibraryRequirement(project) }
         updateNatureIds(project) { _ filterNot Set(plugin.natureId, plugin.oldNatureId) }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/jcompiler/ScalaMethodVerifierProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/jcompiler/ScalaMethodVerifierProvider.scala
@@ -61,7 +61,7 @@ class ScalaMethodVerifierProvider extends IMethodVerifierProvider with HasLogger
               
         case None => false
       }
-    }(orElse = false)
+    }.getOrElse(false)
   }
 
   private def isConcreteTraitMethod(abstractMethod: MethodBinding, project: ScalaProject): Boolean = {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/OrganizeImportsPreferences.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/OrganizeImportsPreferences.scala
@@ -18,6 +18,9 @@ import scala.tools.eclipse.util.SWTUtils.{byNameToSelectionAdapter, fnToSelectio
 import scala.tools.eclipse.ScalaPlugin
 import org.eclipse.jface.preference.RadioGroupFieldEditor
 import org.eclipse.jface.preference.FieldEditor
+import scala.tools.eclipse.util.Utils
+
+
 
 class OrganizeImportsPreferencesPage extends PropertyPage with IWorkbenchPreferencePage {
   import OrganizeImportsPreferences._
@@ -212,7 +215,7 @@ class OrganizeImportsPreferencesInitializer extends AbstractPreferenceInitialize
   /** Actually initializes preferences */
   def initializeDefaultPreferences() : Unit = {
     
-    ScalaPlugin.plugin.check {
+    Utils.tryExecute {
       val node = new DefaultScope().getNode(ScalaPlugin.plugin.pluginId)
       node.put(OrganizeImportsPreferences.groupsKey, "java$scala$org$com")      
       node.put(OrganizeImportsPreferences.wildcardsKey, "scalaz$scalaz.Scalaz")      

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
@@ -7,11 +7,10 @@
 package scala.tools.eclipse.properties
 
 import org.eclipse.core.runtime.preferences.{ AbstractPreferenceInitializer, DefaultScope }
-
 import scala.tools.nsc.Settings
-
 import scala.tools.eclipse.ScalaPlugin
 import scala.tools.eclipse.SettingConverterUtil._
+import scala.tools.eclipse.util.Utils
 
 /**
  * This is responsible for initializing Scala Compiler
@@ -22,7 +21,7 @@ class ScalaCompilerPreferenceInitializer extends AbstractPreferenceInitializer {
   /** Actually initializes preferences */
   def initializeDefaultPreferences() : Unit = {
 	  
-    ScalaPlugin.plugin.check {
+    Utils.tryExecute {
       val node = new DefaultScope().getNode(ScalaPlugin.plugin.pluginId)
       val store = ScalaPlugin.plugin.getPluginPreferences
       

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/reconciliation/ReconciliationParticipantsExtensionPoint.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/reconciliation/ReconciliationParticipantsExtensionPoint.scala
@@ -4,12 +4,12 @@
 package scala.tools.eclipse
 package reconciliation
 
-import scala.tools.eclipse.ScalaPlugin
 import org.eclipse.core.runtime.CoreException
 import org.eclipse.core.runtime.{Platform, IProgressMonitor}
 import org.eclipse.jdt.core.WorkingCopyOwner
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.eclipse.util.HasLogger
+import scala.tools.eclipse.util.Utils
 
 /**
  * The implementation for the org.scala-ide.sdt.core.reconciliationParticipants
@@ -28,7 +28,7 @@ object ReconciliationParticipantsExtensionPoint extends HasLogger {
     val configs = Platform.getExtensionRegistry.getConfigurationElementsFor(PARTICIPANTS_ID).toList
 
     configs map { e =>
-      ScalaPlugin.plugin.check {
+      Utils.tryExecute {
         e.createExecutableExtension("class")
       }
     } collect {
@@ -38,7 +38,7 @@ object ReconciliationParticipantsExtensionPoint extends HasLogger {
   
   def runBefore(scu: ScalaCompilationUnit, monitor: IProgressMonitor, workingCopyOwner: WorkingCopyOwner) {
     extensions foreach { extension =>
-      ScalaPlugin.plugin.check {
+      Utils.tryExecute {
         extension.beforeReconciliation(scu, monitor, workingCopyOwner)
       }
     }
@@ -46,7 +46,7 @@ object ReconciliationParticipantsExtensionPoint extends HasLogger {
   
   def runAfter(scu: ScalaCompilationUnit, monitor: IProgressMonitor, workingCopyOwner: WorkingCopyOwner) {
     extensions foreach { extension =>
-      ScalaPlugin.plugin.check {
+      Utils.tryExecute {
         extension.afterReconciliation(scu, monitor, workingCopyOwner)
       }
     }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
@@ -17,12 +17,15 @@ object Utils extends HasLogger {
   }
   
   /** Try executing the passed `action` and log any exception occurring. */
-  def tryExecute[T](action: => T)(orElse: => T): T = {
-    try action
+  def tryExecute[T](action: => T, msgIfError: => Option[String] = None): Option[T] = {
+    try Some(action)
     catch { 
       case t => 
-        logger.error(t)
-        orElse
+        msgIfError match {
+          case Some(errMsg) => logger.error(errMsg, t)
+          case None => logger.error(t)
+        }
+        None
     }
   }
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
@@ -92,7 +92,7 @@ class NewApplicationWizard extends BasicNewResourceWizard with HasLogger {
   }
 
   override def performFinish: Boolean =
-    tryExecute(createApplication(page.getApplicationName, page.getSelectedPackage))(orElse = false)
+    tryExecute(createApplication(page.getApplicationName, page.getSelectedPackage)).getOrElse(false)
 
   private def openInEditor(file: IFile) = {
     selectAndReveal(file)


### PR DESCRIPTION
Replaced all calls to ScalaPlugin.check and ScalaPlugin.checkOrElse with Utils.tryExecute.
I believe the latter better describes the method's intention.

I would like to merge this into both master and release/scala-ide-2.0.x.
