### PR TITLE
Make the class path validator use its own marker ID.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
@@ -73,6 +73,8 @@ class ScalaPlugin extends AbstractUIPlugin with IResourceChangeListener with IEl
   def scalaLibId = launchId + "." + scalaLib
   def launchTypeId = "scala.application"
   def problemMarkerId = pluginId + ".problem"
+  def classpathProblemMarkerId = pluginId + ".classpathProblem"
+  def settingProblemMarkerId = pluginId + ".settingProblem"
 
   // Retained for backwards compatibility
   val oldPluginId = "ch.epfl.lamp.sdt.core"


### PR DESCRIPTION
The class path validator swallows all error markers when it starts a check, meaning that after a failed build
they are gone. When the class path is correct, this amounts to hiding build errors.

Fixed #1000757.
