### PR TITLE
Tweaks for Re #1000757

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/classpath/ClasspathTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/classpath/ClasspathTests.scala
@@ -260,20 +260,14 @@ class ClasspathTests {
     checkMarkers(0, 0)
     
     // two excepted code errors
-    var markers= project.underlying.findMarkers(ScalaPlugin.plugin.problemMarkerId, false, IResource.DEPTH_INFINITE)
+    var markers= project.underlying.findMarkers(ScalaPlugin.plugin.problemMarkerId, true, IResource.DEPTH_INFINITE)
     assertEquals("Unexpected number of scala problems in project", 2, markers.length)
     
     // switch to an invalid classpath
     setRawClasspathAndCheckMarkers(cleanRawClasspath, 0, 1)
     
-    project.underlying.build(IncrementalProjectBuilder.CLEAN_BUILD, new NullProgressMonitor)
-    project.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor)
-    
-    // one error on the project
-    checkMarkers(0, 1)
-    
-    // no additional code errors
-    markers= project.underlying.findMarkers(ScalaPlugin.plugin.problemMarkerId, false, IResource.DEPTH_INFINITE)
+    // no code errors visible anymore
+    markers= project.underlying.findMarkers(ScalaPlugin.plugin.problemMarkerId, true, IResource.DEPTH_INFINITE)
     assertEquals("Unexpected number of scala problems in project", 0, markers.length)
   }
   

--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -361,6 +361,24 @@
       <super type="org.eclipse.jdt.core.problem"/>
       <persistent value="true"/>
    </extension>
+      
+   <extension
+         id="classpathProblem"
+         name="Scala Classpath Problem"
+         point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"/>
+      <super type="org.eclipse.jdt.core.problem"/>
+      <persistent value="true"/>
+   </extension>
+   
+   <extension
+         id="settingProblem"
+         name="Scala Setting Problem"
+         point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"/>
+      <super type="org.eclipse.jdt.core.problem"/>
+      <persistent value="true"/>
+   </extension>
 
    <extension
          point="org.eclipse.ui.editors.annotationTypes">

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -403,8 +403,8 @@ class ScalaProject private (val underlying: IProject) extends HasLogger {
             case IMarker.SEVERITY_ERROR | IMarker.SEVERITY_WARNING =>
               if (severity == IMarker.SEVERITY_ERROR) {
                 // delete all other Scala and Java error markers
-                underlying.deleteMarkers(plugin.problemMarkerId, false, IResource.DEPTH_ZERO)
-                underlying.deleteMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_ZERO)
+                underlying.deleteMarkers(plugin.problemMarkerId, true, IResource.DEPTH_INFINITE)
+                underlying.deleteMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE)
               }
               
               // create the classpath problem marker


### PR DESCRIPTION
- configured the new marker ids as extensions, so they are visible in the UI.
- recursively removed all marker in the projects with invalid classpath, and fixed the test.
