### PR TITLE
The presentation compiler was not correctly reset when classes from a class folder were changed

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
@@ -252,6 +252,9 @@ class ScalaPlugin extends AbstractUIPlugin with IResourceChangeListener with IEl
       val isAdded   = delta.getKind == ADDED
       
       def hasFlag(flag: Int) = (delta.getFlags & flag) != 0
+      
+      def isChangeInClassFolder(packageFragmentRoot: IPackageFragmentRoot)=
+        (packageFragmentRoot.getKind() & IPackageFragmentRoot.K_BINARY) != 0 && hasFlag(F_CHILDREN)
 
       val elem = delta.getElement
       
@@ -260,7 +263,8 @@ class ScalaPlugin extends AbstractUIPlugin with IResourceChangeListener with IEl
         case JAVA_PROJECT if !isRemoved && !hasFlag(F_CLOSED) => true
 
         case PACKAGE_FRAGMENT_ROOT =>
-          if (isRemoved || hasFlag(F_REMOVED_FROM_CLASSPATH | F_ADDED_TO_CLASSPATH | F_ARCHIVE_CONTENT_CHANGED)) {
+          if (isRemoved || hasFlag(F_REMOVED_FROM_CLASSPATH | F_ADDED_TO_CLASSPATH | F_ARCHIVE_CONTENT_CHANGED) || 
+              isChangeInClassFolder(elem.asInstanceOf[IPackageFragmentRoot])) {
             logger.info("package fragment root changed (resetting pres compiler): " + elem)
             asScalaProject(elem.getJavaProject().getProject).foreach(projectsToReset +=)
             false


### PR DESCRIPTION
Reset the presentation compiler when depending classes from a class folder change.

Re #1000764
