### PR TITLE
Issue/get java to follow sbt 1000388

### DIFF
--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/jcompiler/ExtendedResourceDelta.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/jcompiler/ExtendedResourceDelta.java
@@ -98,7 +98,7 @@ public class ExtendedResourceDelta extends PlatformObject implements IResourceDe
   }
 
   public int getKind() {
-    if (wrapped != null)
+    if (wrapped != null && wrapped.getKind() != IResourceDelta.NO_CHANGE)
       return wrapped.getKind();
     return IResourceDelta.CHANGED;
   }


### PR DESCRIPTION
If SBT request recompile of java sources in the current module due to a change in another
module, the delta that we build for the current project will be of kind
NO_CHANGE and later ignored by the compiler even if it contains source
delta children.

This fix makes sure that the delta always indicates some kind of change to java compiler.
