### PR TITLE
Removed the AJDT weaving dependency so that we are more

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+SCALA LICENSE
+
+Copyright (c) 2002-2011 EPFL, Lausanne, unless otherwise specified.
+All rights reserved.
+
+This software was developed by the Programming Methods Laboratory of the
+Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland.
+
+Permission to use, copy, modify, and distribute this software in source
+or binary form for any purpose with or without fee is hereby granted,
+provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the EPFL nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/org.scala-ide.sdt.aspects/LICENSE
+++ b/org.scala-ide.sdt.aspects/LICENSE
@@ -1,0 +1,70 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement, including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+b) its license agreement:
+i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+b) a copy of this Agreement must be included with each copy of the Program.
+Contributors may not remove or alter any copyright notices contained within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.

--- a/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
@@ -33,8 +33,11 @@ Eclipse-SupplementBundle:
 Bundle-ActivationPolicy: lazy
 Export-Package: 
  scala.tools.eclipse.contribution.weaving.jdt,
+ scala.tools.eclipse.contribution.weaving.jdt.configuration,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions,
  scala.tools.eclipse.contribution.weaving.jdt.cfprovider,
+ scala.tools.eclipse.contribution.weaving.jdt.cuprovider,
+ scala.tools.eclipse.contribution.weaving.jdt.imagedescriptor,
  scala.tools.eclipse.contribution.weaving.jdt.core,
  scala.tools.eclipse.contribution.weaving.jdt.debug,
  scala.tools.eclipse.contribution.weaving.jdt.hierarchy,
@@ -48,3 +51,6 @@ Export-Package:
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter,
  scala.tools.eclipse.contribution.weaving.pde.ui
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Import-Package: org.eclipse.equinox.frameworkadmin,
+ org.eclipse.equinox.internal.simpleconfigurator.manipulator,
+ org.eclipse.equinox.simpleconfigurator.manipulator

--- a/org.scala-ide.sdt.aspects/META-INF/aop.xml
+++ b/org.scala-ide.sdt.aspects/META-INF/aop.xml
@@ -1,8 +1,11 @@
 <aspectj>
 <aspects>
+<aspect name="scala.tools.eclipse.contribution.weaving.jdt.configuration.IsWovenTester"/>
 <aspect name="org.eclipse.jdt.core.dom.ASTConverterAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.builderoptions.ScalaJavaBuilderAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.cfprovider.ClassFileProviderAspect"/>
+<aspect name="scala.tools.eclipse.contribution.weaving.jdt.cuprovider.CompilationUnitProviderAspect"/>
+<aspect name="scala.tools.eclipse.contribution.weaving.jdt.imagedescriptor.ImageDescriptorSelectorAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.core.BindingKeyAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.core.CompilationUnitProblemFinderAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.core.CompilationUnitNameAspect"/>

--- a/org.scala-ide.sdt.aspects/cuprovider.exsd
+++ b/org.scala-ide.sdt.aspects/cuprovider.exsd
@@ -1,0 +1,114 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="scala.tools.eclipse.contribution.weaving.jdt" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="scala.tools.eclipse.contribution.weaving.jdt" id="cuprovider" name="Compilation Unit Provider"/>
+      </appInfo>
+      <documentation>
+         Provides an alternate implementation of org.eclipse.jdt.internal.core.CompilationUnit based on file extension.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="provider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="provider">
+      <annotation>
+         <documentation>
+            Declares the class of the compilation unit provider for compilation units with a given file extension.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":scala.tools.eclipse.contribution.weaving.jdt.cuprovider.ICompilationUnitProvider"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="file_extension" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         1.6.2
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.scala-ide.sdt.aspects/imagedescriptorselector.exsd
+++ b/org.scala-ide.sdt.aspects/imagedescriptorselector.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="scala.tools.eclipse.contribution.weaving.jdt" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="scala.tools.eclipse.contribution.weaving.jdt" id="imagedescriptorselector" name="Image Descriptor Selector"/>
+      </appinfo>
+      <documentation>
+         Selects an icon for a given element.  Enables the ability to override the default icons.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="selector"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="selector">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The class that creates alternative image descriptors.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.contribution.jdt.imagedescriptor.IImageDescriptorSelector"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         1.6.2
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.scala-ide.sdt.aspects/plugin.xml
+++ b/org.scala-ide.sdt.aspects/plugin.xml
@@ -6,4 +6,6 @@
    <extension-point id="indexerprovider" name="Indexer Provider" schema="indexerprovider.exsd"/>
    <extension-point id="formatterCleanUp" name="Formatter Clean Up" schema="formatterCleanUp.exsd"/>
    <extension-point id="method_verifier" name="Method Verifier" schema="methodVerifier.exsd"/>
+   <extension-point id="cuprovider" name="Compilation Unit Provider" schema="cuprovider.exsd"/>
+   <extension-point id="imagedescriptorselector" name="Image Descriptor Selector" schema="imagedescriptorselector.exsd"/>
 </plugin>

--- a/org.scala-ide.sdt.aspects/pom.xml
+++ b/org.scala-ide.sdt.aspects/pom.xml
@@ -45,6 +45,7 @@
         <version>1.3</version>
         <executions>
           <execution>
+            <phase>process-sources</phase>
             <id>compile</id>
             <configuration>
               <source>1.5</source>

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/configuration/IsWovenTester.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/configuration/IsWovenTester.aj
@@ -1,0 +1,37 @@
+package scala.tools.eclipse.contribution.weaving.jdt.configuration;
+
+import org.eclipse.jdt.core.ToolFactory;
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+
+/**
+ * This aspect tests to see if the weaving service is properly installed.
+ * 
+ * @author andrew
+ * @created Dec 3, 2008
+ *
+ */
+public aspect IsWovenTester {
+
+    interface ScalaWeavingMarker { }
+    
+    /**
+     * add a marker interface to an arbitrary class in JDT
+     * later, we can see if the marker has been added.
+     */
+    declare parents : ToolFactory implements ScalaWeavingMarker;
+    
+    private static boolean weavingActive = new ToolFactory() instanceof ScalaWeavingMarker;
+    
+    public static boolean isWeavingActive() {
+        return weavingActive;
+    }
+    
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/configuration/WeavingStateConfigurer.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/configuration/WeavingStateConfigurer.java
@@ -1,0 +1,425 @@
+/*******************************************************************************
+ * Copyright (c) 2009 SpringSource and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Andrew Eisenberg - initial API and implementation
+ *******************************************************************************/
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+package scala.tools.eclipse.contribution.weaving.jdt.configuration;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.equinox.frameworkadmin.BundleInfo;
+import org.eclipse.equinox.internal.simpleconfigurator.manipulator.SimpleConfiguratorManipulatorImpl;
+import org.eclipse.equinox.simpleconfigurator.manipulator.SimpleConfiguratorManipulator;
+import org.eclipse.osgi.framework.internal.core.FrameworkProperties;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.DisabledInfo;
+import org.eclipse.osgi.service.resolver.State;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Version;
+
+import scala.tools.eclipse.contribution.weaving.jdt.ScalaJDTWeavingPlugin;
+import scala.tools.eclipse.contribution.weaving.jdt.configuration.IsWovenTester;
+
+/**
+ * @author Andrew Eisenberg
+ * @created Jan 19, 2009
+ *
+ * Object that controls the state of the Equinox aspects weaver
+ */
+public class WeavingStateConfigurer {
+    
+    private final static Version MIN_WEAVER_VERSION = new Version(1, 6, 1);
+
+    private final static boolean IS_WEAVING = IsWovenTester.isWeavingActive();
+
+    
+    public String getWeaverVersionInfo() {
+        BundleDescription weaver = 
+            Platform.getPlatformAdmin().getState(false).
+            getBundle("org.aspectj.weaver", null);
+        
+        if (weaver != null) {
+            if (MIN_WEAVER_VERSION.compareTo(weaver.getVersion()) <= 0) {
+                return "";
+//                return "AspectJ weaver version " + weaver.getVersion().toString() + " OK!";
+            } else {
+                return "No compatible version of org.aspectj.weaver found.  " +
+                "JDT Weaving requires 1.6.1 or higher.  Found version " +
+                weaver.getVersion();
+            }
+        } else {
+            return "org.aspectj.weaver not installed.  JDT Weaving requires 1.6.3 or higher.";
+        }
+    }
+    
+    public IStatus changeWeavingState(boolean becomeEnabled) {
+        // now, weaving service is controlled by 
+        // starting and stopping weaving.aspectj bundle
+        // this method is used only to ensure the hook exists
+        IStatus success;
+        boolean isCurrentlyWeaving = false;
+        try {
+            isCurrentlyWeaving = currentConfigStateIsWeaving();
+        } catch (Exception e) {
+            ScalaJDTWeavingPlugin.logException(e);
+        }
+        if (becomeEnabled && !isCurrentlyWeaving) {
+            success = changeConfigDotIni(becomeEnabled);
+        } else {
+            // do nothing
+            success = Status.OK_STATUS;
+        }
+        
+        
+        IStatus success2 = changeAutoStartupAspectsBundle(becomeEnabled);
+        
+        IStatus success3 = changeSimpleConfiguratorManipulator(becomeEnabled);
+        if (success.getSeverity() >= IStatus.ERROR || success2.getSeverity() >= IStatus.ERROR || success3.getSeverity() >= IStatus.ERROR) {
+            return new MultiStatus(ScalaJDTWeavingPlugin.ID, IStatus.ERROR, 
+                    new IStatus[] { success, success2, success3, getInstalledBundleInformation() }, "Could not "
+                    + (becomeEnabled ? "ENABLED" : "DISABLED") + " weaving service",
+                    null);
+        } else if (success.getSeverity() >= IStatus.WARNING || success2.getSeverity() >= IStatus.WARNING || success3.getSeverity() >= IStatus.WARNING) {
+            return new MultiStatus(ScalaJDTWeavingPlugin.ID, IStatus.WARNING, 
+                    new IStatus[] { success, success2, success3, getInstalledBundleInformation() }, "Weaving service "
+                    + (becomeEnabled ? "ENABLED" : "DISABLED") + " with warnings",
+                    null);
+        } else {
+            // if successful, also schedule to ask for reindexing on startup
+            if (becomeEnabled) {
+              // We don't ask to reindex (anyway, the Scala nature was not part of the 'weavable natures' list) 
+              // while using the JDT weaving plugin
+//                JDTWeavingPreferences.setAskToReindex(true);
+            }
+            return new MultiStatus(ScalaJDTWeavingPlugin.ID, IStatus.OK, 
+                    new IStatus[] { getInstalledBundleInformation() },
+                    "Weaving service successfully "
+                    + (becomeEnabled ? "ENABLED" : "DISABLED"), null);
+        } 
+    }
+
+    /**
+     * Change the default startup state of the aspectj weaving bundle using the 
+     * {@link SimpleConfiguratorManipulator}
+     * @param becomeEnabled if true, then ensure that the bundle is set to autostarted 
+     * if false, the bundle should not be autostarted
+     * @return {@link Status#OK_STATUS} if all goes well, otherwise returns the exception
+     */
+    private IStatus changeSimpleConfiguratorManipulator(boolean becomeEnabled) {
+        SimpleConfiguratorManipulator manipulator = new SimpleConfiguratorManipulatorImpl();
+        BundleContext bundleContext = null;
+        try {
+            bundleContext = Platform.getBundle(ScalaJDTWeavingPlugin.ID).getBundleContext();
+        } catch (Exception e) {
+            return new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, "Cannot get bundleContext", e);
+        }
+        if (bundleContext == null) {
+            return new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, "Cannot get bundleContext", new Exception());
+        }
+        
+        try {
+            BundleInfo[] infos = manipulator.loadConfiguration(bundleContext, null);
+            BundleInfo weavingInfo = null;
+            for (BundleInfo info : infos) {
+                if (info.getSymbolicName().equals("org.eclipse.equinox.weaving.aspectj")) {
+                    weavingInfo = info;
+                    break;
+                }
+            }
+            if (weavingInfo == null) {
+                return new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, "Could not find equinox aspects bundle", new Exception());
+            }
+            
+            weavingInfo.setMarkedAsStarted(becomeEnabled);
+            
+            URL configURL = Platform.getConfigurationLocation().getURL();
+            if (configURL == null || !"file".equals(configURL.getProtocol())) {
+                throw new IOException("Platform configuration location is not found: " + configURL);
+            }
+            
+            URL installURL = Platform.getInstallLocation().getURL();
+            if (installURL == null || !"file".equals(installURL.getProtocol())) {
+                throw new IOException("Platform install location is not found: " + installURL);
+            }
+            manipulator.saveConfiguration(infos, new File(configURL.getFile() + SimpleConfiguratorManipulator.BUNDLES_INFO_PATH), new File(installURL.getFile()).toURI());
+            
+            return Status.OK_STATUS;
+        } catch (IOException e) {
+            return new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, "Cannot load configuration", e);
+        }
+    }
+
+    private IStatus getInstalledBundleInformation() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("Information on currently installed bundles:\n");
+        
+        Bundle[] allEABundles = Platform.getBundles("org.eclipse.equinox.weaving.aspectj", null); //$NON-NLS-1$
+        if (allEABundles != null) {
+            for (int i = 0; i < allEABundles.length; i++) {
+                Bundle bundle = allEABundles[i];
+                sb.append(createBundleNameString(bundle));
+            }
+        } else {
+            sb.append("org.eclipse.equinox.weaving.aspectj not installed\n");
+        }
+        
+        Bundle[] allWeaverBundles = Platform.getBundles("org.aspectj.weaver", null);
+        if (allWeaverBundles != null) {
+            for (int i = 0; i < allWeaverBundles.length; i++) {
+                Bundle bundle = allWeaverBundles[i];
+                sb.append(createBundleNameString(bundle));
+            }
+        } else {
+            sb.append("org.aspectj.weaver not installed\n");
+        }
+        
+        allWeaverBundles = Platform.getBundles("com.springsource.org.aspectj.weaver", null);
+        if (allWeaverBundles != null) {
+            for (int i = 0; i < allWeaverBundles.length; i++) {
+                Bundle bundle = allWeaverBundles[i];
+                sb.append(createBundleNameString(bundle));
+            }
+        } else {
+            sb.append("com.springsource.org.aspectj.weaver not installed\n");
+        }
+        
+        Bundle[] allWeavingHooks = Platform.getBundles("org.eclipse.equinox.weaving.hook", null);
+        if (allWeavingHooks != null) {
+            for (int i = 0; i < allWeavingHooks.length; i++) {
+                Bundle bundle = allWeavingHooks[i];
+                sb.append(createBundleNameString(bundle));
+            }
+        } else {
+            sb.append("org.eclipse.equinox.weaving.hook not installed\n");
+        }
+
+        
+        return new Status(IStatus.INFO, ScalaJDTWeavingPlugin.ID, sb.toString());
+    }
+
+    private StringBuffer createBundleNameString(Bundle bundle) {
+        StringBuffer sb = new StringBuffer();
+        sb.append(bundle.getSymbolicName()).append("_")
+            .append(bundle.getVersion()).append(" : ID ")
+            .append(bundle.getBundleId()).append(": STATE ");
+        switch (bundle.getState()) {
+            case Bundle.ACTIVE:
+                sb.append("ACTIVE");
+                break;
+
+            case Bundle.INSTALLED:
+                sb.append("INSTALLED");
+                break;
+
+            case Bundle.RESOLVED:
+                sb.append("RESOLVED");
+                break;
+
+            case Bundle.STARTING:
+                sb.append("STARTING");
+                break;
+
+            case Bundle.STOPPING:
+                sb.append("STOPPING");
+                break;
+        }
+        
+        sb.append("\n");
+        return sb;
+    }
+    
+    private IStatus changeAutoStartupAspectsBundle(boolean becomeEnabled) {
+        
+        // get all versions of weaving.aspectj in the platform.  
+        // disable and stop all but the most receent
+        Bundle[] allEABundles = Platform.getBundles("org.eclipse.equinox.weaving.aspectj", null); //$NON-NLS-1$
+        if (allEABundles == null || allEABundles.length == 0) {
+            return new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, "Could not find org.eclipse.equinox.weaving.aspectj" +
+            		" so weaving service cannot be " + 
+            		(becomeEnabled ? "enabled" : "disabled") + ".");
+        }
+        try {
+            State state = Platform.getPlatformAdmin().getState(false);
+            if (becomeEnabled) {
+                allEABundles[0].start();
+                for (int i = 1; i < allEABundles.length; i++) {
+                    allEABundles[i].stop();
+                    BundleDescription desc = state.getBundle(allEABundles[i].getBundleId());
+                    DisabledInfo info = new DisabledInfo(
+                            "org.eclipse.contribution.weaving.jdt", //$NON-NLS-1$
+                            "Disabled older version of Equinox Aspects", desc); //$NON-NLS-1$
+                    try {
+                        Platform.getPlatformAdmin().addDisabledInfo(info);
+                    } catch (IllegalArgumentException e) {
+                        // can ignore
+                    }
+                }
+            } else {
+                for (int i = 0; i < allEABundles.length; i++) {
+                    switch(allEABundles[i].getState()) {
+                        case Bundle.ACTIVE:
+                        case Bundle.INSTALLED:
+                        case Bundle.STARTING:
+                        case Bundle.RESOLVED:
+                            allEABundles[i].stop();
+                    }
+                }
+            }
+            
+            return Status.OK_STATUS;
+        } catch (Exception e) {
+            return new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, "Error occurred in setting org.eclipse.equinox.weaving.aspectj to autostart" +
+                    " so weaving service cannot be " + 
+                    (becomeEnabled ? "enabled" : "disabled") + ".", e);
+        }
+    }
+
+    private IStatus changeConfigDotIni(boolean becomeEnabled) {
+        
+        // a little crude find the config.ini go through each 
+        // line and filter out the osgi.framework.extensions line
+        IStatus success;
+        try {
+            String configArea = getConfigArea();
+            File f = new File(new URI(configArea));
+            if (f.canWrite()) {
+                BufferedReader br = new BufferedReader(new FileReader(f));
+                
+                String newConfig = internalChangeWeavingState(becomeEnabled, br);
+                BufferedWriter bw = new BufferedWriter(new FileWriter(f));
+                bw.write(newConfig);
+                bw.close();
+    
+                
+                if (becomeEnabled == currentConfigStateIsWeaving()) {
+                    success = Status.OK_STATUS;
+                } else {
+                    success = new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, "Could not add or remove org.eclipse.equinox.weaving.hook as a framework adaptor.");
+                }
+            } else {
+                // cannot write to file...most likely this is because the config.ini 
+                // is in a global location that is read-only.
+                success = new Status(IStatus.WARNING, ScalaJDTWeavingPlugin.ID, "Could not add " +
+                		"'osgi.framework.extensions=org.eclipse.equinox.weaving.hook'\n " +
+                		"to the config.ini because the file is read-only.  Weaving may not be enabled.");
+            }
+        } catch (Exception e) {
+            success = new Status(IStatus.ERROR, ScalaJDTWeavingPlugin.ID, e
+                    .getMessage(), e);
+        }
+        return success;
+    }
+
+    protected String internalChangeWeavingState(boolean becomeEnabled, 
+            BufferedReader br) throws IOException {
+        StringBuffer sb = new StringBuffer();
+        String line = null;
+        boolean hookAdded = false;
+        while ((line = br.readLine()) != null) {
+            if (line.trim().startsWith("osgi.framework.extensions=")) {
+                String[] split = line.split("=");
+                if (split.length > 1) {
+                    String[] extNames = split[1].split(",");
+                    boolean shouldAddLine = false;
+                    StringBuffer sb2 = new StringBuffer();
+                    sb2.append("osgi.framework.extensions=");
+                    for (int i = 0; i < extNames.length; i++) {
+                        String extName = extNames[i].trim();
+                        // don't add hook, we add it later in needed
+                        if (!extName.equals("org.eclipse.equinox.weaving.hook")) {
+                            sb2.append(extName + ",");
+                            shouldAddLine = true;
+                        }
+                    }
+                    if (shouldAddLine) {
+                        if (becomeEnabled) {
+                            sb2.append("org.eclipse.equinox.weaving.hook\n");
+                            hookAdded = true;
+                        } else {
+                            // replace last comma
+                            sb2.replace(sb2.length() - 1, sb2.length(), "\n");
+                        }
+                        sb.append(sb2);
+                    }
+                }
+            } else {
+                sb.append(line + "\n");
+            }
+        }
+
+        // if line didn't exist before
+        if (becomeEnabled && !hookAdded) {
+            sb.append("osgi.framework.extensions=org.eclipse.equinox.weaving.hook\n");
+        }
+        try {
+            br.close();
+        } catch (IOException e) {
+            ScalaJDTWeavingPlugin.logException(e);
+        }
+        return sb.toString();
+    }
+
+    private String getConfigArea() {
+        String configArea = FrameworkProperties.getProperty("osgi.configuration.area") + "config.ini";
+        configArea = configArea.replaceAll(" ", "%20");
+        return configArea;
+    }
+    
+    
+    public boolean currentConfigStateIsWeaving() throws Exception {
+        String configArea = getConfigArea();
+        
+        File f = new File(new URI(configArea));
+        if (! f.exists()) {
+            throw new FileNotFoundException("Could not find config file: " + f.getAbsolutePath());
+        }
+        if (! f.canWrite()) {
+            throw new IOException("Could not write to config file: " + f.getAbsolutePath());
+        }
+        BufferedReader br = new BufferedReader(new FileReader(f));
+        return internalCurrentConfigStateIsWeaving(br);
+    }
+
+    protected boolean internalCurrentConfigStateIsWeaving(BufferedReader br)
+            throws IOException {
+        String line = null;
+        while ((line = br.readLine()) != null) {
+            if (line.trim().startsWith("osgi.framework.extensions=") &&
+                    line.contains("org.eclipse.equinox.weaving.hook")) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public boolean isWeaving() {
+        return IS_WEAVING;
+    }
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/cuprovider/CompilationUnitProviderAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/cuprovider/CompilationUnitProviderAspect.aj
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2008 SpringSource and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *      SpringSource
+ *      Andrew Eisenberg (initial implementation)
+ *******************************************************************************/
+package scala.tools.eclipse.contribution.weaving.jdt.cuprovider;
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.internal.core.CompilationUnit;
+import org.eclipse.jdt.internal.core.PackageFragment;
+
+import scala.tools.eclipse.contribution.weaving.jdt.ScalaJDTWeavingPlugin;
+
+/**
+ * Captures all creations of {@link CompilationUnit}.  Uses a registry to determine 
+ * what kind of CompilationUnit to create.  Clients can provide their own
+ * CompilationUnit by using the cuprovider extension and associating a CompilationUnit
+ * subclass with a file extension.
+ * 
+ * @author andrew
+ * @created Dec 2, 2008
+ */
+public aspect CompilationUnitProviderAspect {
+    
+    /**
+     * Captures creations of Compilation units
+     */
+    pointcut compilationUnitCreations(PackageFragment parent, String name, WorkingCopyOwner owner) : 
+            call(public CompilationUnit.new(PackageFragment, String, WorkingCopyOwner)) &&
+            (
+                    within(org.eclipse.jdt..*) ||
+                    within(org.codehaus.jdt.groovy.integration.internal.*) ||  // Captures GroovyLanguageSupport if groovy plugin is installed
+                    within(org.codehaus.jdt.groovy.integration.*) // Captures DefaultLanguageSupport if groovy plugin is installed
+            ) &&
+            args(parent, name, owner);
+
+    CompilationUnit around(PackageFragment parent, String name, WorkingCopyOwner owner) : 
+        compilationUnitCreations(parent, name, owner) {
+        String newName = trimName(name);
+        String extension = findExtension(newName);
+        ICompilationUnitProvider provider = 
+            CompilationUnitProviderRegistry.getInstance().getProvider(extension);
+        if (provider != null) {
+            try {
+                return provider.create(parent, newName, owner);
+            } catch (Throwable t) {
+                ScalaJDTWeavingPlugin.logException(t);
+            }
+        }        
+        return proceed(parent, name, owner);
+    }
+
+    /**
+     * hacks off any excess parts of the compilation unit name that indicate
+     * extra characters were included in the name
+     * 
+     * @param original the original name of the compilation unit
+     * @return new name trimmed to ensure that all trailing memento parts are removed
+     */
+    private String trimName(String original) {
+        String noo = original;
+        int extensionIndex = original.indexOf('.') + 1;
+        if (extensionIndex >= 0) {
+            int mementoIndex = extensionIndex;
+            while (mementoIndex < original.length() && (Character.isJavaIdentifierPart(original.charAt(mementoIndex)) ||
+                    // Bug 352871 - Scala files may have more than one dot in them
+                    original.charAt(mementoIndex) == '.')) {
+                mementoIndex++;
+            }
+            noo = original.substring(0, mementoIndex);
+        }
+        return noo;
+    }
+    
+    private String findExtension(String name) {
+        int extensionIndex = name.lastIndexOf('.') + 1;
+        String extension;
+        if (extensionIndex > 0) {
+            extension = name.substring(extensionIndex);
+        } else {
+            extension = ""; //$NON-NLS-1$
+        }
+        return extension;
+    }
+    
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/cuprovider/CompilationUnitProviderRegistry.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/cuprovider/CompilationUnitProviderRegistry.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2008 SpringSource and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *      SpringSource
+ *      Andrew Eisenberg (initial implementation)
+ *******************************************************************************/
+package scala.tools.eclipse.contribution.weaving.jdt.cuprovider;
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.Platform;
+
+import scala.tools.eclipse.contribution.weaving.jdt.ScalaJDTWeavingPlugin;
+
+public class CompilationUnitProviderRegistry {
+    public static String CUPROVIDERS_EXTENSION_POINT = "org.scala-ide.sdt.aspects.cuprovider"; //$NON-NLS-1$
+    
+    private static final CompilationUnitProviderRegistry INSTANCE = 
+        new CompilationUnitProviderRegistry();
+    
+    public static CompilationUnitProviderRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    private CompilationUnitProviderRegistry() { 
+        // do nothing
+    }
+    
+    private Map<String, ICompilationUnitProvider> registry; 
+    
+    void registerCompilationUnitProvider(String key, ICompilationUnitProvider provider) {
+        registry.put(key, provider);
+    }
+    
+    ICompilationUnitProvider getProvider(String key) {
+        if (!isRegistered()) {
+            registerProviders();
+        }
+        return (ICompilationUnitProvider) registry.get(key);
+    }
+    
+    
+    public boolean isRegistered() {
+        return registry != null;
+    }
+    
+    public void registerProviders() {
+        registry = new HashMap<String, ICompilationUnitProvider>();
+        IExtensionPoint exP =
+            Platform.getExtensionRegistry().getExtensionPoint(CUPROVIDERS_EXTENSION_POINT);
+        if (exP != null) {
+            IExtension[] exs = exP.getExtensions();
+            for (int i = 0; i < exs.length; i++) {
+                IConfigurationElement[] configs = exs[i].getConfigurationElements();
+                for (int j = 0; j < configs.length; j++) {
+                    try {
+                        IConfigurationElement config = configs[j];
+                        if (config.isValid()) {
+                            ICompilationUnitProvider provider = (ICompilationUnitProvider) 
+                                    config.createExecutableExtension("class"); //$NON-NLS-1$
+                            registerCompilationUnitProvider(config.getAttribute("file_extension"), provider); //$NON-NLS-1$
+                        }
+                    } catch (CoreException e) {
+                      ScalaJDTWeavingPlugin.logException(e);
+                    } 
+                }
+            }
+        }
+    }
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/cuprovider/ICompilationUnitProvider.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/cuprovider/ICompilationUnitProvider.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2008 SpringSource and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *      SpringSource
+ *      Andrew Eisenberg (initial implementation)
+ *******************************************************************************/
+package scala.tools.eclipse.contribution.weaving.jdt.cuprovider;
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.internal.core.CompilationUnit;
+import org.eclipse.jdt.internal.core.PackageFragment;
+
+public interface ICompilationUnitProvider {
+    public CompilationUnit create(PackageFragment parent, String name, WorkingCopyOwner owner);
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/imagedescriptor/IImageDescriptorSelector.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/imagedescriptor/IImageDescriptorSelector.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2008 SpringSource and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *      SpringSource
+ *      Andrew Eisenberg (initial implementation)
+ *******************************************************************************/
+package scala.tools.eclipse.contribution.weaving.jdt.imagedescriptor;
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+
+import org.eclipse.jdt.internal.ui.text.java.LazyJavaCompletionProposal;
+import org.eclipse.jface.resource.ImageDescriptor;
+
+public interface IImageDescriptorSelector {
+    /**
+     * Creates the image descriptor for Java-like elements appearing in open type dialogs and the search view
+     * Arguments are passed in from the Aspect
+     */
+    public ImageDescriptor getTypeImageDescriptor(boolean isInner, boolean isInInterfaceOrAnnotation, int flags, boolean useLightIcons, Object element);
+    
+    /**
+     * Creates the image descriptor for Java-like elements appearing in content assist
+     */
+    public ImageDescriptor createCompletionProposalImageDescriptor(LazyJavaCompletionProposal proposal);
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/imagedescriptor/ImageDescriptorSelectorAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/imagedescriptor/ImageDescriptorSelectorAspect.aj
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2008 SpringSource and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *      SpringSource
+ *      Andrew Eisenberg (initial implementation)
+ *******************************************************************************/
+package scala.tools.eclipse.contribution.weaving.jdt.imagedescriptor;
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.internal.ui.text.java.LazyJavaCompletionProposal;
+import org.eclipse.jdt.internal.ui.viewsupport.JavaElementImageProvider;
+import org.eclipse.jdt.ui.text.java.CompletionProposalLabelProvider;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.graphics.Image;
+
+/**
+ * Captures locations in the code where {@link ImageDescriptor}s are created in the
+ * context of creating Java elements.  
+ * Allows other providers to plug in their own ImageDescriptors instead for the
+ * creation of Java-like elements. 
+ * 
+ * @author andrew
+ * @created Dec 2, 2008
+ *
+ */
+public privileged aspect ImageDescriptorSelectorAspect {
+    
+    /**
+     * Getting the image for open type dialogs
+     * 
+     * Note that if multiple image descriptor registries can work on the same kind of element,
+     * then there is potential for conflicts.
+     * 
+     * All we do here is return the first descriptor that we find.  Conflicts be damned!
+     * If there ever is a conflict (unlikely), we will deal with the consequences as it comes.
+     */
+    ImageDescriptor around(boolean isInner, boolean isInInterfaceOrAnnotation, int flags, boolean useLightIcons, Object element) : 
+            imageDescriptorCreation(isInner, isInInterfaceOrAnnotation, flags, useLightIcons) && 
+            cflow(typeSelectionDialogGettingLabel(element)) {
+        ImageDescriptor descriptor = getImageDescriptor(isInner, isInInterfaceOrAnnotation, flags, useLightIcons, element);
+        return descriptor != null ? 
+                descriptor : 
+                proceed(isInner, isInInterfaceOrAnnotation, flags, useLightIcons, element);
+    }
+    
+    pointcut imageDescriptorCreation(boolean isInner, boolean isInInterfaceOrAnnotation, int flags, boolean useLightIcons) :
+        execution(public static ImageDescriptor JavaElementImageProvider.getTypeImageDescriptor(boolean, boolean, int, boolean)) &&
+        args(isInner, isInInterfaceOrAnnotation, flags, useLightIcons);
+    
+    /**
+     *  This pointcut captures the act of getting a label for elements in the type selection dialog
+     */
+    // XXX I don't want to use wild cards here, but for some reason the methods are not woven if no wild cards are used.
+    // I should file a bug for this.
+    pointcut typeSelectionDialogGettingLabel(Object element) : 
+        (execution(public Image *..FilteredTypesSelectionDialog*.TypeItemLabelProvider.getImage(Object)) ||  // for open type dialog
+         execution(public Image *..HierarchyLabelProvider.getImage(Object)) || // for type hierarchy view
+         execution(public Image *..DebugTypeSelectionDialog*.DebugTypeLabelProvider.getImage(Object)))   // for choosing a main class
+         && within(org.eclipse.jdt.internal..*)
+         && args(element);
+
+    
+
+    /** 
+     * Getting {@link ImageDescriptor} for other standard places where java elements go
+     */
+    pointcut computingDescriptor(Object element, int flags) : 
+        execution(ImageDescriptor JavaElementImageProvider.computeDescriptor(Object, int)) &&
+        within(JavaElementImageProvider) &&
+        args(element, flags);
+    
+    ImageDescriptor around(Object element, int flags) : computingDescriptor(element, flags) {
+        
+        ImageDescriptor descriptor = getImageDescriptor(false, false, flags, false, element);
+        return descriptor != null ? 
+                descriptor : 
+                proceed(element, flags);
+    }
+    
+    
+    
+    private ImageDescriptor getImageDescriptor(boolean isInner, boolean isInInterfaceOrAnnotation, int flags, boolean useLightIcons, Object element) {
+        try {
+            for (IImageDescriptorSelector selector : ImageDescriptorSelectorRegistry.getInstance()) {
+                ImageDescriptor descriptor = selector.getTypeImageDescriptor(isInner, isInInterfaceOrAnnotation, flags, useLightIcons, element);
+                if (descriptor != null) {   
+                    return descriptor;
+                }
+            }
+        } catch (Throwable t) {
+//            JDTWeavingPlugin.logException(t);
+        }
+        return null;
+        
+    }
+    
+    //////////////////////////////////////////////////////
+    // This section of the aspect handles image descriptor creation for content assist
+    
+    // execution of CompletionProposalLabelProvider.createImageDescriptor && cflow(LazyJavaCompletionProposal.computeImage)
+    pointcut javaCompletionProposalImageComputing(LazyJavaCompletionProposal proposal) :
+        execution(protected Image LazyJavaCompletionProposal.computeImage()) && within(LazyJavaCompletionProposal)
+        && this(proposal);
+    
+    pointcut creatingProposalImageDescriptor() : execution(public ImageDescriptor CompletionProposalLabelProvider.createImageDescriptor(CompletionProposal)) 
+        && within(CompletionProposalLabelProvider);
+
+    ImageDescriptor around(LazyJavaCompletionProposal proposal) : cflow(javaCompletionProposalImageComputing(proposal)) &&
+            creatingProposalImageDescriptor() {
+        ImageDescriptor desc = getAssistImageDescriptor(proposal);
+        
+        return desc != null ? desc : proceed(proposal);
+    }
+    
+    
+    private ImageDescriptor getAssistImageDescriptor(LazyJavaCompletionProposal proposal) {
+        try {
+            for (IImageDescriptorSelector selector : ImageDescriptorSelectorRegistry.getInstance()) {
+                ImageDescriptor descriptor = selector.createCompletionProposalImageDescriptor(proposal);
+                if (descriptor != null) {   
+                    return descriptor;
+                }
+            }
+        } catch (Throwable t) {
+//            JDTWeavingPlugin.logException(t);
+        }
+        return null;
+        
+    }
+    
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/imagedescriptor/ImageDescriptorSelectorRegistry.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/imagedescriptor/ImageDescriptorSelectorRegistry.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2008 SpringSource and others.
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *      SpringSource
+ *      Andrew Eisenberg (initial implementation)
+ *******************************************************************************/
+package scala.tools.eclipse.contribution.weaving.jdt.imagedescriptor;
+
+/*******************************************************************************
+ * Added to the Scala plugin to fix interoperability issues between the 
+ * Spring IDE and the Scala IDE. This plugin now implements the cuprovider and
+ * imagedescriptorselector extension points, previously provided by the 
+ * JDT weaving plugin.
+ * 
+ *******************************************************************************/
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.Platform;
+
+import scala.tools.eclipse.contribution.weaving.jdt.ScalaJDTWeavingPlugin;
+
+public class ImageDescriptorSelectorRegistry implements Iterable<IImageDescriptorSelector> {
+    private static final ImageDescriptorSelectorRegistry INSTANCE = 
+        new ImageDescriptorSelectorRegistry();
+    private static final String SELECTORS_EXTENSION_POINT = "org.scala-ide.sdt.aspects.imagedescriptorselector"; //$NON-NLS-1$
+    
+    public static ImageDescriptorSelectorRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    private ImageDescriptorSelectorRegistry() { 
+        // do nothing
+    }
+    
+    private Set<IImageDescriptorSelector> registry;
+    
+    void registerSelector(IImageDescriptorSelector provider) {
+        registry.add(provider);
+    }
+    
+    public boolean isRegistered() {
+        return registry != null;
+    }
+    
+    public void registerSelectors() {
+        registry = new HashSet<IImageDescriptorSelector>();
+        IExtensionPoint exP =
+            Platform.getExtensionRegistry().getExtensionPoint(SELECTORS_EXTENSION_POINT);
+        if (exP != null) {
+            IExtension[] exs = exP.getExtensions();
+            if (exs != null) {
+                for (int i = 0; i < exs.length; i++) {
+                    IConfigurationElement[] configs = exs[i].getConfigurationElements();
+                    for (int j = 0; j < configs.length; j++) {
+                        try {
+                            IConfigurationElement config = configs[j];
+                            if (config.isValid()) {
+                                IImageDescriptorSelector provider = (IImageDescriptorSelector) 
+                                        config.createExecutableExtension("class"); //$NON-NLS-1$
+                                registry.add(provider);
+                            }
+                        } catch (CoreException e) {
+                            ScalaJDTWeavingPlugin.logException(e);
+                        } 
+                    }
+                }
+            }
+        }
+    }
+
+    public Iterator<IImageDescriptorSelector> iterator() {
+        if (!isRegistered()) {
+            registerSelectors();
+        }
+        return registry.iterator();
+    }
+}

--- a/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
@@ -47,15 +47,15 @@ Require-Bundle:
  org.junit4;bundle-version="4.5.0",
  org.eclipse.ui.browser;bundle-version="3.3.0"
 Import-Package: 
- org.eclipse.contribution.jdt.cuprovider;apply-aspects:=false,
- org.eclipse.contribution.jdt.imagedescriptor;apply-aspects:=false,
- org.eclipse.contribution.jdt.preferences;apply-aspects:=false,
- org.eclipse.contribution.jdt.sourceprovider;apply-aspects:=false,
+ com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.cfprovider;apply-aspects:=false,
+ scala.tools.eclipse.contribution.weaving.jdt.configuration;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.core;apply-aspects:=false,
+ scala.tools.eclipse.contribution.weaving.jdt.cuprovider;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.hierarchy;apply-aspects:=false,
+ scala.tools.eclipse.contribution.weaving.jdt.imagedescriptor;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.indexerprovider;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.jcompiler;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.launching;apply-aspects:=false,
@@ -63,9 +63,7 @@ Import-Package:
  scala.tools.eclipse.contribution.weaving.jdt.spellingengineprovider;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.ui;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor;apply-aspects:=false,
- scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter;apply-aspects:=false,
- com.ibm.icu.text;apply-aspects:=false;
- org.eclipse.swt.graphics;apply-aspects:=false
+ scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter;apply-aspects:=false
 Export-Package: 
  scala.tools.eclipse,
  scala.tools.eclipse.actions,

--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -855,7 +855,7 @@
       sequence="M2+M3+D S" />
   </extension>
 
-  <extension point="org.eclipse.contribution.weaving.jdt.cuprovider">
+  <extension point="org.scala-ide.sdt.aspects.cuprovider">
     <provider
       class="scala.tools.eclipse.javaelements.ScalaCompilationUnitProvider"
       file_extension="scala">
@@ -882,7 +882,7 @@
     <provider class="scala.tools.eclipse.jcompiler.ScalaMethodVerifierProvider" />
   </extension>
   
-  <extension point="org.eclipse.contribution.weaving.jdt.imagedescriptorselector">
+  <extension point="org.scala-ide.sdt.aspects.imagedescriptorselector">
     <selector
       class="scala.tools.eclipse.javaelements.ScalaImageDescriptorSelector">
     </selector>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/DiagnosticDialog.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/DiagnosticDialog.scala
@@ -17,7 +17,7 @@ import org.eclipse.jdt.internal.ui.preferences.PreferencesMessages
 import org.eclipse.jdt.internal.corext.util.Messages
 
 import org.eclipse.core.runtime.IStatus
-import org.eclipse.contribution.jdt.preferences.{ WeavingStateConfigurer, WeavingStateConfigurerUI, JDTWeavingPreferences }
+import scala.tools.eclipse.contribution.weaving.jdt.configuration.{ WeavingStateConfigurer }
 import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.browser.IWorkbenchBrowserSupport 
 
@@ -345,7 +345,7 @@ class DiagnosticDialog(shell: Shell) extends Dialog(shell) {
   }
   
   def turnWeavingOn() {
-    JDTWeavingPreferences.setAskToEnableWeaving(false)
+//    JDTWeavingPreferences.setAskToEnableWeaving(false)
     
     val changeResult: IStatus = configurer.changeWeavingState(true)    
     

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnitProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnitProvider.scala
@@ -1,6 +1,6 @@
 package scala.tools.eclipse.javaelements
 
-import org.eclipse.contribution.jdt.cuprovider.ICompilationUnitProvider
+import scala.tools.eclipse.contribution.weaving.jdt.cuprovider.ICompilationUnitProvider
 import org.eclipse.jdt.core.WorkingCopyOwner
 import org.eclipse.jdt.internal.core.PackageFragment
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaImageDescriptorSelector.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaImageDescriptorSelector.scala
@@ -1,6 +1,6 @@
 package scala.tools.eclipse.javaelements
 
-import org.eclipse.contribution.jdt.imagedescriptor.IImageDescriptorSelector
+import scala.tools.eclipse.contribution.weaving.jdt.imagedescriptor.IImageDescriptorSelector
 import org.eclipse.jdt.core.JavaModelException
 import org.eclipse.jdt.internal.ui.text.java.LazyJavaCompletionProposal;
 import org.eclipse.jface.resource.ImageDescriptor;

--- a/org.scala-ide.sdt.feature/feature.xml
+++ b/org.scala-ide.sdt.feature/feature.xml
@@ -55,8 +55,12 @@ SUCH DAMAGE.
    </license>
 
    <url>
-      <update label="Scala IDE for Eclipse update site" url="http://download.scala-ide.org/update-current-35"/>
+      <update label="Scala IDE for Eclipse update site" url="http://download.scala-ide.org/update-current"/>
    </url>
+
+   <includes
+         id="org.scala-ide.sdt.weaving.feature"
+         version="0.0.0"/>
 
    <requires>
       <import plugin="org.eclipse.equinox.weaving.aspectj"/>
@@ -100,13 +104,6 @@ SUCH DAMAGE.
          unpack="false"/>
 
    <plugin
-         id="org.scala-ide.sdt.aspects"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.scala-ide.sdt.core"
          download-size="0"
          install-size="0"
@@ -126,7 +123,7 @@ SUCH DAMAGE.
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+
    <plugin
          id="org.scala-ide.sbt.full.library"
          download-size="0"

--- a/org.scala-ide.sdt.update-site/site.xml
+++ b/org.scala-ide.sdt.update-site/site.xml
@@ -3,17 +3,9 @@
    <feature url="features/org.scala-ide.sdt.feature_0.0.0.jar" id="org.scala-ide.sdt.feature" version="0.0.0">
       <category name="sdt"/>
    </feature>
-   <feature url="features/org.scala-ide.sdt.weaving.feature_0.0.0.jar" id="org.scala-ide.sdt.weaving.feature" version="0.0.0">
-      <category name="sdt-weaving"/>
-   </feature>
    <feature url="features/org.scala-ide.sdt.source.feature_0.0.0.jar" id="org.scala-ide.sdt.source.feature" version="0.0.0">
       <category name="sdt-source"/>
    </feature>
    <category-def name="sdt" label="Scala IDE for Eclipse"/>
-   <category-def name="sdt-weaving" label="JDT Weaving">
-      <description>
-         JDT Weaving for Scala provides the Java Development Tools Weaving service for Eclipse. If you already have it installed (for instance, if you installed AspectJ or Springsource ToolSuite), do *not* install this version.
-      </description>
-   </category-def>
    <category-def name="sdt-source" label="Scala IDE for Eclipse Source Feature"/>
 </site>

--- a/org.scala-ide.sdt.weaving.feature/feature.xml
+++ b/org.scala-ide.sdt.weaving.feature/feature.xml
@@ -6,48 +6,81 @@
       provider-name="scala-ide.org">
 
    <description>
-      This feature adds the JDT weaving service to Eclipse. If you
-already have a feature that installs it (such as the AspectJ
-plugin or the Springsource Tool Suite), please do NOT select
-this feature.
+      This feature is necessary for the Scala IDE to function properly. It adds extension points inside the
+Java Development Tools through AspectJ weaving.
    </description>
 
-   <license url="http://scala-lang.org/downloads/license.html">
-      SCALA LICENSE
+   <license url="http://eclipse.org/legal/epl-v10.html">
+      Eclipse Public License - v 1.0
 
-Copyright (c) 2002-2010 EPFL, Lausanne, unless otherwise specified.
-All rights reserved.
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
 
-This software was developed by the Programming Methods Laboratory of the
-Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland.
+1. DEFINITIONS
 
-Permission to use, copy, modify, and distribute this software in source
-or binary form for any purpose with or without fee is hereby granted,
-provided that the following conditions are met:
+&quot;Contribution&quot; means:
 
-   1. Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
+a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution &apos;originates&apos; from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor&apos;s behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
+&quot;Contributor&quot; means any person or entity that distributes the Program.
 
-   2. Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
+&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
 
-   3. Neither the name of the EPFL nor the names of its contributors
-      may be used to endorse or promote products derived from this
-      software without specific prior written permission.
+&quot;Program&quot; means the Contributions distributed in accordance with this Agreement.
 
+&quot;Recipient&quot; means anyone who receives the Program under this Agreement, including all Contributors.
 
-THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS&apos;&apos; AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient&apos;s responsibility to acquire that license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+b) its license agreement:
+i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+b) a copy of this Agreement must be included with each copy of the Program.
+Contributors may not remove or alter any copyright notices contained within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every other Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor&apos;s responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient&apos;s rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient&apos;s rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient&apos;s obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
    </license>
 
    <plugin
@@ -65,13 +98,6 @@ SUCH DAMAGE.
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.contribution.weaving.jdt"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.weaving.aspectj"
          download-size="0"
          install-size="0"
@@ -80,6 +106,13 @@ SUCH DAMAGE.
 
    <plugin
          id="org.eclipse.equinox.weaving.hook"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.scala-ide.sdt.aspects"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
compatible with Spring IDE and AJDT.

Copied the corresponding code from the AJDT plugin
to our aspects code. Kept the same two extension points.

Changed the update site to show only the Scala IDE
feature (binary and source). The weaving feature is
a nested feature in the SDT feature, because it needs its
own license.

Added LICENSE files. The Scala license for the project,
and the EPL for the org.scala-ide.sdt.aspects bundle.

Fixed #1000780.
