### PR TITLE
Changed the Scala library/compiler version check

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
@@ -131,10 +131,11 @@ class ScalaPlugin extends AbstractUIPlugin with IResourceChangeListener with IEl
   //lazy val sbtScalaCompiler = pathInBundle(sbtCompilerBundle, "/lib/scala-" + shortScalaVer + "/lib/scala-compiler.jar")
   
   val scalaLibBundle = {
-    val bundles = Option(Platform.getBundles(ScalaPlugin.plugin.libraryPluginId, scalaCompilerBundleVersion.toString())).getOrElse(Array[Bundle]())
+    // all library bundles
+    val bundles = Option(Platform.getBundles(ScalaPlugin.plugin.libraryPluginId, null)).getOrElse(Array[Bundle]())
     logger.debug("[scalaLibBundle] Found %d bundles: %s".format(bundles.size, bundles.toList.mkString(", ")))
-    bundles.find(_.getVersion() == scalaCompilerBundleVersion).getOrElse {
-      logger.warning("Couldnt find a match for %s in %s. Using default.".format(scalaCompilerBundleVersion, bundles.toList.mkString(", ")))
+    bundles.find(b => b.getVersion().getMajor() == scalaCompilerBundleVersion.getMajor() && b.getVersion().getMinor() == scalaCompilerBundleVersion.getMinor()).getOrElse {
+      logger.error("Could not find a match for %s in %s. Using default.".format(scalaCompilerBundleVersion, bundles.toList.mkString(", ")), null)
       Platform.getBundle(ScalaPlugin.plugin.libraryPluginId)
     }
   }


### PR DESCRIPTION
It know checks at the major/minor level, not lower. And logs an error if it cannot find a match.

Fix #1000793
