### PR TITLE
Improved UI for Scala completions. 

### DIFF
--- a/org.scala-ide.sdt.core.tests/test-workspace/completion/src/ticket_1000772/CompletionsWithName.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/completion/src/ticket_1000772/CompletionsWithName.scala
@@ -1,0 +1,15 @@
+package ticket_1000772
+
+class ForTesting {
+  def method(param1: String, param2: String)(secondSectionParam1: Int)(implicit x: Int) {
+  }
+}
+
+class Foo {
+
+  def bar {
+    val x: ForTesting = null
+
+    x.m /*!*/
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -253,6 +253,11 @@ class ScalaPresentationCompiler(project : ScalaProject, settings : Settings)
      
      val contextString = sym.paramss.map(_.map(p => "%s: %s".format(p.decodedName, p.tpe)).mkString("(", ", ", ")")).mkString("")
      
+     val paramNames = for {
+       section <- sym.paramss
+       if section.nonEmpty && !section.head.isImplicit
+     } yield for (param <- section) yield param.name.toString
+     
      import scala.tools.eclipse.completion.HasArgs
      CompletionProposal(kind,
          start, 
@@ -263,6 +268,7 @@ class ScalaPresentationCompiler(project : ScalaProject, settings : Settings)
          relevance,
          HasArgs.from(sym.paramss),
          sym.isJavaDefined,
+         paramNames,
          sym.fullName,
          false)
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/CompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/CompletionProposal.scala
@@ -28,6 +28,7 @@ case class CompletionProposal(kind: MemberKind.Value,
   relevance: Int,
   hasArgs: HasArgs.Value,
   isJava: Boolean,
+  explicitParamNames: List[List[String]], // parameter names (excluding any implicit parameter sections)
   fullyQualifiedName: String, // for Class, Trait, Type, Objects: the fully qualified name
   needImport: Boolean        // for Class, Trait, Type, Objects: import statement has to be added
 )

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaCompletions.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaCompletions.scala
@@ -117,6 +117,7 @@ class ScalaCompletions extends HasLogger {
 	            50,
 	            HasArgs.NoArgs,
 	            true,
+	            List(),
 	            fullyQualifiedName,
 	            true)
 	      }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaContextInformation.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaContextInformation.scala
@@ -4,12 +4,12 @@ import org.eclipse.jface.text.contentassist.{IContextInformation,IContextInforma
 import org.eclipse.swt.graphics.Image
 
 class ScalaContextInformation(
-    display: String, info: String, image: Image) 
+    display: String, info: String, image: Image, pos: Int) 
     extends IContextInformation 
     with IContextInformationExtension {
   
   def getContextDisplayString() = display
   def getImage() = image
   def getInformationDisplayString() = info
-  def getContextInformationPosition(): Int = 0
+  def getContextInformationPosition(): Int = pos
 }


### PR DESCRIPTION
- when a proposal is chosen, its parameter names are inserted
  in place of the arguments, and the editor is put in 'link' mode:
  Tab moves the caret to the next argument, Esc and ';' move the caret
  to the end of the argument list (and exits the linked mode). Hitting
  <enter> moves the caret to the end, unless it comes after an opening
  brace -> that means a closure is needed, and the editor is put out
  of the linked mode
- context information works now. A method signature (parameter names and
  types) are shown above the completion point, and the current argument
  is correctly highlighted (bold). When the cursor leaves the argument list,
  the context information window is now removed.
