### PR TITLE
Support Eclipse 3.7 (Indigo)

### DIFF
--- a/org.scala-ide.build/pom.xml
+++ b/org.scala-ide.build/pom.xml
@@ -17,10 +17,9 @@
     <maven.compiler.source>1.5</maven.compiler.source>
     <maven.compiler.target>1.5</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <!-- <repo.scala-ide>file:/absolute/path/to/scala-ide/org.scala-ide.build-toolchain/mkrepo/scala-eclipse-toolchain-osgi-2.9.2-SNAPSHOT</repo.scala-ide> -->
     <repo.scala-ide>http://download.scala-ide.org</repo.scala-ide>
-    <repo.helios>http://download.eclipse.org/releases/helios/</repo.helios>
-    <!-- <repo.helios>file:/absolute/path/to/helios/helios-mirror</repo.helios> -->
+    <repo.indigo>http://download.eclipse.org/releases/indigo/</repo.indigo>
+    <repo.ajdt>http://download.eclipse.org/tools/ajdt/37/update</repo.ajdt>
   </properties>
 
   <prerequisites>
@@ -103,17 +102,17 @@
   </build>
   <repositories>
     <repository>
-      <id>Helios</id>
-      <name>Eclipse Helios p2 repository</name>
+      <id>Indigo</id>
+      <name>Eclipse Indigo p2 repository</name>
       <layout>p2</layout>
-      <url>${repo.helios}</url>
+      <url>${repo.indigo}</url>
       <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
-      <id>ajdt-helios</id>
-      <name>AJDT for Eclipse Helios p2 repository</name>
+      <id>ajdt-indigo</id>
+      <name>AJDT for Eclipse Indigo p2 repository</name>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/tools/ajdt/36/update</url>
+      <url>${repo.ajdt}</url>
       <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/spellingengineprovider/ISpellingEngineProvider.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/spellingengineprovider/ISpellingEngineProvider.java
@@ -5,8 +5,8 @@
 
 package scala.tools.eclipse.contribution.weaving.jdt.spellingengineprovider;
 
-import org.eclipse.ui.texteditor.spelling.ISpellingEngine;
+import org.eclipse.jdt.internal.ui.text.spelling.SpellingEngine;
 
 public interface ISpellingEngineProvider {
-	public ISpellingEngine getScalaSpellingEngine();
+	public SpellingEngine getScalaSpellingEngine();
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaBuilder.scala
@@ -32,7 +32,7 @@ class ScalaBuilder extends IncrementalProjectBuilder with HasLogger {
     JDTUtils.refreshPackageExplorer
   }
   
-  override def build(kind : Int, ignored : ju.Map[_, _], monitor : IProgressMonitor) : Array[IProject] = {
+  override def build(kind : Int, ignored : ju.Map[String, String], monitor : IProgressMonitor) : Array[IProject] = {
     import IncrementalProjectBuilder._
     import buildmanager.sbtintegration.EclipseSbtBuildManager
     

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSpellingEngineProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSpellingEngineProvider.scala
@@ -3,7 +3,7 @@ package scala.tools.eclipse
 import scala.tools.eclipse.contribution.weaving.jdt.spellingengineprovider.ISpellingEngineProvider
 import scala.tools.eclipse.lexical.ScalaPartitions._
 
-import org.eclipse.ui.texteditor.spelling.ISpellingEngine
+import org.eclipse.jdt.internal.ui.text.spelling.SpellingEngine
 
 import org.eclipse.jdt.internal.ui.text.spelling.SpellingEngine
 import org.eclipse.core.runtime.AssertionFailedException
@@ -31,7 +31,7 @@ import org.eclipse.jdt.internal.ui.text.spelling.JavaSpellingProblem
  */
 class ScalaSpellingEngineProvider extends ISpellingEngineProvider {
 
-  def getScalaSpellingEngine: ISpellingEngine = new ScalaSpellingEngine
+  def getScalaSpellingEngine: SpellingEngine = new ScalaSpellingEngine
 
   class ScalaSpellingEngine extends SpellingEngine {
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaJavaCompletionProposalComputer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaJavaCompletionProposalComputer.scala
@@ -38,6 +38,8 @@ import org.eclipse.jdt.core.dom.FieldAccess
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement
 import org.eclipse.jdt.core.dom.ClassInstanceCreation
 
+import org.eclipse.jface.text.contentassist.ICompletionProposal
+
 /** A completion proposal for Java sources. This adds mixed-in concrete members to scope
  *  completions in Java.
  *  
@@ -62,7 +64,7 @@ class ScalaJavaCompletionProposalComputer extends IJavaCompletionProposalCompute
   def computeContextInformation(context: ContentAssistInvocationContext, monitor: IProgressMonitor) = 
     javaEmptyList()
     
-  def computeCompletionProposals(context: ContentAssistInvocationContext, monitor: IProgressMonitor): java.util.List[_] = {
+  def computeCompletionProposals(context: ContentAssistInvocationContext, monitor: IProgressMonitor): java.util.List[ICompletionProposal] = {
     context match {
       case jc: JavaContentAssistInvocationContext => 
         if (ScalaPlugin.plugin.isScalaProject(jc.getProject()))
@@ -78,7 +80,7 @@ class ScalaJavaCompletionProposalComputer extends IJavaCompletionProposalCompute
   /**
    * Return completion proposals for mixed-in methods.
    */
-  def mixedInCompletions(unit: ICompilationUnit, invocationOffset: Int, selectionProvider: ISelectionProvider, monitor: IProgressMonitor): java.util.List[_] = {
+  def mixedInCompletions(unit: ICompilationUnit, invocationOffset: Int, selectionProvider: ISelectionProvider, monitor: IProgressMonitor): java.util.List[ICompletionProposal] = {
     // make sure the unit is consistent with the editor buffer
     unit.makeConsistent(monitor)
     // ask for the Java AST of the source
@@ -130,7 +132,7 @@ class ScalaJavaCompletionProposalComputer extends IJavaCompletionProposalCompute
 
     import scala.collection.JavaConversions._
 
-    completionProposals: java.util.List[_]
+    completionProposals: java.util.List[ICompletionProposal]
   }
 
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaElements.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaElements.scala
@@ -8,7 +8,7 @@ package scala.tools.eclipse.javaelements
 import scala.collection.immutable.Seq
 import scala.reflect.NameTransformer
 
-import org.eclipse.jdt.core.{ IField, IJavaElement, IMember, IMethod, IType, ITypeParameter }
+import org.eclipse.jdt.core.{ IField, IJavaElement, IMember, IMethod, IType, ITypeParameter, Flags }
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants
 import org.eclipse.jdt.internal.core.{
   BinaryType, JavaElement, JavaElementInfo, LocalVariable, SourceConstructorInfo, SourceField, SourceFieldElementInfo,
@@ -151,9 +151,8 @@ class ScalaTypeElement(parent : JavaElement, name : String, display : String)
 class ScalaLocalVariableElement(
   parent : JavaElement, name : String,
   declarationSourceStart : Int, declarationSourceEnd : Int, nameStart : Int, nameEnd : Int,
-  typeSignature : String,
-  display : String) extends LocalVariable(
-  parent, name, declarationSourceStart, declarationSourceEnd, nameStart, nameEnd, typeSignature, null) with
+  typeSignature : String, display : String, jdtFlags : Int, methodParameter : Boolean ) extends LocalVariable(
+  parent, name, declarationSourceStart, declarationSourceEnd, nameStart, nameEnd, typeSignature, null, jdtFlags, methodParameter) with
   ScalaElement {
   override def getLabelText(flags : Long) = display
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaIndexBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaIndexBuilder.scala
@@ -6,7 +6,6 @@
 package scala.tools.eclipse.javaelements
 
 import org.eclipse.core.resources.IFile
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants
 
 import scala.tools.nsc.symtab.Flags
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSelectionEngine.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSelectionEngine.scala
@@ -138,6 +138,11 @@ class ScalaSelectionEngine(nameEnvironment: SearchableEnvironment, requestor: IS
             case jt if jt == JType.UNKNOWN | jt == JType.ADDRESS | jt == JType.REFERENCE => JObjectType.JAVA_LANG_OBJECT
             case jt => jt
           }
+
+          val isMember = defn.owner.isClass
+
+          val jdtFlags = mapModifiers(defn)
+
           val localVar = new ScalaLocalVariableElement(
             parent.asInstanceOf[JavaElement],
             name,
@@ -146,7 +151,7 @@ class ScalaSelectionEngine(nameEnvironment: SearchableEnvironment, requestor: IS
             defn.pos.point,
             defn.pos.point + name.length - 1,
             jtype.getSignature,
-            name + " : " + defn.tpe.toString)
+            name + " : " + defn.tpe.toString, jdtFlags, isMember)
           Cont(ssr.addElement(localVar))
         } else Cont.Noop
       }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposalComputer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposalComputer.scala
@@ -34,13 +34,13 @@ class ScalaCompletionProposalComputer extends ScalaCompletions with IJavaComplet
 
 
   def computeContextInformation(context : ContentAssistInvocationContext,
-      monitor : IProgressMonitor) : java.util.List[_] = {
+      monitor : IProgressMonitor) : java.util.List[IContextInformation] = {
     // Currently not supported
     java.util.Collections.emptyList()
   }
   
   def computeCompletionProposals(context : ContentAssistInvocationContext,
-         monitor : IProgressMonitor) : java.util.List[_] = {
+         monitor : IProgressMonitor) : java.util.List[ICompletionProposal] = {
     import java.util.Collections.{ emptyList => javaEmptyList }
     
     val position = context.getInvocationOffset()


### PR DESCRIPTION
This merge is the result of @emolitor work done in the platform/indigo-37 branch. I've simply squashed all changes made in platform/indigo-37 in a single commit, as I feel it keeps history cleaner (and there are not that many changes anyway).

Eric, I only made two, hopefully minor, changes: 
-  Using the released AJDT 2.1.3 instead of 2.2-SNAPSHOT. (I don't see a need to link against 2.2, at least until there is a stable release)
- Call `mapModifiers` to map modifiers of a Scala's symbols to JDT flags (there was a big TODO comment in the code, which I hence removed). 

Here follows the list of changes applied in this commit:
- Created a repo.ajdt entry and use 2.1.3 for JDT 3.7 (we could also use AJDT
  2.2 snapshot, but I still think it's better to use the currently released
  AJDT and move to 2.2 only after it is officially released).
- Use Eclipse Indigo release site (this fixes JDK 7 builds).
- Pass isMember correctly derived if the owner is a class.  Obtain `jdtFlags`
  using `ScalaJavaMapper.mapModifiers(symbol)`.
- Add `flags` and `methodParameter` to `ScalaLocalVariableElement`.
