### PR TITLE
Add a 2nd pointcut to handle files named "package.scala".

### DIFF
--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/core/CompilationUnitNameAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/core/CompilationUnitNameAspect.aj
@@ -1,15 +1,22 @@
 package scala.tools.eclipse.contribution.weaving.jdt.core;
 
 import org.eclipse.jdt.internal.core.util.Util;
+import org.eclipse.jdt.core.JavaConventions;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jdt.internal.core.JavaModelStatus;
 
 /**
  * We override the behaviour of isValidCompilationUnitName() for .scala files.
  * The standard implementation applies Java identifier rules on the prefix of
  * the file name, so that, for example, "package.scala" would not be judged
- * valid. See Issue #3266.
+ * valid. See Issues #3266, #1000859.
  */
 @SuppressWarnings("restriction")
 public aspect CompilationUnitNameAspect {
+
+	private static boolean isScalaFileName(String name) {
+		return name != null && name.length() > 6 && name.endsWith(".scala");
+	}
 
 	pointcut isValidCompilationUnitName(String name, String sourceLevel, String complianceLevel):
 	    args(name, sourceLevel, complianceLevel) &&
@@ -17,8 +24,20 @@ public aspect CompilationUnitNameAspect {
 
 	boolean around(String name, String sourceLevel, String complianceLevel):
 	    isValidCompilationUnitName(name, sourceLevel, complianceLevel) {
-		if (name != null && name.endsWith(".scala"))
+		if (isScalaFileName(name))
 			return true;
+		else
+			return proceed(name, sourceLevel, complianceLevel);
+	}
+
+	pointcut validateCompilationUnitName(String name, String sourceLevel, String complianceLevel):
+	    args(name, sourceLevel, complianceLevel) &&
+		execution(IStatus JavaConventions.validateCompilationUnitName(String, String, String));
+
+	IStatus around(String name, String sourceLevel, String complianceLevel):
+	    validateCompilationUnitName(name, sourceLevel, complianceLevel) {
+		if (isScalaFileName(name))
+			return JavaModelStatus.VERIFIED_OK;
 		else
 			return proceed(name, sourceLevel, complianceLevel);
 	}


### PR DESCRIPTION
For ticket #1000859

I deviated slightly from the "Workflow" - I did not test this with the different Scala compiler versions, but that is because the only change was to an AspectJ file.
