### PR TITLE
Issue/move class refactoring 1000422

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -941,7 +941,20 @@
                path="edit">
             <separator name="scala.tools.eclipse.refactoring.refactoringGroup"/>
          </menu>
-           <action
+         <action
+               class="scala.tools.eclipse.refactoring.move.MoveClassAction"
+               definitionId="scala.tools.eclipse.refactoring.command.MoveClass"
+               id="scala.tools.eclipse.refactoring.moveClassAction"
+               label="Move Class/Object/Trait"
+               menubarPath="scala.tools.eclipse.refactoring.refactoringMenu/scala.tools.eclipse.refactoring.sourceGeneratorGroup"
+               tooltip="Move Class/Object/Trait">
+            <!--<enablement>
+               <objectClass
+                     name="org.eclipse.jface.text.TextSelection">
+               </objectClass>
+            </enablement>-->
+         </action>
+         <action
                class="scala.tools.eclipse.refactoring.ExtractMethodAction"
                definitionId="scala.tools.eclipse.refactoring.command.ExtractMethod"
                id="scala.tools.eclipse.refactoring.extractMethodAction"
@@ -954,7 +967,7 @@
                </objectClass>
             </enablement>
          </action>
-           <action
+         <action
                class="scala.tools.eclipse.refactoring.ExtractLocalAction"
                definitionId="scala.tools.eclipse.refactoring.command.ExtractLocal"
                id="scala.tools.eclipse.refactoring.extractLocalAction"
@@ -1026,6 +1039,10 @@
          description="Shows the refactor quick menu"
          categoryId="scala.tools.eclipse.refactoring.commands.refactoring"
          id="scala.tools.eclipse.refactoring.commands.quickMenu"/>
+      <command
+         categoryId="scala.tools.eclipse.refactoring.commands.refactoring"
+         id="scala.tools.eclipse.refactoring.command.MoveClass"
+         name="Move Class/Object/Trait"/>
       <command
          categoryId="scala.tools.eclipse.refactoring.commands.refactoring"
          id="scala.tools.eclipse.refactoring.command.ExtractMethod"
@@ -1231,5 +1248,20 @@
           id="org.scala-ide.sdt.core.SemanticHighlightingPresenter"
           name="Semantic Highlighting">
     </participant>
+ </extension>
+ <extension
+       point="org.eclipse.ltk.core.refactoring.moveParticipants">
+    <moveParticipant
+          class="scala.tools.eclipse.refactoring.move.ScalaMoveParticipant"
+          id="org.scala-ide.sdt.core.moveParticipant"
+          name="Scala Move Participant">
+       <enablement>
+          <with variable="element">
+             <instanceof
+                   value="org.eclipse.core.resources.IResource">
+             </instanceof>
+          </with>
+       </enablement>
+    </moveParticipant>
  </extension>
 </plugin>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ActionWithNoWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ActionWithNoWizard.scala
@@ -23,14 +23,12 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog
 trait ActionWithNoWizard {
   this: RefactoringAction =>
 
-  val shell = PlatformUI.getWorkbench.getActiveWorkbenchWindow.getShell
-
   override def run(action: IAction) {
     runRefactoringInUiJob()
   }
   
   def runRefactoringInUiJob() {
-    runInUiJob { (pm, shell) =>
+    ProgressHelpers.runInUiJob { (pm, shell) =>
       createScalaIdeRefactoringForCurrentEditorAndSelection() match {
         case Some(refactoring: ScalaIdeRefactoring) =>
           val status = refactoring.checkInitialConditions(pm)
@@ -46,23 +44,5 @@ trait ActionWithNoWizard {
       
       Status.OK_STATUS
     }
-  }
-  
-  def runInUiJob(block: (IProgressMonitor, Shell) => IStatus) {
-    new UIJob("Refactoring") {
-      def runInUIThread(pm: IProgressMonitor): IStatus = {
-        block(pm, shell)
-      }
-    }.schedule
-  }
-  
-  def runInProgressDialog(block: IProgressMonitor => Unit) {
-    
-    val runnable = new IRunnableWithProgress {
-      def run(pm: IProgressMonitor) = block(pm)
-    }
-    
-    val dialog = new ProgressMonitorDialog(PlatformUI.getWorkbench.getActiveWorkbenchWindow.getShell)
-    dialog.run(false /*run in ui thread!*/, true /*cancelable*/, runnable)
   }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/EditorHelpers.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/EditorHelpers.scala
@@ -28,6 +28,7 @@ import org.eclipse.jface.text.link.LinkedModeModel
 import org.eclipse.jface.text.link.LinkedPositionGroup
 import org.eclipse.jface.text.link.LinkedPosition
 import org.eclipse.jface.text.link.LinkedModeUI
+import scala.tools.refactoring.common.TextChange
 
 object EditorHelpers {
    
@@ -75,7 +76,7 @@ object EditorHelpers {
     }
   }
   
-  def createTextFileChange(file: IFile, fileChanges: List[scala.tools.refactoring.common.Change]): TextFileChange = {
+  def createTextFileChange(file: IFile, fileChanges: List[TextChange]): TextFileChange = {
     new TextFileChange(file.getName(), file) {
             
       val fileChangeRootEdit = new MultiTextEdit
@@ -97,7 +98,7 @@ object EditorHelpers {
    * @param file The file that we're currently editing (the document alone isn't enough because we need to get an IFile).
    * @param changes The changes that should be applied.
    */
-  def applyChangesToFileWhileKeepingSelection(document: IDocument, textSelection: ITextSelection, file: AbstractFile, changes: List[Change])  { 
+  def applyChangesToFileWhileKeepingSelection(document: IDocument, textSelection: ITextSelection, file: AbstractFile, changes: List[TextChange])  { 
     
     def selectionIsInManipulatedRegion(region: IRegion): Boolean = {
       val (regionStart, regionEnd) = {
@@ -149,7 +150,7 @@ object EditorHelpers {
     }
   }
   
-  def applyRefactoringChangeToEditor(change: Change, editor: ScalaSourceFileEditor) = {
+  def applyRefactoringChangeToEditor(change: TextChange, editor: ScalaSourceFileEditor) = {
     val edit = new ReplaceEdit(change.from, change.to - change.from, change.text)
     val document = editor.getDocumentProvider.getDocument(editor.getEditorInput)
     edit.apply(document)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractLocalAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractLocalAction.scala
@@ -11,6 +11,7 @@ import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.common.{Change, Selections}
 import scala.tools.refactoring.implementations.ExtractLocal
 import org.eclipse.ui.PlatformUI
+import scala.tools.refactoring.common.TextChange
 
 /**
  * From a selected expression, the Extract Local refactoring will create a new 
@@ -39,7 +40,7 @@ class ExtractLocalAction extends RefactoringAction {
      * that does not exist and then looking up the position of these
      * names in the generated change.
      */
-    def doInlineExtraction(change: Change, name: String) {
+    def doInlineExtraction(change: TextChange, name: String) {
       EditorHelpers.doWithCurrentEditor { editor =>
                 
         EditorHelpers.applyRefactoringChangeToEditor(change, editor)
@@ -60,7 +61,7 @@ class ExtractLocalAction extends RefactoringAction {
       case Some(r: ExtractLocalScalaIdeRefactoring) => 
               
         r.preparationResult.right.map(_ => r.performRefactoring()) match {
-          case Right((change: Change) :: Nil) =>
+          case Right((change: TextChange) :: Nil) =>
             doInlineExtraction(change, r.name)
           case _ =>
             runRefactoring(createWizardForRefactoring(Some(r)), shell)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/FullProjectIndex.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/FullProjectIndex.scala
@@ -1,0 +1,190 @@
+package scala.tools.eclipse
+package refactoring
+
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.IProgressMonitor
+import scala.tools.eclipse.javaelements.ScalaSourceFile
+import scala.tools.eclipse.util.HasLogger
+import scala.tools.nsc.util.SourceFile
+import scala.tools.refactoring.analysis.GlobalIndexes
+import scala.tools.refactoring.common.InteractiveScalaCompiler
+import scala.tools.refactoring.MultiStageRefactoring
+import org.eclipse.jdt.internal.core.search.PathCollector
+import org.eclipse.jdt.internal.core.search.indexing.IndexManager
+import org.eclipse.jdt.internal.core.JavaModelManager
+import org.eclipse.jdt.core.search.SearchEngine
+import org.eclipse.jdt.core.IJavaElement
+import org.eclipse.jdt.core.search.SearchPattern
+import org.eclipse.jdt.core.search.IJavaSearchConstants
+import org.eclipse.jdt.internal.core.search.PatternSearchJob
+import org.eclipse.jdt.core.search.SearchParticipant
+import org.eclipse.core.runtime.SubProgressMonitor
+import org.eclipse.jdt.internal.core.search.BasicSearchEngine
+import org.eclipse.jdt.core.search.IJavaSearchScope
+import org.eclipse.core.runtime.IPath
+
+/**
+ * A trait that can be mixed into refactorings that need an index of the whole 
+ * project (e.g. Global Rename, Move Class).
+ * 
+ * This loads all the files in the project into the presentation compiler, which
+ * takes significant time. Once the Scala IDE has its own index, we should be able
+ * to make this much more efficient than it currently is.
+ */
+trait FullProjectIndex extends HasLogger {
+  
+  val refactoring: MultiStageRefactoring with InteractiveScalaCompiler with GlobalIndexes    
+    
+  val project: ScalaProject
+  
+  /**
+   * A cleanup handler, will later be set by the refactoring
+   * to remove all loaded compilation units from the compiler.
+   */
+  type CleanupHandler = () => Unit
+  
+  /**
+   * Builds an index from all the source files in the current project. The returned 
+   * CleanupHandler needs to be called when the index isn't used anymore, this will
+   * then unload all the originally unloaded files from the presentation compiler.
+   * 
+   * @param hints If present, only files that contain one of these Strings is added
+   *              to the index. It uses the JDT SearchEngine to search files.
+   */
+  def buildFullProjectIndex(pm: IProgressMonitor, hints: List[String]): (refactoring.IndexLookup, CleanupHandler) = {
+    
+    import refactoring.global
+  
+    def allProjectSourceFiles: Seq[String] = {
+      if(hints.isEmpty) {
+        project.allSourceFiles map (_.getFullPath.toString) toSeq
+      } else {
+        
+        val scope = SearchEngine.createJavaSearchScope(Array[IJavaElement](project.javaProject), IJavaSearchScope.SOURCES)
+        
+        val combinedPattern = hints map { hint =>
+          SearchPattern.createPattern(
+              hint, IJavaSearchConstants.TYPE, IJavaSearchConstants.ALL_OCCURRENCES,  SearchPattern.R_EXACT_MATCH)
+        } reduceLeft SearchPattern.createOrPattern
+        
+        val pathCollector = new PathCollector
+        val indexManager = JavaModelManager.getIndexManager
+        indexManager.performConcurrentJob(
+          new PatternSearchJob(combinedPattern, BasicSearchEngine.getDefaultSearchParticipant, scope, pathCollector),
+          IJavaSearchConstants.FORCE_IMMEDIATE_SEARCH,
+          new SubProgressMonitor(pm, hints.size)
+        )
+
+        pathCollector.getPaths
+      }
+    }
+    
+    def collectAllScalaSources(files: Seq[String]): List[SourceFile] = {
+      val allScalaSourceFiles = files flatMap { f =>
+        if(pm.isCanceled)
+          return Nil
+        else 
+          ScalaSourceFile.createFromPath(f)
+      } toList
+      
+      allScalaSourceFiles map { ssf =>
+        if(pm.isCanceled)
+          return Nil
+        else
+          ssf.withSourceFile { (sourceFile, _) => sourceFile}()
+      }
+    }
+    
+    /**
+     * First loads all the source files into the compiler and then starts
+     * typeckecking them. The method won't block until typechecking is done
+     * but return all the Response objects instead.
+     * 
+     * If the process gets canceled, no more new typechecks will be started.
+     */
+    def mapAllFilesToResponses(files: List[SourceFile], pm: IProgressMonitor) = {
+
+      pm.subTask("reloading source files")
+      val r = new global.Response[Unit]
+      global.askReload(files, r)
+      r.get
+
+      files flatMap { f =>
+        if(pm.isCanceled) {
+          None
+        } else {
+          val r = new global.Response[global.Tree]
+          global.askType(f, forceReload = false /*we just loaded the files*/, r)
+          Some(r)
+        }
+      }        
+    }
+    
+    /**
+     * Waits until all the typechecking has finished. Every 200 ms, it is checked
+     * whether the user has canceled the process.
+     */
+    def typeCheckAll(responses: List[global.Response[global.Tree]], pm: IProgressMonitor) = {
+      
+      def waitForResultOrCancel(r: global.Response[global.Tree]) = {
+
+        var result = None: Option[global.Tree]
+        
+        do {
+          if (pm.isCanceled) r.cancel()
+          else r.get(200) match {
+            case Some(Left(data)) if r.isComplete /*no provisional results*/ => 
+              result = Some(data)
+            case _ => // continue waiting
+          }
+        } while (!r.isComplete && !r.isCancelled && !pm.isCanceled)
+          
+        result
+      }
+      
+      responses flatMap { 
+        case r if !pm.isCanceled => 
+          waitForResultOrCancel(r)
+        case r =>
+          None
+      }
+    }
+          
+    pm.beginTask("loading files: ", 3)
+            
+    // we need to store the already loaded files so that we don't
+    // remove them from the presentation compiler later.
+    val previouslyLoadedFiles = global.unitOfFile.values map (_.source) toList
+    
+    val files = collectAllScalaSources(allProjectSourceFiles)
+    
+    val responses = mapAllFilesToResponses(files, pm)
+    
+    pm.subTask("typechecking source files")
+    
+    val trees = typeCheckAll(responses, pm)
+    
+    // will be called after the refactoring has finished
+    val cleanup = { () => 
+      (files filterNot previouslyLoadedFiles.contains) foreach {
+        global.removeUnitOf
+      }
+    }
+    
+    val cus = if(!pm.isCanceled) {
+      
+      pm.subTask("creating index")
+      
+      trees flatMap { tree =>
+        
+        project.withPresentationCompiler { compiler =>
+          compiler.askOption { () =>
+            refactoring.CompilationUnitIndex(tree)
+          }
+        }()
+      }
+    } else Nil
+    
+    (refactoring.GlobalIndex(cus), cleanup)
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
@@ -110,12 +110,7 @@ class OrganizeImportsAction extends RefactoringAction with ActionWithNoWizard {
       def createChanges(scalaSourceFile: ScalaSourceFile, imports: Iterable[TypeNameMatch], pm: IProgressMonitor) = {
         scalaSourceFile.withSourceFile { (sourceFile, compiler) =>
           val refactoring = new AddImportStatement { 
-            val global = compiler 
-            // The editor has not necessarily been saved, so we need to make 
-            // sure the refactoring gets the correct content of the document.
-            override def getContentForFile(file: AbstractFile): Array[Char] = {
-              sourceFile.content
-            }
+            val global = compiler
           }
           refactoring.addImports(scalaSourceFile.file, imports map (_.getFullyQualifiedName))
         }(Nil)
@@ -145,7 +140,7 @@ class OrganizeImportsAction extends RefactoringAction with ActionWithNoWizard {
 
       val typeSearchDialog = {
         val labelProvider = new TypeNameMatchLabelProvider(TypeNameMatchLabelProvider.SHOW_FULLYQUALIFIED)
-        new MultiElementListSelectionDialog(shell, labelProvider) {
+        new MultiElementListSelectionDialog(ProgressHelpers.shell, labelProvider) {
           setTitle(ActionMessages.OrganizeImportsAction_selectiondialog_title)
           setMessage(ActionMessages.OrganizeImportsAction_selectiondialog_message)
         }
@@ -208,7 +203,7 @@ class OrganizeImportsAction extends RefactoringAction with ActionWithNoWizard {
           // continue with organizing imports
           runRefactoringInUiJob()
         case missingTypes =>
-          runInProgressDialog { pm =>
+          ProgressHelpers.runInProgressDialogBlockUi { pm =>
             pm.beginTask("Organizing Imports", 4)
             addMissingImportsToFile(missingTypes, file, pm)
             pm.done

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ProgressHelpers.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ProgressHelpers.scala
@@ -1,0 +1,40 @@
+package scala.tools.eclipse
+package refactoring
+
+import org.eclipse.core.runtime.{IStatus, IProgressMonitor}
+import org.eclipse.jface.dialogs.ProgressMonitorDialog
+import org.eclipse.jface.operation.IRunnableWithProgress
+import org.eclipse.swt.widgets.Shell
+import org.eclipse.ui.progress.UIJob
+import org.eclipse.ui.PlatformUI
+
+object ProgressHelpers {
+  
+  def shell = PlatformUI.getWorkbench.getActiveWorkbenchWindow.getShell
+  
+  def runInUiJob(block: (IProgressMonitor, Shell) => IStatus) {
+    new UIJob("Refactoring") {
+      def runInUIThread(pm: IProgressMonitor): IStatus = {
+        block(pm, shell)
+      }
+    }.schedule
+  }
+    
+  def runInProgressDialogBlockUi(block: IProgressMonitor => Unit) {
+    runInProgressDialog(block, fork = false)
+  }
+    
+  def runInProgressDialogNonblocking(block: IProgressMonitor => Unit) {
+    runInProgressDialog(block, fork = true)
+  }
+
+  private def runInProgressDialog(block: IProgressMonitor => Unit, fork: Boolean) {
+    
+    val runnable = new IRunnableWithProgress {
+      def run(pm: IProgressMonitor) = block(pm)
+    }
+    
+    val dialog = new ProgressMonitorDialog(PlatformUI.getWorkbench.getActiveWorkbenchWindow.getShell)
+    dialog.run(fork, true /*cancelable*/, runnable)
+  } 
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/MoveClassAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/MoveClassAction.scala
@@ -1,0 +1,131 @@
+package scala.tools.eclipse
+package refactoring
+package move
+
+import org.eclipse.core.resources.{IFolder, IFile}
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.jdt.core.IPackageFragment
+import org.eclipse.jdt.internal.corext.refactoring.nls.changes.CreateFileChange
+import org.eclipse.ltk.core.refactoring.resource.MoveResourceChange
+import org.eclipse.ltk.core.refactoring.{RefactoringStatus, CompositeChange}
+
+import scala.tools.eclipse.javaelements.ScalaSourceFile
+import scala.tools.eclipse.refactoring.{RefactoringAction, FullProjectIndex}
+import scala.tools.refactoring.analysis.GlobalIndexes
+import scala.tools.refactoring.common.{TextChange, NewFileChange, ConsoleTracing}
+import scala.tools.refactoring.implementations.MoveClass
+
+/**
+ * The Move Class refactoring moves (non-nested) classes, objects and traits between different
+ * packages. In files that contains multiple classes, it's possible to split off a class and
+ * move it to its own file.
+ * 
+ * Using the ScalaMoveParticipant, the refactoring also hooks into other Eclipse move actions,
+ * like for example when a file is moved by drag&drop in the package explorer.
+ * 
+ */
+class MoveClassAction extends RefactoringAction {
+  
+  def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new MoveClassScalaIdeRefactoring(start, end, file)
+
+  class MoveClassScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile) 
+      extends ScalaIdeRefactoring("Move Class/Trait/Object", file, start, end) with FullProjectIndex {
+      
+    val project = file.project
+    
+    var moveSingleImpl: refactoring.PreparationResult = None
+    
+    var target: IPackageFragment = null
+    
+    def refactoringParameters = refactoring.RefactoringParameters(target.getElementName, moveSingleImpl)
+    
+    def setMoveSingleImpl(moveSingle: Boolean) {
+      if(moveSingle && preparationResult.isRight) {
+        // the function is never called if we don't have a value:
+        moveSingleImpl = preparationResult.right.get
+      } else {
+        moveSingleImpl = None
+      }
+    }
+    
+    val refactoring = withCompiler { compiler =>  
+      new MoveClass with GlobalIndexes with ConsoleTracing { 
+        val global = compiler
+        
+        /* The initial index is empty, it will be filled during the initialization
+         * where we can show a progress bar and let the user cancel the operation.*/
+        var index = GlobalIndex(Nil)
+      }
+    }
+    
+    /**
+     * A cleanup handler, will later be set by the refactoring
+     * to remove all loaded compilation units from the compiler.
+     */
+    var cleanup = () => ()
+    
+    override def checkInitialConditions(pm: IProgressMonitor): RefactoringStatus = {
+
+      // Call this early so that we can access the preparationresult
+      val status = super.checkInitialConditions(pm)
+      
+      if(pm.isCanceled) {
+        status.addWarning("Indexing was cancelled, this might lead to undesired results. Please review the changes carefully!")
+      }
+
+      status
+    }
+    
+    override def createChange(pm: IProgressMonitor): CompositeChange = {
+
+      val (index, cleanupHandler) = {
+        val toMove = refactoring.statsToMove(selection, refactoringParameters) collect {
+          case impl: refactoring.global.ImplDef => impl.name.toString
+        }
+        buildFullProjectIndex(pm, toMove)
+      }
+      
+      refactoring.index = index
+      
+      // will be called after the refactoring has finished
+      cleanup = cleanupHandler
+      
+      // the changes contain either a NewFileChange or we need to move the current file.
+      
+      val (textChanges, newFileChanges) = {
+        (performRefactoring() :\ (List[TextChange](), List[NewFileChange]())) {
+          case (change: TextChange, (textChanges, newFiles)) =>
+            (change :: textChanges, newFiles)
+          case (change: NewFileChange, (textChanges, newFilesChanges)) =>
+            (textChanges, change :: newFilesChanges)
+        }
+      }
+        
+      val change = new CompositeChange(getName) {
+
+        scalaChangesToEclipseChanges(textChanges) foreach add
+        
+        newFileChanges match {
+          
+          // If there's no new file to create, we move the current file.
+          case Nil => 
+            add(new MoveResourceChange(file.getResource, target.getCorrespondingResource.asInstanceOf[IFolder]))
+
+          // Otherwise, create a new file with the changes's content.
+          case newFile :: rest =>
+            val pth = target.getPath.append(preparationResult.right.get.get.name.toString + ".scala")
+            add(new CreateFileChange(pth, newFile.text, file.getResource.asInstanceOf[IFile].getCharset)) 
+        }
+      }
+      
+      cleanup()
+      
+      change
+    }
+      
+    override def getPages = {
+      val selectedImpl = preparationResult.right.toOption flatMap (_.map(_.name.toString))
+      List(new ui.MoveClassRefactoringConfigurationPage(file.getResource(), selectedImpl, target_=, setMoveSingleImpl))
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/ScalaMoveParticipant.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/ScalaMoveParticipant.scala
@@ -1,0 +1,84 @@
+package scala.tools.eclipse
+package refactoring.move
+
+import org.eclipse.core.resources.{IFolder, IFile}
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.ltk.core.refactoring.participants.{MoveParticipant, CheckConditionsContext}
+import org.eclipse.ltk.core.refactoring.{RefactoringStatus, CompositeChange, Change}
+import scala.tools.eclipse.javaelements.ScalaSourceFile
+import scala.tools.eclipse.ScalaPlugin
+import scala.tools.refactoring.common.TextChange
+import scala.tools.eclipse.refactoring.ProgressHelpers
+
+class ScalaMoveParticipant extends MoveParticipant {
+  
+  val getName = "Scala Move Participant"
+
+  private var resourceToMove: IFile = _
+  
+  private var change: Change = _
+  
+  protected def initialize(element: Object) = element match {
+    case f: IFile => 
+      resourceToMove = f
+      f.getName.endsWith("scala")
+    case _ => false
+  }
+
+  def checkConditions(pm: IProgressMonitor, context: CheckConditionsContext): RefactoringStatus = {
+    
+    getArguments.getDestination match {
+      case destination: IFolder =>
+        val javaProject = ScalaPlugin.plugin.getJavaProject(resourceToMove.getProject)
+        val targetPackage = javaProject.findPackageFragment(destination.getFullPath())        
+            
+        ScalaSourceFile.createFromPath(resourceToMove.getFullPath.toOSString) map { scalaSourceFile =>
+    
+          val moveRefactoring = {
+            val action = new MoveClassAction
+            new action.MoveClassScalaIdeRefactoring(/*selection is unimportant: */ 0, 0, scalaSourceFile)
+          }
+          
+          var initialConditions: Option[RefactoringStatus] = None
+          
+          // The Move refactoring in JDT is so fast that it doesn't need a cancelable
+          // progress monitor, so we run the refactoring in our own.
+          ProgressHelpers.runInProgressDialogNonblocking { pm =>
+            
+            initialConditions = Some(moveRefactoring.checkInitialConditions(pm))
+            moveRefactoring.setMoveSingleImpl(false /*move all classes in the file*/)
+            moveRefactoring.target = targetPackage
+      
+            if(pm.isCanceled) {
+              // when the user cancelled we still want to do the refactoring,
+              // but we skip our part. Really? Test! Add warning to the status.
+              pm.setCanceled(false)
+            } else {
+              change = new CompositeChange("Move Scala Class") {
+                val changes = moveRefactoring.performRefactoring() collect {
+                  case tc: TextChange => tc
+                }
+                moveRefactoring.scalaChangesToEclipseChanges(changes) foreach add
+              }
+            }
+          }
+          
+          moveRefactoring.cleanup()
+          
+          new RefactoringStatus {
+            initialConditions foreach (_.getEntries foreach addEntry) 
+          }
+        } getOrElse null
+        
+      case _ => null
+    }
+  }
+  
+  /**
+   * The refactoring needs to be executed before the file is moved, otherwise the 
+   * underlying IFile changes and the refactoring is applied to the old file.
+   */
+  override def createPreChange(pm: IProgressMonitor)= change
+  
+  def createChange(pm: IProgressMonitor) = null
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
@@ -32,8 +32,11 @@ class GlobalRenameAction extends RefactoringAction {
   /**
    * The actual refactoring instance that is used by the RefactoringAction.
    */
-  class RenameScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile) extends ScalaIdeRefactoring("Rename", file, start, end) {
+  class RenameScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile) 
+    extends ScalaIdeRefactoring("Rename", file, start, end) with FullProjectIndex {
       
+    val project = file.project
+    
     var name = ""
       
     def refactoringParameters = name
@@ -43,7 +46,7 @@ class GlobalRenameAction extends RefactoringAction {
         val global = compiler
         
         /* The initial index is empty, it will be filled during the initialization
-         * where we can show a progress bar and let the uer cancel the operation.*/
+         * where we can show a progress bar and let the user cancel the operation.*/
         var index = GlobalIndex(Nil)
       }
     }
@@ -59,116 +62,17 @@ class GlobalRenameAction extends RefactoringAction {
      */
     override def checkInitialConditions(pm: IProgressMonitor): RefactoringStatus = {
 
-      val allProjectSourceFiles = file.project.allSourceFiles.toList
-      
-      def initializeDefaultNameFromSelectedSymbol() = {
-        preparationResult.right.foreach { preparationResult =>
-          name = preparationResult.selectedTree.symbol.nameString
-        }
-      }
-      
-      def collectAllScalaSources(files: List[IFile]) = {
-        val allScalaSourceFiles = files flatMap { f =>
-          ScalaSourceFile.createFromPath(f.getFullPath.toString)
-        }
-        
-        allScalaSourceFiles map { ssf => 
-          ssf.withSourceFile { (sourceFile, _) => sourceFile
-          }()
-        }
-      }
-      
-      /**
-       * First loads all the source files into the compiler and then starts
-       * typeckecking them. The method won't block until typechecking is done
-       * but return all the Response objects instead.
-       * 
-       * If the process gets canceled, no more new typechecks will be started.
-       */
-      def mapAllFilesToResponses(files: List[SourceFile], pm: IProgressMonitor) = {
-
-        pm.subTask("Loading source files.")
-
-        val r = new refactoring.global.Response[Unit]
-        refactoring.global.askReload(files, r)
-        r.get
-        
-        files flatMap { f =>
-          if(pm.isCanceled) {
-            None
-          } else {
-            val r = new refactoring.global.Response[refactoring.global.Tree]
-            refactoring.global.askType(f, forceReload = false, r)
-            Some(r)
-          }
-        }        
-      }
-      
-      /**
-       * Waits until all the typechecking has finished. Every 200 ms, it is checked
-       * whether the user has canceled the process.
-       */
-      def typeCheckAll(responses: List[refactoring.global.Response[refactoring.global.Tree]], pm: IProgressMonitor) = {
-        
-        import refactoring.global._
-        
-        def waitForResultOrCancel(r: Response[Tree]) = {
-
-          var result = None: Option[Tree]
-          
-          do {
-            if (pm.isCanceled) r.cancel()
-            else r.get(200) match {
-              case Some(Left(data)) if r.isComplete /*no provisional results*/ => 
-                result = Some(data)
-              case _ => // continue waiting
-            }
-          } while (!r.isComplete && !r.isCancelled)
-            
-          result
-        }
-        
-        responses flatMap { 
-          case r if !pm.isCanceled => 
-            waitForResultOrCancel(r)
-          case r =>
-            None
-        }
-      }
-      
-      initializeDefaultNameFromSelectedSymbol()
-      
-      pm.beginTask("loading files for renaming", 3)
-              
-      // we need to store the already loaded files so that don't
-      // remove them from the presentation compiler later.
-      val previouslyLoadedFiles = refactoring.global.unitOfFile.values map (_.source) toList
-      
-      val files = collectAllScalaSources(allProjectSourceFiles)
-      
-      val responses = mapAllFilesToResponses(files, pm)
-      
-      pm.subTask("typechecking source files")
-      
-      val trees = typeCheckAll(responses, pm)
-      
-      if(!pm.isCanceled) {
-        
-        pm.subTask("creating index for renaming")
-        
-        val cus = trees map refactoring.CompilationUnitIndex.apply
-        
-        refactoring.index = refactoring.GlobalIndex(cus)
-      }
-      
-      // will be called after the refactoring has finished
-      cleanup = { () => 
-        (files filterNot previouslyLoadedFiles.contains) foreach {
-          refactoring.global.removeUnitOf
-        }
-      }
-
       val status = super.checkInitialConditions(pm)
+
+      if(!status.hasError) {
+        val selectedName = preparationResult.right.get.selectedTree.symbol.nameString
+        val (index, cleanupHandler) = buildFullProjectIndex(pm, selectedName :: Nil)
+        
+        refactoring.index = index
+        
+        // will be called after the refactoring has finished
+        cleanup = cleanupHandler
+      }
       
       if(pm.isCanceled) {
         status.addWarning("Indexing was cancelled, types will not be renamed.")
@@ -204,6 +108,8 @@ class GlobalRenameAction extends RefactoringAction {
           }
         case _ =>
       }
+      
+      cleanup()
       
       compositeChange
     }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/RenameParticipant.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/RenameParticipant.scala
@@ -10,6 +10,7 @@ import scala.tools.eclipse.javaelements.ScalaSourceFile
 import tools.nsc.util.{ NoPosition, Position, RangePosition }
 import org.eclipse.ltk.core.refactoring.CompositeChange
 import scala.tools.eclipse.util.FileUtils
+import scala.tools.refactoring.common.TextChange
 
 /**
  * This rename participant hooks into the JDT's Rename File refactoring and renames the
@@ -76,7 +77,10 @@ class RenameParticipant extends LtkRenameParticipant {
             pm.setCanceled(false)
           } else {
             change = new CompositeChange("Rename Scala Class") {
-              scalaChangesToEclipseChanges(performRefactoring) foreach add
+              val changes = performRefactoring() collect {
+                case tc: TextChange => tc
+              }
+              scalaChangesToEclipseChanges(changes) foreach add
             }
           }
           

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ui/MoveClassRefactoringConfigurationPage.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ui/MoveClassRefactoringConfigurationPage.scala
@@ -1,0 +1,164 @@
+package scala.tools.eclipse.refactoring
+package ui
+
+import org.eclipse.core.resources.{ResourcesPlugin, IResource}
+import org.eclipse.jdt.core.{JavaCore, IPackageFragmentRoot, IPackageFragment, IJavaProject}
+import org.eclipse.jdt.internal.ui.refactoring.reorg.CreateTargetQueries
+import org.eclipse.jdt.ui.JavaElementLabelProvider
+import org.eclipse.jface.viewers.{ViewerFilter, Viewer, TreeViewer, StructuredSelection, SelectionChangedEvent, IStructuredSelection, ISelectionChangedListener}
+import org.eclipse.ltk.core.refactoring.RefactoringStatus
+import org.eclipse.ltk.ui.refactoring.UserInputWizardPage
+import org.eclipse.swt.events.{SelectionEvent, SelectionAdapter}
+import org.eclipse.swt.layout.{GridLayout, GridData}
+import org.eclipse.swt.widgets.{Label, Composite, Button}
+import org.eclipse.swt.SWT
+import org.eclipse.ui.model.{WorkbenchViewerComparator, BaseWorkbenchContentProvider}
+import scala.tools.eclipse.ScalaPlugin
+
+class MoveClassRefactoringConfigurationPage(
+  resourceToMove: IResource,
+  singleImplSelected: Option[String],
+  setPackageFragment: IPackageFragment => Unit,
+  setMoveOnlySelectedClass: Boolean => Unit) extends UserInputWizardPage("MoveResourcesRefactoringConfigurationPage") {
+
+  lazy val originatingPackage = {
+    val javaProject = ScalaPlugin.plugin.getJavaProject(resourceToMove.getProject)
+    val pf = javaProject.findPackageFragment(resourceToMove.getParent().getFullPath())
+    pf.getElementName()
+  }
+  
+  private var destinationField: TreeViewer = _
+  private var moveSelectedClass: Button = _
+
+  def createControl(parent: Composite) {
+    initializeDialogUnits(parent)
+
+    val composite = new Composite(parent, SWT.NONE)
+    composite.setLayout(new GridLayout(2, false))
+    composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true))
+    composite.setFont(parent.getFont)
+
+    val label = new Label(composite, SWT.NONE)
+    label.setText("&Choose destination for ''%s'':".format(resourceToMove.getName))
+    label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true))
+
+    val button = new Button(composite, SWT.NONE)
+    button.setText("Create New Package...")
+
+    button.addSelectionListener(new SelectionAdapter {
+      override def widgetSelected(e: SelectionEvent) {
+        val createTargetQueries = new CreateTargetQueries(parent.getShell)
+        val createdTarget = createTargetQueries.createNewPackageQuery.getCreatedTarget(destinationField.getSelection)
+        destinationField.refresh()
+        resourceToMove.getProject.refreshLocal(IResource.DEPTH_ONE, null)
+        if(createdTarget != null)
+          destinationField.setSelection(new StructuredSelection(createdTarget))
+      }
+    })
+
+    destinationField = new TreeViewer(composite, SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER)
+    val gd = new GridData(GridData.FILL, GridData.FILL, true, true, 2, 1)
+    gd.widthHint = convertWidthInCharsToPixels(40)
+    gd.heightHint = convertHeightInCharsToPixels(15)
+    gd.grabExcessVerticalSpace = true
+    gd.grabExcessHorizontalSpace = true
+    destinationField.getTree.setLayoutData(gd)
+    destinationField.setLabelProvider(new JavaElementLabelProvider)
+    destinationField.setContentProvider(new BaseWorkbenchContentProvider)
+    destinationField.setComparator(new WorkbenchViewerComparator)
+
+    destinationField.setInput(JavaCore.create(ResourcesPlugin.getWorkspace.getRoot))
+
+    destinationField.addFilter(new ViewerFilter {
+      override def select(viewer: Viewer, parentElement: Object, element: Object): Boolean = {
+        element match {
+          case project: IJavaProject =>
+            project.getProject.equals(resourceToMove.getProject)
+          case pkg: IPackageFragmentRoot =>
+            !pkg.isArchive && !pkg.isExternal && pkg.isOpen && !pkg.isReadOnly
+          case pkg: IPackageFragment =>
+            !pkg.isDefaultPackage
+          case _ =>
+            false
+        }
+      }
+    })
+    destinationField.expandAll
+    destinationField.addSelectionChangedListener(new ISelectionChangedListener {
+      var subsequentSelection = false
+      def selectionChanged(event: SelectionChangedEvent) {
+        if (subsequentSelection) {
+          validatePage
+        } else {
+          // Don't validate the page on the first selection to
+          // prevent showing an error message at the start.
+          subsequentSelection = true
+        }
+      }
+    })
+
+    if (singleImplSelected.isDefined) {
+      moveSelectedClass = new Button(composite, SWT.CHECK)
+      moveSelectedClass.setSelection(true)
+      setMoveOnlySelectedClass(true)
+      moveSelectedClass.setText("Move \"" + singleImplSelected.get + "\" (uncheck to move the whole file)")
+    }
+
+    setPageComplete(false)
+    setControl(composite)
+  }
+
+  override def setVisible(visible: Boolean) {
+    if (visible) {
+      destinationField.getTree.setFocus
+      setErrorMessage(null) // no error messages until user interacts
+    }
+    super.setVisible(visible)
+  }
+
+  private def validatePage {
+    val status = new RefactoringStatus
+
+    getSelectedPackage match {
+      case None =>
+        status.addFatalError("Select a package.")
+      case Some(pkg) if pkg.getElementName == originatingPackage =>
+        status.addFatalError("Selected element is already in this package.")
+      case _ => 
+    }
+    
+    
+    // warn if the selected impl is a sealed class!
+    setPageComplete(status)
+  }
+
+  protected override def performFinish = {
+    initializeRefactoring
+    super.performFinish
+  }
+
+  override def getNextPage = {
+    initializeRefactoring
+    super.getNextPage
+  }
+
+  private def initializeRefactoring {
+    getSelectedPackage foreach { pkg =>
+      setPackageFragment(pkg)
+      if (moveSelectedClass != null) {
+        setMoveOnlySelectedClass(moveSelectedClass.getSelection)
+      }
+    }
+  }
+
+  private def getSelectedPackage = {
+    destinationField.getSelection match {
+      case selection: IStructuredSelection =>
+        selection.getFirstElement match {
+          case pkg: IPackageFragment => Some(pkg)
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+}


### PR DESCRIPTION
Integrates the Move Class/Object/Trait refactoring in the IDE.

This allows to either move a single class from a file with multiple definitions
to its own file, or move the complete file. The package declaration will
be updated, and the imports/references to the moved class are adjusted
in the whole project. The refactoring is also involved when a source file is
moved from the package explorer (MoveParticipant).

Of course Move Class also works on Traits and Objects, but for simplicity,
it's internally named MoveClass.

Some restrictions: it works only on Scala sources, and not across
multiple projects. Also, visibility issues that might arise are completely
ignored for now (I was surprised to find that the JDT also doesn't seem to care
much about visibility problems in its move refactorings).
