### PR TITLE
Fixed 1000891. Correctly handle formatter problem

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/formatter/FormatterTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/formatter/FormatterTests.scala
@@ -1,0 +1,19 @@
+package scala.tools.eclipse.formatter
+
+import scala.tools.eclipse.testsetup.TestProjectSetup
+import org.junit.Test
+import org.junit.Assert._
+
+object FormatterTests extends TestProjectSetup("general")
+
+class FormatterTests {
+  import FormatterTests._
+  
+  @Test
+  def NotNullForInvalidCode_1000891() = {
+    val formatter= new ScalaFormatterCleanUpProvider
+    val cu= compilationUnit("formatter/NotNullForInvalidCode_1000891.scala")
+    assertNotNull("The formatter should not return null as changes", formatter.createCleanUp(cu))
+  }
+
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/general/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/general/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/general/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/general/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>general</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/general/src/formatter/NotNullForInvalidCode_1000891.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/general/src/formatter/NotNullForInvalidCode_1000891.scala
@@ -1,0 +1,8 @@
+package t891
+
+import .K
+
+class ScalaClass extends ScalaTrait[K] {
+
+}
+

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/formatter/ScalaFormatterCleanUpProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/formatter/ScalaFormatterCleanUpProvider.scala
@@ -25,7 +25,11 @@ class ScalaFormatterCleanUpProvider extends IFormatterCleanUpProvider {
     val preferences = FormatterPreferences.getPreferences(cu.getJavaProject)
     val edits =
       try ScalaFormatter.formatAsEdits(cu.getSource, preferences, Some(lineDelimiter))
-      catch { case e: ScalaParserException => return null }
+      catch {
+        case e: ScalaParserException =>
+          // failed to format file, return no edits
+          List.empty
+      }
 
     val multiEdit = new MultiTextEdit
     multiEdit.addChildren(edits map asEclipseTextEdit toArray)


### PR DESCRIPTION
Modified ScalaFormatterCleanUpProvider so it doesn't return
null but an empty change list if scalariform is not able to
parse the Scala code.
Added a test.

Scalariform doesn't support invalid scala, and doesn't plan to support it in a short term. https://github.com/mdr/scalariform/issues/46
