### PR TITLE
Passing to -Xplugin a path containing whitespaces is finally parsed correctly

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/compiler/settings/CompilerSettingsTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/compiler/settings/CompilerSettingsTest.scala
@@ -16,7 +16,15 @@ class CompilerSettingsTest {
   import CompilerSettingsTest._
   
   @Test
-  def continuations_plugin_works() {
+  def loadContinuationsPluginVia_XpluginsdirCompilerSetting() {
+    ScalaPlugin.plugin.defaultPluginsDir.foreach(project.storage.setValue("Xpluginsdir", _))
+    val plugins = loadedPlugins(project)
+    Assert.assertEquals("Loaded plugins: ", List("continuations"), loadedPlugins(project))
+  }
+  
+  @Test
+  def loadContinuationsPluginVia_XpluginCompilerSetting() {
+    ScalaPlugin.plugin.defaultPluginsDir.foreach(project.storage.setValue("Xplugin", _))
     val plugins = loadedPlugins(project)
     Assert.assertEquals("Loaded plugins: ", List("continuations"), loadedPlugins(project))
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/ScalaSbtCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/ScalaSbtCompiler.scala
@@ -13,8 +13,7 @@ object SettingsCleanup {
                          s.YpresentationDebug, s.YpresentationDelay, s.YpresentationLog,
                          s.YpresentationReplay, s.YpresentationVerbose,
                          s.classpath, s.bootclasspath)
-    // FIXME: For no apparent reason calling `ScalaPlugin.defaultScalaSettings` is not the same as using `new Settings`!?
-    val s1 = new Settings(Log.settingsError(log))
+    val s1 = ScalaPlugin.defaultScalaSettings(Log.settingsError(log))
     val xs = (s.userSetSettings -- toDefault).toList flatMap (_.unparse)
 
     s1.processArguments(xs.toList, true)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
@@ -51,7 +51,7 @@ trait ScalaPluginPreferencePage extends HasLogger {
           store.setToDefault(name)
         else {
           val value = setting match {
-            case ms: Settings#MultiStringSetting => ms.value.mkString(" ")
+            case ms: Settings#MultiStringSetting => ms.value.mkString(",")
             case setting                         => setting.value.toString
           }
           store.setValue(name, value)
@@ -283,7 +283,24 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
       control.redraw
       control.addSelectionListener(new SelectionListener() {
         override def widgetDefaultSelected(e: SelectionEvent) {}
-        override def widgetSelected(e: SelectionEvent) { handleToggle }
+        override def widgetSelected(e: SelectionEvent) { 
+          handleToggle
+          // Every time we toogle "Use Project Settings", we make sure 
+          // to reset the default value assigned to -Xpluginsdir.  
+          setDefaultPluginsDirValue()
+        }
+        /** This is a ugly (needed) hack to make sure that the default location pointed by 
+         * -Xpluginsdir contain the continuations plugin. If you change this, make sure to 
+         * read the comment in {{{ScalaPlugin.defaultScalaSettings}}}.*/ 
+        private def setDefaultPluginsDirValue() {
+          for(box <- eclipseBoxes;
+              eclipseSetting <- box.eSettings if eclipseSetting.setting.name == "-Xpluginsdir") {
+            eclipseSetting.control match {
+              case t: Text => ScalaPlugin.plugin.defaultPluginsDir.foreach(t.setText(_))
+              case _ => 
+            }
+          }
+        }
       })
     }
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/EclipseSettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/EclipseSettings.scala
@@ -2,13 +2,12 @@ package scala.tools.eclipse.properties
 
 import scala.tools.nsc.Settings
 import scala.tools.eclipse.{ SettingConverterUtil }
-
 import org.eclipse.swt.widgets.{ Button, Combo, Composite, Control, Event, Group, Label, Listener, Text }
 import org.eclipse.swt.layout.{ GridData, GridLayout }
 import org.eclipse.swt.SWT
 import org.eclipse.swt.events.{ ModifyEvent, ModifyListener, SelectionAdapter, SelectionEvent, SelectionListener }
-
 import org.eclipse.jface.preference.IPreferenceStore
+import scala.tools.eclipse.util.Trim
 
 trait EclipseSettings {
   self: ScalaPluginPreferencePage =>
@@ -144,9 +143,8 @@ trait EclipseSettings {
     def createControl(page: Composite) {
       control = new Text(page, SWT.SINGLE | SWT.BORDER)
       control.setText(setting.value)
-      var layout = data
-      layout = new GridData()
-      layout.widthHint = 150
+      val layout = new GridData()
+      layout.widthHint = 200
       control.setLayoutData(layout)
       control.addModifyListener(ModifyListenerSing)
     }
@@ -163,14 +161,18 @@ trait EclipseSettings {
     var control: Text = _
     def createControl(page: Composite) {
       control = new Text(page, SWT.SINGLE | SWT.BORDER)
-      control.setLayoutData(data)
-      control.setText(setting.value.mkString(" "))
+      val layout = new GridData()
+      layout.widthHint = 200
+      control.setLayoutData(layout)
+      control.setText(setting.value.mkString(", "))
       control.addModifyListener(ModifyListenerSing)
     }
 
-    def isChanged = setting.value.mkString(" ") != control.getText
+    def values: List[String] = control.getText().split(',').flatMap(Trim(_)).toList
+    
+    def isChanged = setting.value != values
     def reset() { control.setText("") }
-    def apply() { setting.value = control.getText.trim.split(" +").toList }
+    def apply() { setting.value = values }
   }
 
   /** Text setting selectable using a drop down combo box.
@@ -202,11 +204,8 @@ trait EclipseSettings {
     def createControl(page: Composite) {
       control = new Text(page, SWT.SINGLE | SWT.BORDER)
       control.setText(setting.value)
-      var layout = data
-      if (setting.value.isEmpty) {
-        layout = new GridData()
-        layout.widthHint = 200
-      }
+      val layout = new GridData()
+      layout.widthHint = 200
       control.setLayoutData(layout)
       control.setMessage("Path is relative to the workspace")
       control.addModifyListener(ModifyListenerSing)
@@ -223,17 +222,14 @@ trait EclipseSettings {
       control = new Text(page, SWT.SINGLE | SWT.BORDER)
       control.setText(setting.value.mkString(", "))
       var layout = data
-      if (setting.value.isEmpty) {
-        layout = new GridData()
-        layout.widthHint = 200
-      }
+      layout.widthHint = 200
       control.setLayoutData(layout)
       control.setMessage("Path is relative to the workspace")
       control.addModifyListener(ModifyListenerSing)
     }
 
-    def fileNames() = {
-      control.getText().split(',').map(f => fileName(f.trim)).toList
+    def fileNames(): List[String] = {
+      control.getText().split(',').flatMap(f => Trim(f).map(fileName)).toList
     }
 
     override def isChanged = setting.value != fileNames()


### PR DESCRIPTION
Up until now, passing to -Xplugin a path containing whitespaces resulted in
_no_ plugin being loaded. That because
`MultiStringSetting#tryToSetFromPropertyValue` was splitting the passed value
at whitespace occurrences, which was of course resulting in a mess.

The pull request https://github.com/scala/scala/pull/235 in the Scala compiler
has fixed this issue (patch available in both 2.10 and 2.9.2). In short, now
commas (`,`) are used to split -Xplugin value (when more than one plugin is
passed to it). Some adaptation on our side was also needed for correctly
handling commas as the splitting character.

This commit also fix a issue with the way we used to hande -Xpluginsdir value.
Read the big comment in ScalaPlugin.defaultScalaSettings for more information
about this.

As a side note, enabling continuations should now work as described in
http://scala-ide.org/docs/tutorials/continuations-plugin/index.html.

Fixes #1000917.
