### PR TITLE
Implement code select. 

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
@@ -27,10 +27,7 @@ import scala.tools.nsc.util.{ BatchSourceFile, SourceFile }
 import scala.tools.eclipse.contribution.weaving.jdt.{ IScalaCompilationUnit, IScalaWordFinder }
 import scala.tools.eclipse.{ ScalaImages, ScalaPlugin, ScalaPresentationCompiler, ScalaSourceIndexer, ScalaWordFinder }
 import scala.tools.eclipse.util.ReflectionUtils
-import org.eclipse.jdt.core.IField
-import org.eclipse.jdt.core.IMethod
-import org.eclipse.jdt.core.ISourceReference
-import org.eclipse.jdt.core.IParent
+import org.eclipse.jdt.core._
 import org.eclipse.jdt.internal.core.JavaElement
 import org.eclipse.jdt.internal.core.SourceRefElement
 import scala.tools.eclipse.logging.HasLogger
@@ -187,9 +184,23 @@ trait ScalaCompilationUnit extends Openable with env.ICompilationUnit with Scala
       case elem => elem
     }
   }
-    
-  override def codeSelect(cu : env.ICompilationUnit, offset : Int, length : Int, workingCopyOwner : WorkingCopyOwner) : Array[IJavaElement] = {
-    Array.empty
+
+  override def codeSelect(cu: env.ICompilationUnit, offset: Int, length: Int, workingCopyOwner: WorkingCopyOwner): Array[IJavaElement] = {
+    withSourceFile { (srcFile, compiler) =>
+      val pos = compiler.rangePos(srcFile, offset, offset, offset)
+
+      val typed = new compiler.Response[compiler.Tree]
+      compiler.askTypeAt(pos, typed)
+      val typedRes = typed.get
+      val element = for {
+       t <- typedRes.left.toOption
+       if t.hasSymbol
+       element <- compiler.getJavaElement(t.symbol)
+      } yield Array(element: IJavaElement)
+      
+      val res = element.getOrElse(Array.empty[IJavaElement])
+      res
+    }(Array.empty[IJavaElement])
   }
 
   def codeComplete

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -11,9 +11,56 @@ import scala.tools.nsc.symtab.Flags
 import scala.tools.eclipse.ScalaPresentationCompiler
 import ch.epfl.lamp.fjbg.{ JObjectType, JType }
 import scala.tools.eclipse.logging.HasLogger
+import org.eclipse.jdt.core._
+import org.eclipse.jdt.internal.core.JavaModelManager
+import org.eclipse.core.runtime.Path
 
 trait ScalaJavaMapper extends ScalaAnnotationHelper with HasLogger { self : ScalaPresentationCompiler => 
 
+  /** Return the Java Element corresponding to the given Scala Symbol, looking in the
+   *  given project list
+   * 
+   *  If the symbol exists in several projects, it returns one of them.
+   */
+  def getJavaElement(sym: Symbol, projects: IJavaProject*): Option[IJavaElement] = {
+    assert(sym ne null)
+    if (sym == NoSymbol) return None
+    
+    def matchesMethod(meth: IMethod): Boolean = {
+      import Signature._
+      askOption { () =>
+        ((meth.getElementName == sym.name.toString)
+          && meth.getParameterTypes.map(tp => getTypeErasure(getElementType(tp)))
+                                   .sameElements(sym.tpe.paramTypes.map(mapParamTypeSignature)))
+      }.getOrElse(false)
+    }
+
+    if (sym.isPackage) {
+      val fullName = sym.fullName
+      val results = projects.map(p => Option(p.findPackageFragment(new Path(fullName))))
+      results.flatten.headOption
+    } else if (sym.isClass || sym.isModule) {
+      val fullClassName = mapType(sym)
+      val results = projects.map(p => Option(p.findType(fullClassName)))
+      results.find(_.isDefined).flatten.headOption
+    } else getJavaElement(sym.owner) match {
+        case Some(ownerClass: IType) => 
+          if (sym.isMethod) ownerClass.getMethods.find(matchesMethod)
+          else ownerClass.getFields.find(_.getElementName == sym.name.toString)
+        case _ => None
+    }
+  }
+  
+  /** Return the Java Element corresponding to the given Scala Symbol, looking in the
+   *  all existing Java projects.
+   *  
+   *  If the symbol exists in several projects, it returns one of them.
+   */
+  def getJavaElement(sym: Symbol): Option[IJavaElement] = {
+    val javaModel = JavaModelManager.getJavaModelManager.getJavaModel
+    getJavaElement(sym, javaModel.getJavaProjects(): _*)
+  }
+  
   def mapType(t : Tree) : String = {
     (t match {
       case tt : TypeTree => {


### PR DESCRIPTION
This allows the Javadoc view to track the cursor, and searching for references of the current method under the cursor.

It's part of my clean-up effort of branches that hang around my checkout. I think this one is generally useful and adds some convenience when working with Java APIs, plus it cleans up something that never worked.
