### PR TITLE
Open Declaration via the context menu now works as expected.

### DIFF
--- a/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
@@ -49,6 +49,7 @@ Export-Package:
  scala.tools.eclipse.contribution.weaving.jdt.search,
  scala.tools.eclipse.contribution.weaving.jdt.spellingengineprovider,
  scala.tools.eclipse.contribution.weaving.jdt.ui,
+ scala.tools.eclipse.contribution.weaving.jdt.ui.actions,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter,
  scala.tools.eclipse.contribution.weaving.pde.ui

--- a/org.scala-ide.sdt.aspects/META-INF/aop.xml
+++ b/org.scala-ide.sdt.aspects/META-INF/aop.xml
@@ -20,6 +20,7 @@
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.launching.JavaLaunchableTesterAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.search.SearchAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.ui.ScalaOverrideLabelAspect"/>
+<aspect name="scala.tools.eclipse.contribution.weaving.jdt.ui.actions.OpenActionProviderAspect" />
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.ClassFileEditorIdAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.HoversAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.ScalaCloseStringsAspect"/>

--- a/org.scala-ide.sdt.aspects/openactionprovider.exsd
+++ b/org.scala-ide.sdt.aspects/openactionprovider.exsd
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="scala.tools.eclipse.contribution.weaving.jdt" xmlns="http://www.w3.org/2001/XMLSchema">
+   <annotation>
+      <appinfo>
+         <meta.schema plugin="scala.tools.eclipse.contribution.weaving.jdt" id="openactionprovider" name="Open Action"/>
+      </appinfo>
+      <documentation>
+         Provides an alternate implementation of org.eclipse.jdt.ui.actions.OpenAction.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="provider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="provider">
+      <annotation>
+         <documentation>
+            Declares the class of the open action provider for scala sources.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":scala.tools.eclipse.contribution.weaving.jdt.ui.actions.IOpenActionProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+</schema>

--- a/org.scala-ide.sdt.aspects/plugin.xml
+++ b/org.scala-ide.sdt.aspects/plugin.xml
@@ -8,4 +8,5 @@
    <extension-point id="method_verifier" name="Method Verifier" schema="methodVerifier.exsd"/>
    <extension-point id="cuprovider" name="Compilation Unit Provider" schema="cuprovider.exsd"/>
    <extension-point id="imagedescriptorselector" name="Image Descriptor Selector" schema="imagedescriptorselector.exsd"/>
+   <extension-point id="openactionprovider" name="Open Action Provider" schema="openactionprovider.exsd"/>
 </plugin>

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ScalaJDTWeavingPlugin.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ScalaJDTWeavingPlugin.java
@@ -26,6 +26,10 @@ public class ScalaJDTWeavingPlugin extends Plugin
       INSTANCE.getLog().log(new Status(IStatus.ERROR, ID, t.getMessage(), t));
   }
   
+  public static void logErrorMessage(String msg) {
+      INSTANCE.getLog().log(new Status(IStatus.ERROR, ID, msg));
+  }
+  
   
   public static ScalaJDTWeavingPlugin getInstance() {
       return INSTANCE;

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/actions/IOpenActionProvider.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/actions/IOpenActionProvider.java
@@ -1,0 +1,8 @@
+package scala.tools.eclipse.contribution.weaving.jdt.ui.actions;
+
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
+import org.eclipse.jdt.ui.actions.OpenAction;
+
+public interface IOpenActionProvider {
+	public OpenAction getOpenAction(JavaEditor editor);
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/actions/OpenActionProviderAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/actions/OpenActionProviderAspect.aj
@@ -1,0 +1,51 @@
+package scala.tools.eclipse.contribution.weaving.jdt.ui.actions;
+
+import java.util.List;
+
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
+import org.eclipse.jdt.ui.actions.OpenAction;
+
+import scala.tools.eclipse.contribution.weaving.jdt.ScalaJDTWeavingPlugin;
+import scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.IScalaEditor;
+
+/**
+ * When the user right clicks on a element and select "Open Declaration" in the
+ * context menu, an instance of <code>OpenAction</code> is used to resolve the
+ * binding and jump to the declaration. Because the Eclipse API does not expose
+ * an extension point for this action, we need to create a custom one and
+ * intercept the creation of an <code>OpenAction</code>, if it originates from a
+ * <code>IScalaEditor</code>.
+ */
+@SuppressWarnings("restriction")
+public privileged aspect OpenActionProviderAspect {
+
+  pointcut newInstance(JavaEditor editor): 
+		call(public OpenAction.new(JavaEditor)) && 
+		args(editor);
+
+  OpenAction around(JavaEditor editor) : newInstance(editor) {
+    if (editor instanceof IScalaEditor) {
+      List<IOpenActionProvider> providers = OpenActionProviderRegistry
+          .getInstance().getProviders();
+      if (providers.size() == 1) {
+        IOpenActionProvider provider = providers.get(0);
+        return provider.getOpenAction(editor);
+      } else if (providers.isEmpty()) {
+        return proceed(editor);
+      } else {
+        String msg = "Found multiple provider classes for extension point `"
+            + OpenActionProviderRegistry.OPEN_ACTION_PROVIDERS_EXTENSION_POINT
+            + "`.\n"
+            + "This is ambiguos, therefore I'm going to ignore this custom extension point and use the default implementation.\n"
+            + "\tHint: To fix this look in your plugin.xml file and make sure to declare at most one provider class for the extension point: "
+            + OpenActionProviderRegistry.OPEN_ACTION_PROVIDERS_EXTENSION_POINT;
+
+        ScalaJDTWeavingPlugin.getInstance().logErrorMessage(msg);
+
+        return proceed(editor);
+      }
+    } else {
+      return proceed(editor);
+    }
+  }
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/actions/OpenActionProviderRegistry.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/actions/OpenActionProviderRegistry.java
@@ -1,0 +1,18 @@
+package scala.tools.eclipse.contribution.weaving.jdt.ui.actions;
+
+import scala.tools.eclipse.contribution.weaving.jdt.util.AbstractProviderRegistry;
+
+public class OpenActionProviderRegistry extends AbstractProviderRegistry<IOpenActionProvider> {
+	public static String OPEN_ACTION_PROVIDERS_EXTENSION_POINT = "org.scala-ide.sdt.aspects.openactionprovider"; //$NON-NLS-1$
+
+	private static final OpenActionProviderRegistry INSTANCE = new OpenActionProviderRegistry();
+
+	public static OpenActionProviderRegistry getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	protected String getExtensionPointId() {
+		return OPEN_ACTION_PROVIDERS_EXTENSION_POINT;
+	}
+}

--- a/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
@@ -62,6 +62,7 @@ Import-Package:
  scala.tools.eclipse.contribution.weaving.jdt.search;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.spellingengineprovider;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.ui;apply-aspects:=false,
+ scala.tools.eclipse.contribution.weaving.jdt.ui.actions;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter;apply-aspects:=false
 Export-Package: 

--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -885,6 +885,10 @@
   <extension point="org.scala-ide.sdt.aspects.spellingengineprovider">
     <provider class="scala.tools.eclipse.ScalaSpellingEngineProvider" />
   </extension> 
+  
+  <extension point="org.scala-ide.sdt.aspects.openactionprovider">
+    <provider class="scala.tools.eclipse.ui.actions.OpenActionProvider" />
+  </extension> 
 
   <extension point="org.scala-ide.sdt.aspects.formatterCleanUp">
     <provider class="scala.tools.eclipse.formatter.ScalaFormatterCleanUpProvider" />

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/actions/HyperlinkOpenAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/actions/HyperlinkOpenAction.scala
@@ -1,0 +1,17 @@
+package scala.tools.eclipse.ui.actions
+
+import org.eclipse.jdt.ui.actions.OpenAction
+import scala.tools.eclipse.ScalaSourceFileEditor
+import org.eclipse.jface.text.ITextSelection
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility
+import scala.tools.eclipse.javaelements.ScalaCompilationUnit
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor
+
+class HyperlinkOpenAction(editor: JavaEditor) extends OpenAction(editor) {
+  override def run() {
+    val inputJavaElement = EditorUtility.getEditorInputJavaElement(editor, false)
+    Option(inputJavaElement) map (_.asInstanceOf[ScalaCompilationUnit]) foreach { scu =>
+      scu.followReference(editor, getSelectionProvider.getSelection.asInstanceOf[ITextSelection])
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/actions/OpenActionProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/actions/OpenActionProvider.scala
@@ -1,0 +1,9 @@
+package scala.tools.eclipse.ui.actions
+
+import scala.tools.eclipse.contribution.weaving.jdt.ui.actions.IOpenActionProvider
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor
+import org.eclipse.jdt.ui.actions.OpenAction
+
+class OpenActionProvider extends IOpenActionProvider {
+  override def getOpenAction(editor: JavaEditor): OpenAction = new HyperlinkOpenAction(editor)
+}


### PR DESCRIPTION
When the user right clicks on a element and select "Open Declaration" in the
context menu, an instance of `OpenAction` is used to resolve the binding and
jump to the declaration.

Because the Eclipse API does not expose an extension point for this action, I
had to create a custom extension point (using AJDT), which allows weaving in to
JDT and can be used to intercept the creation of `OpenAction`, if it
originates from a Scala editor.

This seem to be the only solution, which does not involve creating our own
Scala Editor. Hopefully, we will be able to remove this custom extension point
once we implement the Scala Editor (this is planned for Milestone 2 of the
Scala IDE Helium).  Using AJDT for customizing the behavior of `OpenAction`
was also suggested by Andrew Eisenberg in the following StackOverflow question:

```
http://stackoverflow.com/questions/1882053/how-can-i-define-a-custom-action-for-open-declaration-shortcut-f3-in-eclipse
```

Fix #1000920.
