### PR TITLE
Fixes the invalid thread access generated when creating a Java file for the first time

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
@@ -47,6 +47,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin
 import org.eclipse.swt.SWT
 import scala.tools.eclipse.util.Colors
 import scala.PartialFunction.condOpt
+import scala.tools.eclipse.util.SWTUtils
 
 class ScalaSourceFileEditor extends CompilationUnitEditor with ScalaEditor {
 
@@ -274,7 +275,12 @@ class ScalaSourceFileEditor extends CompilationUnitEditor with ScalaEditor {
       case ShowInferredSemicolonsAction.PREFERENCE_KEY =>
         getAction(ShowInferredSemicolonsAction.ACTION_ID).asInstanceOf[IUpdate].update()
       case _ =>
-        super.handlePreferenceStoreChanged(event)
+        if (affectsTextPresentation(event)) {
+          // those events will trigger a UI change
+          SWTUtils.asyncExec(super.handlePreferenceStoreChanged(event))
+        } else {
+          super.handlePreferenceStoreChanged(event)
+        }
     }
 
   override def configureSourceViewerDecorationSupport(support: SourceViewerDecorationSupport) {


### PR DESCRIPTION
Some Java preferences get set the first time a code template is
used. This preference changes trigger UI updates, but the Java editor
(base of the Scala editor) does not execute these UI updates in the right
thread.
Forcing those preference change to be run in the UI thread.
Fixes #1000738
