### PR TITLE
Added a ``Open the Log`` menu item under the Scala menu

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -220,16 +220,23 @@
          <groupMarker name="additions"/>
        </menu>
        <action id="org.scala-ide.sdt.ui.runDiag.action"
-         label="Run Setup Diagnostics..."
+         label="Run Setup Diagnostics"
          menubarPath="org_scala-ide_sdt_ui_menu/diagnostics"
          tooltip="Verify that Scala configuration is correct"
          class="scala.tools.eclipse.actions.RunDiagnosticAction"
          enablesFor="*">
        </action>
        <action id="org.scala-ide.sdt.ui.reportBug.action"
-         label="Report a Bug..."
+         label="Report a Bug"
          menubarPath="org_scala-ide_sdt_ui_menu/additions"
          tooltip="Report a bug in the Scala Development Tools"
+         class="scala.tools.eclipse.actions.RunDiagnosticAction"
+         enablesFor="*">
+       </action>
+       <action id="org.scala-ide.sdt.ui.openLogFile.action"
+         label="Open the Log"
+         menubarPath="org_scala-ide_sdt_ui_menu/additions"
+         tooltip="Open the Log file in an editor"
          class="scala.tools.eclipse.actions.RunDiagnosticAction"
          enablesFor="*">
        </action>       

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/RunDiagnosticAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/RunDiagnosticAction.scala
@@ -7,20 +7,23 @@ import org.eclipse.ui.{ IObjectActionDelegate, IWorkbenchPart, IWorkbenchWindowA
 import scala.tools.eclipse.ScalaPlugin.plugin
 import scala.tools.eclipse.javaelements.JDTUtils
 import scala.tools.eclipse.util.Utils
+import scala.tools.eclipse.logging.LogManager
+import scala.tools.eclipse.ui.OpenExternalFile
 
 class RunDiagnosticAction extends IObjectActionDelegate with IWorkbenchWindowActionDelegate {
   private var parentWindow: IWorkbenchWindow = null
 	
   val RUN_DIAGNOSTICS = "org.scala-ide.sdt.ui.runDiag.action"
   val REPORT_BUG      = "org.scala-ide.sdt.ui.reportBug.action"
+  val OPEN_LOG_FILE   = "org.scala-ide.sdt.ui.openLogFile.action"  
   
   override def init(window: IWorkbenchWindow) {  
     parentWindow = window
   } 
   
   def dispose = { }
-  
-	def selectionChanged(action: IAction, selection: ISelection) {  }
+
+  def selectionChanged(action: IAction, selection: ISelection) {  }
   
   def run(action: IAction) { 
     Utils tryExecute {
@@ -31,6 +34,8 @@ class RunDiagnosticAction extends IObjectActionDelegate with IWorkbenchWindowAct
         case REPORT_BUG =>
           val shell = if (parentWindow == null) ScalaPlugin.getShell else parentWindow.getShell
           new diagnostic.ReportBugDialog(shell).open
+        case OPEN_LOG_FILE =>
+          OpenExternalFile(LogManager.logFile).open()
         case _ => 
       }
     }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/ReportBugDialog.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/ReportBugDialog.scala
@@ -4,11 +4,14 @@ package diagnostic
 
 import org.eclipse.jface.dialogs.{ Dialog, IDialogConstants }
 import org.eclipse.swt.widgets.{ List => SWTList, _ }
-import org.eclipse.swt.layout.{ GridLayout, GridData }
+import org.eclipse.swt.layout.{ RowLayout, GridLayout, GridData }
+import org.eclipse.ui.internal.layout.CellLayout
 import org.eclipse.swt.SWT
 import org.eclipse.swt.events.{ ModifyListener, ModifyEvent, SelectionAdapter, SelectionListener, SelectionEvent }
 import org.eclipse.core.runtime.Platform
+
 import scala.tools.eclipse.logging.LogManager
+import scala.tools.eclipse.ui.OpenExternalFile
 
 
 class ReportBugDialog(shell: Shell) extends Dialog(shell) {
@@ -34,11 +37,22 @@ class ReportBugDialog(shell: Shell) extends Dialog(shell) {
         "Scala compiler version:\t" + ScalaPlugin.plugin.scalaCompilerBundleVersion + "\n" +
         "Scala library version:\t" + ScalaPlugin.plugin.scalaLibBundle.getVersion + "\n" +
         "Eclipse version: " + Platform.getBundle("org.eclipse.platform").getVersion)    
-    
-    val reportBugLink = new Link(control, SWT.NONE)
-    reportBugLink.setText("<a href=\"" + SDT_TRACKER_URL + "\">Report a bug</a> on Assembla")      
-    reportBugLink.addListener(SWT.Selection, DiagnosticDialog.linkListener)
 
+    val group2 = new Group(control, SWT.SHADOW_NONE)
+    group2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false))
+    // lay out the widgets on the same row
+    val rowLayout = new RowLayout(SWT.HORIZONTAL)
+    rowLayout.spacing = -3 // remove space between widgets
+    group2.setLayout(rowLayout)
+
+    val logFileLink = new Link(group2, SWT.NONE)
+    logFileLink.setText("<a>Check</a> the log")
+    logFileLink.addListener(SWT.Selection, OpenExternalFile(LogManager.logFile))
+
+    val reportBugLink = new Link(group2, SWT.NONE)
+    reportBugLink.setText("and <a href=\"" + SDT_TRACKER_URL + "\">report a bug</a>.")      
+    reportBugLink.addListener(SWT.Selection, DiagnosticDialog.linkListener)
+    
     control
   }
   

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/OpenExternalFile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/OpenExternalFile.scala
@@ -11,13 +11,15 @@ import org.eclipse.swt.widgets.Event
 import org.eclipse.ui.PlatformUI
 
 /** This class can be used to open an editor on a file outside the workspace. */
-private class OpenExternalFile private (file: File) extends Listener with HasLogger {
+class OpenExternalFile private (file: File) extends Listener with HasLogger {
   require(file != null, "file should not be null.")
   require(file.exists, "file %s does not exist.".format(file.getAbsolutePath))
 
   import scala.util.control.Exception.catching
 
-  def handleEvent(e: Event): Unit = {
+  def handleEvent(e: Event): Unit = open()
+  
+  def open(): Unit = {
     val parentLocation = file.getParent
     var fileStore = EFS.getLocalFileSystem().getStore(new Path(parentLocation));
 
@@ -38,5 +40,5 @@ private class OpenExternalFile private (file: File) extends Listener with HasLog
 }
 
 object OpenExternalFile {
-  def apply(file: File): Listener = new OpenExternalFile(file)
+  def apply(file: File): OpenExternalFile = new OpenExternalFile(file)
 }


### PR DESCRIPTION
I've made two changes to make the log easier to consult:
- Added a `Open the Log` menu item under the Scala menu. Clicking
  on it will open the log file inside Eclipse (using a standard text
  editor).
- The dialog opened when clicking the `Report A Bug` menu item
  (which is also located under the Scala menu) now contains a link to
  open the log file.

Hopefully, these changes will make it easier for a user to consult the
log and provide potentially useful information when creating a bug report.

Fixed #1000970.
