### PR TITLE
Quickfix to expand case-class bindings in pattern-matching.

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -960,6 +960,7 @@
                label="Refactor"
                path="edit">
             <separator name="scala.tools.eclipse.refactoring.refactoringGroup"/>
+            <separator name="scala.tools.eclipse.refactoring.quickfixGroup"/>
          </menu>
          <action
                class="scala.tools.eclipse.refactoring.move.MoveClassAction"
@@ -1035,6 +1036,19 @@
             </enablement>
          </action>
          <action
+               class="scala.tools.eclipse.refactoring.ExpandCaseClassBindingAction"
+               definitionId="scala.tools.eclipse.refactoring.command.ExpandCaseClassBinding"
+               id="scala.tools.eclipse.refactoring.expandCaseClassBindingAction"
+               label="Expand Case Class Binding"
+               menubarPath="scala.tools.eclipse.refactoring.refactoringMenu/scala.tools.eclipse.refactoring.quickfixGroup"
+               tooltip="Expand Case Class Binding">
+            <enablement>
+               <objectClass
+                     name="org.eclipse.jface.text.TextSelection">
+               </objectClass>
+            </enablement>
+         </action>
+         <action
                class="scala.tools.eclipse.actions.RunSelectionAction"
                definitionId="scala.tools.eclipse.interpreter.RunSelection"
                disabledIcon="icons/full/dtool16/run_interpreter.gif"
@@ -1083,6 +1097,10 @@
          categoryId="scala.tools.eclipse.refactoring.commands.refactoring"
          id="scala.tools.eclipse.refactoring.command.Rename"
          name="Rename"/>
+      <command
+         categoryId="scala.tools.eclipse.refactoring.commands.refactoring"
+         id="scala.tools.eclipse.refactoring.command.ExpandCaseClassBinding"
+         name="Expand Case Class Binding"/>
       <command
          categoryId="scala.tools.eclipse.category"
          id="org.scala-ide.sdt.core.commands.ToggleImplicitsDisplay"

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandCaseClassBindingProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandCaseClassBindingProposal.scala
@@ -1,0 +1,13 @@
+package scala.tools.eclipse.quickfix
+
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.text.contentassist.IContextInformation
+import org.eclipse.swt.graphics.Image
+import org.eclipse.swt.graphics.Point
+import scala.tools.eclipse.refactoring.ExtractLocalAction
+import scala.tools.eclipse.refactoring.ExpandCaseClassBindingAction
+
+object ExpandCaseClassBindingProposal
+	extends ProposalRefactoringActionAdapter(
+	    new ExpandCaseClassBindingAction, "Expand case class binding")

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickAssistProcessor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickAssistProcessor.scala
@@ -61,6 +61,7 @@ class ScalaQuickAssistProcessor extends org.eclipse.jdt.ui.text.java.IQuickAssis
     val refactoringSuggestions: Seq[IJavaCompletionProposal] = try {
       List(
         ExtractLocalProposal,
+        ExpandCaseClassBindingProposal,
         InlineLocalProposal,
         RenameProposal,
         ExtractMethodProposal).par.filter(_.isValidProposal).seq

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExpandCaseClassBindingAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExpandCaseClassBindingAction.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2005-2010 LAMP/EPFL
+ */
+
+package scala.tools.eclipse.refactoring
+
+import scala.tools.eclipse.javaelements.ScalaSourceFile
+import scala.tools.refactoring.implementations.ExpandCaseClassBinding
+
+/**
+ * A refactoring that expands bindings to case-classes in pattern matches with
+ * the corresponding extractor. The refactoring is only accessible through a
+ * quickfix.
+ *
+ * Does not show a wizard but directly applies the changes (ActionWithNoWizard trait).
+ */
+class ExpandCaseClassBindingAction extends RefactoringAction with ActionWithNoWizard {
+
+  def createRefactoring(selectionStart: Int, selectionEnd: Int, file: ScalaSourceFile) =
+    new ExpandCaseClassBindingScalaIdeRefactoring(selectionStart, selectionEnd, file)
+
+  class ExpandCaseClassBindingScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
+    extends ScalaIdeRefactoring("Expand Case Class Binding", file, start, end) {
+
+    val refactoring = file.withSourceFile((sourceFile, compiler) => new ExpandCaseClassBinding {
+      val global = compiler
+    })()
+
+    /**
+     * The refactoring does not take any parameters.
+     */
+    def refactoringParameters = new refactoring.RefactoringParameters
+  }
+}


### PR DESCRIPTION
See http://misto.ch/expand-case-class-bindings-in-pattern-matching/ and #1000982.

Note that this also needs the latest scala-refactoring library, so we should wait for the next nightly build before merging.
