### PR TITLE
Show the inferred type of selected code.

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -854,13 +854,11 @@
       description="Debug Scala Application"
       id="org.eclipse.shortcut.scala.debug"
       name="Debug Scala Application" />
-     <command
-	  name="Show inferred semicolons"
-	  description="Shows inferred semicolons in the current editor"
-	  categoryId="org.eclipse.ui.category.textEditor"
-	  id="scala.tools.eclipse.toggleShowInferredSemicolonsAction"/>
-	  
-      
+    <command
+      name="Show inferred semicolons"
+      description="Shows inferred semicolons in the current editor"
+      categoryId="org.eclipse.ui.category.textEditor"
+      id="scala.tools.eclipse.toggleShowInferredSemicolonsAction"/>
   </extension>
 
   <extension point="org.eclipse.ui.bindings">
@@ -1091,6 +1089,12 @@
          categoryId="org.eclipse.debug.ui.category.run"
          id="scala.tools.eclipse.interpreter.RunSelection"
          name="Send Selection to Scala Interpreter"/>
+      <command
+            categoryId="scala.tools.eclipse.category"
+            description="Shows the type of the current selection"
+            id="scala.tools.eclipse.editor.ShowTypeOfSelection"
+            name="Show Type">
+      </command>
 </extension>
 
    <extension point="org.eclipse.ui.contexts">
@@ -1129,6 +1133,12 @@
    		 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
    		 contextId="scala.tools.eclipse.scalaEditorScope"
    		 sequence="M2+M3+R"/>
+   <key
+         commandId="scala.tools.eclipse.editor.ShowTypeOfSelection"
+         contextId="scala.tools.eclipse.scalaEditorScope"
+         schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+         sequence="M2+M1+S T">
+   </key>
    </extension>
    <extension point="org.eclipse.ui.bindings"> <!-- Cross-platform bindings -->
    <key
@@ -1177,6 +1187,10 @@
           class="scala.tools.eclipse.semantichighlighting.implicits.ToggleImplicitsDisplayHandler"
           commandId="org.scala-ide.sdt.core.commands.ToggleImplicitsDisplay">
     </handler>
+    <handler
+          class="scala.tools.eclipse.actions.ShowTypeOfSelectionCommand"
+          commandId="scala.tools.eclipse.editor.ShowTypeOfSelection">
+    </handler>
  </extension>
  <extension
        point="org.eclipse.ui.menus">
@@ -1191,6 +1205,26 @@
                 style="toggle">
           </command>
        </toolbar>
+    </menuContribution>
+    <menuContribution
+          locationURI="popup:#CompilationUnitEditorContext?before=additions">
+       <command
+             commandId="scala.tools.eclipse.editor.ShowTypeOfSelection"
+             id="one"
+             label="Show Type"
+             mnemonic="S"
+             style="push"
+             tooltip="Shows the type of the current selection">
+          <visibleWhen
+                checkEnabled="false">
+             <with
+                   variable="activeEditorId">
+                <equals
+                      value="scala.tools.eclipse.ScalaSourceFileEditor">
+                </equals>
+             </with>
+          </visibleWhen>
+       </command>
     </menuContribution>
  </extension>  
   

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaHover.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaHover.scala
@@ -10,6 +10,7 @@ import org.eclipse.jface.text.{ ITextViewer, IRegion, ITextHover }
 
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.nsc.symtab.Flags
+import scala.tools.eclipse.util.EclipseUtils._
 
 class ScalaHover(codeAssist : () => Option[ICodeAssist]) extends ITextHover {
   
@@ -39,8 +40,7 @@ class ScalaHover(codeAssist : () => Option[ICodeAssist]) extends ITextHover {
 
           
           val resp = new Response[Tree]
-          val range = compiler.rangePos(src, start, start, end)
-          askTypeAt(range, resp)
+          askTypeAt(region.toRangePos(src), resp)
           (for (t <- resp.get.left.toOption;
               hover <- hoverInfo(t)) yield hover) getOrElse NoHoverInfo
         }) (NoHoverInfo)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/ShowTypeOfSelectionCommand.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/ShowTypeOfSelectionCommand.scala
@@ -1,0 +1,66 @@
+package scala.tools.eclipse.actions
+
+import scala.tools.eclipse.ScalaSourceFileEditor
+import org.eclipse.core.commands.AbstractHandler
+import org.eclipse.core.commands.ExecutionEvent
+import org.eclipse.jface.text.ITextSelection
+import org.eclipse.ui.handlers.HandlerUtil
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility
+import scala.tools.eclipse.javaelements.ScalaCompilationUnit
+import org.eclipse.jface.text.information.IInformationProvider
+import org.eclipse.jface.text.ITextViewer
+import org.eclipse.jface.text.Region
+import org.eclipse.jface.text.IRegion
+import scala.tools.eclipse.util.EclipseUtils._
+
+class ShowTypeOfSelectionCommand extends AbstractHandler {
+
+  override def execute(event: ExecutionEvent): Object = {
+    HandlerUtil.getActiveEditor(event) match {
+      case scalaEditor: ScalaSourceFileEditor =>
+        scalaEditor.getSelectionProvider.getSelection match {
+          case sel: ITextSelection =>
+            scalaEditor.typeOfExpressionPresenter.showInformation()
+          case _ => ()
+        }
+      case _ => ()
+    }
+    null
+  }
+
+}
+
+object TypeOfExpressionProvider extends IInformationProvider {
+  def getSubject(textViewer: ITextViewer, offset: Int): IRegion = {
+    val r = textViewer.getSelectedRange
+    new Region(r.x, r.y)
+  }
+
+  def getInformation(textViewer: ITextViewer, region: IRegion): String = {
+    
+    EditorUtility.getActiveEditorJavaInput match {
+      case scu: ScalaCompilationUnit =>
+        scu.withSourceFile { (src, compiler) =>
+          import compiler._
+          
+          def typeInfo(tpe: Type): String = 
+            Option(tpe).map(_.toString).getOrElse(null)
+          
+          val response = new Response[Tree]
+          askTypeAt(region.toRangePos(src), response)
+          (for {
+            t <- response.get.left.toOption
+          } yield t match {
+            case ValDef(_, _, _, rhs) =>
+              typeInfo(rhs.tpe)
+            case DefDef(_, _, _, _, _, rhs) =>
+              typeInfo(rhs.tpe)
+            case _ => 
+              typeInfo(t.tpe)
+          }).getOrElse(null)
+        }(null)
+
+      case _ => null
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/EclipseUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/EclipseUtils.scala
@@ -24,6 +24,11 @@ import org.eclipse.jface.preference.PreferenceConverter
 import org.eclipse.swt.graphics.RGB
 import org.eclipse.ui.IWorkbenchPage
 import org.eclipse.ui.PlatformUI
+import org.eclipse.jface.text.IRegion
+import scala.tools.nsc.util.Position
+import scala.tools.nsc.util.SourceFile
+import scala.tools.nsc.interactive.RangePositions
+import scala.tools.nsc.util.RangePosition
 
 object EclipseUtils {
 
@@ -52,6 +57,15 @@ object EclipseUtils {
     def apply(offset: Int): Char = document.getChar(offset)
 
   }
+  
+  class PimpedRegion(region: IRegion) {
+    def toRangePos(src: SourceFile): Position = {
+      val offset = region.getOffset
+      new RangePosition(src, offset, offset, offset + region.getLength)
+    }
+  }
+  
+  implicit def pimpedRegion(region: IRegion) = new PimpedRegion(region)
 
   implicit def asEclipseTextEdit(edit: TextEdit): EclipseTextEdit =
     new ReplaceEdit(edit.position, edit.length, edit.replacement)


### PR DESCRIPTION
Implemented 'Show Type of Selection'. The implementation can definitely be improved,
but it does the job. The current shortcut is `Ctrl-Shift-S T`, since all combinations involving
`T` are already taken by `Open Type` and `Quick Type Hierarchy`.
