### PR TITLE
Adriaan owes me a beer: editor improvements. 

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
@@ -7,7 +7,6 @@
 package scala.tools.eclipse
 
 import java.util.ResourceBundle
-
 import scala.Option.option2Iterable
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.eclipse.javaelements.ScalaSourceFile
@@ -20,7 +19,6 @@ import scala.tools.eclipse.util.RichAnnotationModel.annotationModel2RichAnnotati
 import scala.tools.eclipse.util.SWTUtils.fnToPropertyChangeListener
 import scala.tools.eclipse.util.SWTUtils
 import scala.tools.eclipse.util.Utils
-
 import org.eclipse.core.runtime.jobs.Job
 import org.eclipse.core.runtime.IAdaptable
 import org.eclipse.core.runtime.IProgressMonitor
@@ -63,10 +61,12 @@ import org.eclipse.ui.texteditor.SourceViewerDecorationSupport
 import org.eclipse.ui.texteditor.TextOperationAction
 import org.eclipse.ui.ISelectionListener
 import org.eclipse.ui.IWorkbenchPart
-
 import ScalaSourceFileEditor.OCCURRENCE_ANNOTATION
 import ScalaSourceFileEditor.SCALA_EDITOR_SCOPE
 import ScalaSourceFileEditor.bundleForConstructedKeys
+import org.eclipse.swt.events.VerifyEvent
+import org.eclipse.jface.text.ITextViewerExtension
+import scala.tools.eclipse.ui.SurroundSelectionStrategy
 
 
 class ScalaSourceFileEditor extends CompilationUnitEditor with ScalaEditor {
@@ -309,6 +309,11 @@ class ScalaSourceFileEditor extends CompilationUnitEditor with ScalaEditor {
   override def createPartControl(parent: org.eclipse.swt.widgets.Composite) {
     super.createPartControl(parent)
     refactoring.RefactoringMenu.fillQuickMenu(this)
+    getSourceViewer match {
+      case sourceViewer: ITextViewerExtension =>
+        sourceViewer.prependVerifyKeyListener(new SurroundSelectionStrategy(getSourceViewer))
+      case _ =>
+    }
   }
 
   override def handlePreferenceStoreChanged(event: PropertyChangeEvent) =

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/SurroundSelectionStrategy.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/SurroundSelectionStrategy.scala
@@ -1,0 +1,42 @@
+package scala.tools.eclipse.ui
+
+import org.eclipse.jface.text.source.ISourceViewer
+import org.eclipse.jface.text.IAutoEditStrategy
+import org.eclipse.jface.text.DocumentCommand
+import org.eclipse.jface.text.IDocument
+import org.eclipse.swt.custom.VerifyKeyListener
+import org.eclipse.swt.events.VerifyEvent
+
+class SurroundSelectionStrategy(sourceViewer: ISourceViewer) extends VerifyKeyListener {
+  val activeChars = Map(
+    '(' -> ')',
+    '{' -> '}',
+    '"' -> '"',
+    '[' -> ']')
+
+  /** Automatically surround the current selection with the corresponding
+   *  character, if it is a parenthesis/brace of quotes.
+   *  
+   *  Since it gets a chance to see all characters, it also suppresses the
+   *  automatically generated closing angle bracket that the Java editor
+   *  always appends, leading to <> in the code.
+   */
+  override def verifyKey(event: VerifyEvent) {
+    val selection = sourceViewer.getSelectedRange
+    val doc = sourceViewer.getDocument
+    val chr = event.character
+
+    if (selection.y > 0 && activeChars.isDefinedAt(chr)) {
+      val text = doc.get(selection.x, selection.y)
+      doc.replace(selection.x, selection.y, chr + text + activeChars(chr))
+      // stop the Java editor from adding a closing bracket as well
+      event.doit = false
+    } else if (chr == '<') {
+      // the Java editor usually inserts a closing angle bracket (Java Generics)
+      // we suppress it here.
+      doc.replace(selection.x, 0, "<")
+      sourceViewer.setSelectedRange(selection.x + 1, 0)
+      event.doit = false
+    }
+  }
+}


### PR DESCRIPTION
If there is an active selection, typing ", (, { or [ will surround the existing selection, instead of deleting it.

Oh, one more thing: it suppresses the Java editor overly-eager insertion of a 
closing angle bracket, a la Java Generics.

Fixed #1001010.
