### PR TITLE
Correctly expose to JDT Scala sources' throws annotations

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/StructureBuilderTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/structurebuilder/StructureBuilderTest.scala
@@ -516,4 +516,61 @@ class StructureBuilderTest {
     // verify
     assertEquals(T1000711TestOracle.expectedFragment, jdtStructure)
   }
+  
+  @Test
+  def throwsAnnotationOfClassConstructorsAndMethodsAreAvailableInJava_t100105() {
+    //when
+    val requestor = mock(classOf[IProblemRequestor])
+    when(requestor.isActive()).thenReturn(true)
+
+    val owner = mock(classOf[WorkingCopyOwner])
+    when(owner.getProblemRequestor(any())).thenReturn(requestor)
+
+    val unit = compilationUnit("t1001005/Caller.java")
+    
+    // then
+    // this will trigger the java reconciler so that the problems will be reported to the `requestor`
+    unit.getWorkingCopy(owner, new NullProgressMonitor)
+
+    // verify
+    verify(requestor, times(0)).acceptProblem(any())
+  }
+  
+  @Test
+  def throwsAnnotationOfTraitMethodsAreAvailableInJava_t1000707() {
+    //when
+    val requestor = mock(classOf[IProblemRequestor])
+    when(requestor.isActive()).thenReturn(true)
+
+    val owner = mock(classOf[WorkingCopyOwner])
+    when(owner.getProblemRequestor(any())).thenReturn(requestor)
+
+    val unit = compilationUnit("t1000707/Bar.java")
+    
+    // then
+    // this will trigger the java reconciler so that the problems will be reported to the `requestor`
+    unit.getWorkingCopy(owner, new NullProgressMonitor)
+
+    // verify
+    verify(requestor, times(0)).acceptProblem(any())
+  }
+  
+  @Test
+  def throwsAnnotationOfTraitMethodsAreAvailableInJava_t1000800() {
+    //when
+    val requestor = mock(classOf[IProblemRequestor])
+    when(requestor.isActive()).thenReturn(true)
+
+    val owner = mock(classOf[WorkingCopyOwner])
+    when(owner.getProblemRequestor(any())).thenReturn(requestor)
+
+    val unit = compilationUnit("t1000800/ThrowingClass.java")
+    
+    // then
+    // this will trigger the java reconciler so that the problems will be reported to the `requestor`
+    unit.getWorkingCopy(owner, new NullProgressMonitor)
+   
+    // verify
+    verify(requestor, times(0)).acceptProblem(any())
+  }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000707/Bar.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000707/Bar.java
@@ -1,0 +1,5 @@
+package t1000707;
+
+public class Bar implements Foo {
+    public void foo() throws Exception {   }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000707/Foo.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000707/Foo.scala
@@ -1,0 +1,6 @@
+package t1000707
+
+trait Foo {
+  @throws(classOf[Exception])
+  def foo(): Unit
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000800/ThrowingClass.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000800/ThrowingClass.java
@@ -1,0 +1,7 @@
+package t1000800;
+
+public class ThrowingClass implements ThrowingInterface {
+	public void throwingMethod() throws InterruptedException {
+		Thread.sleep(1000);
+	}
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000800/ThrowingInterface.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1000800/ThrowingInterface.scala
@@ -1,0 +1,6 @@
+package t1000800
+
+trait ThrowingInterface {
+  @throws(classOf[Exception]) 
+  def throwingMethod()
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1001005/Calle.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1001005/Calle.scala
@@ -1,0 +1,19 @@
+package t1001005
+
+import java.io.IOException
+import java.net.SocketException
+
+class Callee @throws(classOf[InstantiationException]) () {
+  
+  @throws(classOf[NoSuchFieldException])
+  def this(i: Int) {
+    this()
+  }
+
+  @throws(classOf[IOException])
+  @throws(classOf[SocketException])
+  def doStuff(i: Int) {
+    if (i > 0) throw new IOException
+    else throw new SocketException
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1001005/Caller.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/simple-structure-builder/src/t1001005/Caller.java
@@ -1,0 +1,22 @@
+package t1001005;
+
+import java.io.IOException;
+import java.net.SocketException;
+
+public class Caller {
+	public static void main(String[] args) {
+		try {
+			try {
+				new Callee().doStuff(Integer.parseInt(args[0]));
+			} 
+			catch (InstantiationException e) {}
+
+			try {
+				new Callee(2).doStuff(Integer.parseInt(args[0]));
+			}
+			catch (NoSuchFieldException e) {}
+		}
+		catch (SocketException e) {} 
+		catch (IOException e) {}
+	}
+}


### PR DESCRIPTION
Scala @throws annotation were not exposed to JDT up until now, which was
causing wrong errors to be reported by the Scala presentation compiler.

Fix #1001005, #1000707 and #1000800
