### PR TITLE
Don't show Source Generation and Externalize (String) groups in editor menu

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
@@ -295,7 +295,7 @@ class ScalaSourceFileEditor extends CompilationUnitEditor with ScalaEditor {
       val groups = groupMenuItemsByGroupId(mm.getItems)
 
       // these two contributions won't work on Scala files, so we remove them
-      val blacklist = List("codeGroup", "importGroup")
+      val blacklist = List("codeGroup", "importGroup", "generateGroup", "externalizeGroup")
 
       // and provide our own organize imports instead
       mm.appendToGroup("importGroup", new refactoring.OrganizeImportsAction { setText("Organize Imports") })


### PR DESCRIPTION
Disabled Java specific actions for Source Generation and Externalizing String.
These actions were displayed in the editor's context menu, under the Source menu item.

Created an enhancement ticket (Re #1001018).

Fixed #1000972

I'd like to merge this also in branch release/2.0.x
