### PR TITLE
Use the configured JDK when instantiating the presentation compiler. 

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/JavaSig.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/JavaSig.scala
@@ -55,13 +55,12 @@ trait JavaSig { pc: ScalaPresentationCompiler =>
           // there is no need to generate the generic type information for local symbols
           !symbol.isLocal && erasure.needsJavaSig(symbol.info)
         }
-        
+
         if (needsJavaSig) {
-	      // it's *really* important we ran pc.atPhase so that symbol's type is updated! (atPhase does side-effects on the type!)
-	      for (signature <- erasure.javaSig(symbol, pc.atPhase(pc.currentRun.erasurePhase)(symbol.info)))
-	        yield signature.replace("/", ".")
-	    } 
-	    else None
+          // it's *really* important we ran pc.atPhase so that symbol's type is updated! (atPhase does side-effects on the type!)
+          for (signature <- erasure.javaSig(symbol, pc.atPhase(pc.currentRun.erasurePhase)(symbol.info)))
+            yield signature.replace("/", ".")
+        } else None
       }.getOrElse(None)
     }
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/AnalysisCompile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/AnalysisCompile.scala
@@ -60,22 +60,6 @@ class AnalysisCompile (conf: BasicConfiguration, bm: EclipseSbtBuildManager, con
       }
     }
     
-    def getJdkPath(jProject: IJavaProject) = {
-      val rawClasspath = bm.project.javaProject.getRawClasspath()
-      rawClasspath.toSeq.flatMap(cp =>
-        cp.getEntryKind match {
-          case org.eclipse.jdt.core.IClasspathEntry.CPE_CONTAINER =>
-            val path0 = cp.getPath
-            if (!path0.isEmpty && path0.segment(0) == JavaRuntime.JRE_CONTAINER) {
-              val container = JavaCore.getClasspathContainer(cp.getPath, bm.project.javaProject)
-              Some(container.getClasspathEntries.toSeq.map(_.getPath.toFile))
-            } else None
-          case _ => None
-          
-        }).flatten
-    }
-
-    
     def doCompile(scalac: ScalaSbtCompiler, javac: JavaEclipseCompiler,
               sources: Seq[File],  reporter: Reporter, settings: Settings,
               compOrder: CompileOrder.Value, compOptions: Seq[String] = Nil,
@@ -98,7 +82,7 @@ class AnalysisCompile (conf: BasicConfiguration, bm: EclipseSbtBuildManager, con
             // whatever is set by the env variable and not necessarily what was given
             // in the project definition
             ClasspathOptions(bootLibrary = true, compiler = false, extra = true, autoBoot = false, filterLibrary = true))
-        val jrePath = getJdkPath(bm.project.javaProject)
+        val jrePath = bm.project.jdkPaths.map(_.toFile)
         val classpathWithoutJVM: Set[File] = conf.classpath.toSet -- jrePath
         val searchClasspath = classpathWithoutJVM ++ jrePath
         val entry = Locate.entry(searchClasspath.toSeq, Locate.definesClass) // use default defineClass for now


### PR DESCRIPTION
The Scala compiler adds the currently running JDK to the class path, taking precedence over the JDK 
configured in the build path. This commit fixed #1000820, and generalizes the scheme used by the Sbt
builder.

Unfortunately I couldn't come up with any reliable way to write a test: JDK configurations are not portable, and the compiler needs a real JDK in order to instantiated. 
