### PR TITLE
Fix typo: "paramters"

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -615,7 +615,7 @@ class ScalaProject private (val underlying: IProject) extends HasLogger {
     
     // handle additional parameters
     val additional = store.getString(CompilerSettings.ADDITIONAL_PARAMS)
-    logger.info("setting additional paramters: " + additional)
+    logger.info("setting additional parameters: " + additional)
     settings.processArgumentString(additional)
   }
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ToggleImplicitsDisplayHandler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ToggleImplicitsDisplayHandler.scala
@@ -38,7 +38,7 @@ class ToggleImplicitsDisplayHandler extends AbstractHandler with IElementUpdater
   /**
    * refresh widget linked to this handlers (button, menu items,...)
    */
-  def updateElement(element : UIElement, paramters : java.util.Map[_,_]) {
+  def updateElement(element : UIElement, parameters : java.util.Map[_,_]) {
     element.setChecked(isChecked)    
   }
 


### PR DESCRIPTION
I noticed the string `"setting additional paramters: "` in my Eclipse log, so I fixed the misspelling of the word _parameters_ in two places.
