### PR TITLE
Rename renamed import selectors.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/MoveClassAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/MoveClassAction.scala
@@ -54,7 +54,7 @@ class MoveClassAction extends RefactoringAction {
         
         /* The initial index is empty, it will be filled during the initialization
          * where we can show a progress bar and let the user cancel the operation.*/
-        var index = GlobalIndex(Nil)
+        var index = EmptyIndex
       }
     }
     

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
@@ -47,7 +47,7 @@ class GlobalRenameAction extends RefactoringAction {
         
         /* The initial index is empty, it will be filled during the initialization
          * where we can show a progress bar and let the user cancel the operation.*/
-        var index = GlobalIndex(Nil)
+        var index = EmptyIndex
       }
     }
     

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/LocalRenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/LocalRenameAction.scala
@@ -44,7 +44,14 @@ class LocalRenameAction extends RefactoringAction {
         selected <- selectedSymbolTree.toList
         t <- index.occurences(selected.symbol)
       } yield {
-        val pos = t.namePosition
+        val pos = t match {
+          case ImportSelectorTree(name, global.EmptyTree) =>
+            name.pos
+          case ImportSelectorTree(_, rename) =>
+            rename.pos
+          case t => 
+            t.namePosition 
+        }
         if(pos.source.content(pos.start) == '`') {
           (pos.start + 1, pos.end - pos.start - 2)
         } else {


### PR DESCRIPTION
Names that are renamed in an import can now be renamed in the file. This is done
using the existing linked-mode-ui rename, with a special case for import
selectors. The code to decide whether a file-local rename should be performed was
duplicated in scala-refactoring, so we now just reuse that.

Fixes #1000884
