### PR TITLE
Handle invalid target packages in the Move participant.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/ScalaMoveParticipant.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/ScalaMoveParticipant.scala
@@ -32,7 +32,13 @@ class ScalaMoveParticipant extends MoveParticipant {
     getArguments.getDestination match {
       case destination: IFolder =>
         val javaProject = ScalaPlugin.plugin.getJavaProject(resourceToMove.getProject)
-        val targetPackage = javaProject.findPackageFragment(destination.getFullPath())        
+        val targetPackage = javaProject.findPackageFragment(destination.getFullPath)
+        
+        if(targetPackage == null) {
+          val msg = "Could not find the target package for "+ destination.getFullPath +". Scala source files will not " +
+          		"be refactored."
+          return RefactoringStatus.createWarningStatus(msg)
+        }
             
         ScalaSourceFile.createFromPath(resourceToMove.getFullPath.toOSString) map { scalaSourceFile =>
     


### PR DESCRIPTION
When the target package of a move refactoring cannot be found (e.g. because
the target is not a source folder), we abort with a warning. The user can
then still move the file, but he will be warned that the source won't be
changed. The JDT doesn't warn the user but simply moves the file without
refactorings its content.

See #1001044
