### PR TITLE
Add configuration for editor 'surround selection' feature. 

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -94,6 +94,12 @@
             class="scala.tools.eclipse.logging.ui.properties.LoggingPreferencePage"
             id="org.scala-ide.sdt.core.properties.Logging"
             name="Logging">
+      </page>
+      <page
+            category="org.scala-ide.sdt.core.preferences"
+            class="scala.tools.eclipse.properties.EditorPreferencePage"
+            id="org.scala-ide.sdt.core.editor"
+            name="Editor">
       </page>      
    </extension>
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/SurroundSelectionStrategy.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/SurroundSelectionStrategy.scala
@@ -6,17 +6,26 @@ import org.eclipse.jface.text.DocumentCommand
 import org.eclipse.jface.text.IDocument
 import org.eclipse.swt.custom.VerifyKeyListener
 import org.eclipse.swt.events.VerifyEvent
+import org.eclipse.jface.util.IPropertyChangeListener
+import scala.tools.eclipse.properties.EditorPreferencePage._
+import scala.tools.eclipse.ScalaPlugin
+import org.eclipse.jface.util.PropertyChangeEvent
 
-class SurroundSelectionStrategy(sourceViewer: ISourceViewer) extends VerifyKeyListener {
-  val activeChars = Map(
-    '(' -> ')',
-    '{' -> '}',
-    '"' -> '"',
-    '[' -> ']')
+class SurroundSelectionStrategy(sourceViewer: ISourceViewer) extends VerifyKeyListener with IPropertyChangeListener {
+  @volatile
+  private var activeChars = getConfiguredActiveChars
+
+  ScalaPlugin.prefStore.addPropertyChangeListener(this)
+
+  private lazy val optionToMapping = Map(
+    P_ENABLE_SMART_PARENS -> ('(', ')'),
+    P_ENABLE_SMART_BRACES -> ('{', '}'),
+    P_ENABLE_SMART_QUOTES -> ('"', '"'),
+    P_ENABLE_SMART_BRACKETS -> ('[', ']'))
 
   /** Automatically surround the current selection with the corresponding
-   *  character, if it is a parenthesis/brace of quotes.
-   *  
+   *  character, if it is defined in the `activeChars` map.
+   *
    *  Since it gets a chance to see all characters, it also suppresses the
    *  automatically generated closing angle bracket that the Java editor
    *  always appends, leading to <> in the code.
@@ -38,5 +47,19 @@ class SurroundSelectionStrategy(sourceViewer: ISourceViewer) extends VerifyKeyLi
       sourceViewer.setSelectedRange(selection.x + 1, 0)
       event.doit = false
     }
+  }
+
+  /** Return a map of characters that have been enabled to act as active chars.
+   *
+   *  @note For each pair `(c1, c2)` in the map, when pressing c1 and a selection is
+   *        active, it will surround it with c1,c2 instead of replacing the selection.
+   */
+  private def getConfiguredActiveChars: Map[Char, Char] = {
+    val store = ScalaPlugin.prefStore
+    for ((option, mapping) <- optionToMapping if store.getBoolean(option)) yield mapping
+  }
+
+  def propertyChange(event: PropertyChangeEvent) {
+    activeChars = getConfiguredActiveChars
   }
 }


### PR DESCRIPTION
Each character can be individually enabled. By default they are off.

Fixes #1001034
