### PR TITLE
More reliable refactoring in multi-file situations.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/FullProjectIndex.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/FullProjectIndex.scala
@@ -62,9 +62,10 @@ trait FullProjectIndex extends HasLogger {
         
         val scope = SearchEngine.createJavaSearchScope(Array[IJavaElement](project.javaProject), IJavaSearchScope.SOURCES)
         
-        val combinedPattern = hints map { hint =>
-          SearchPattern.createPattern(
-              hint, IJavaSearchConstants.TYPE, IJavaSearchConstants.ALL_OCCURRENCES,  SearchPattern.R_EXACT_MATCH)
+        val combinedPattern = hints flatMap { hint =>
+          import IJavaSearchConstants._
+          val searchFor = SearchPattern.createPattern(hint, _: Int, ALL_OCCURRENCES,  SearchPattern.R_EXACT_MATCH) 
+          searchFor(TYPE) :: searchFor(METHOD) :: searchFor(FIELD) :: searchFor(PACKAGE) :: Nil
         } reduceLeft SearchPattern.createOrPattern
         
         val pathCollector = new PathCollector

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/MoveClassAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/move/MoveClassAction.scala
@@ -79,7 +79,7 @@ class MoveClassAction extends RefactoringAction {
     override def createChange(pm: IProgressMonitor): CompositeChange = {
 
       val (index, cleanupHandler) = {
-        val toMove = refactoring.statsToMove(selection, refactoringParameters) collect {
+        val toMove = refactoring.statsToMove(selection(), refactoringParameters) collect {
           case impl: refactoring.global.ImplDef => impl.name.toString
         }
         buildFullProjectIndex(pm, toMove)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
@@ -84,7 +84,7 @@ class GlobalRenameAction extends RefactoringAction {
     override def checkFinalConditions(pm: IProgressMonitor): RefactoringStatus = {
       val status = super.checkFinalConditions(pm)
       
-      refactoring.doesNameCollide(name, selection.selectedSymbolTree map (_.symbol) getOrElse refactoring.global.NoSymbol) match {
+      refactoring.doesNameCollide(name, selection().selectedSymbolTree map (_.symbol) getOrElse refactoring.global.NoSymbol) match {
         case Nil => ()
         case collisions => 
           val names = collisions map (s => s.fullName) mkString ", "

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/LocalRenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/LocalRenameAction.scala
@@ -36,7 +36,7 @@ class LocalRenameAction extends RefactoringAction {
     
     def runInlineRename(r: RenameScalaIdeRefactoring) {
       import r.refactoring._
-      import r.selection.selectedSymbolTree      
+      val selectedSymbolTree = r.selection().selectedSymbolTree      
       
       val positions = for {
         // there's always a selected tree, otherwise


### PR DESCRIPTION
Stop using lazy vals for caching compiler objects, because this leads to
problems with the compiler's symbols. In detail: when starting a refactoring,
the current file is type checked and used for initial condition tests.
Then depending on the refactoring, more files are type-checked and added
to an index. We used lazy vals to hold the results of the initial
checks, e.g. the symbol of the selected method, but this then leads
to problems when this "old" symbol is used in the index that was built with
the newer symbols. In short, it gave me many headaches, and the tiny
performance improvements were not worth it.

Also fixes a bug with the project wide index which only searched for
types and not other elements.

Fixes #1001059.
