### PR TITLE
Pass the user's formatting options to the refactoring library codegen.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
@@ -9,9 +9,9 @@ import java.text.Collator
 import java.util.Comparator
 
 import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.core.compiler.IProblem
 import org.eclipse.jdt.core.search.{TypeNameMatch, SearchEngine, IJavaSearchConstants}
-import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.internal.corext.util.{TypeNameMatchCollector, QualifiedTypeNameHistory}
 import org.eclipse.jdt.internal.ui.actions.ActionMessages
 import org.eclipse.jdt.internal.ui.dialogs.MultiElementListSelectionDialog
@@ -20,8 +20,7 @@ import org.eclipse.jface.action.IAction
 import org.eclipse.jface.window.Window
 
 import scala.tools.eclipse.javaelements.{ScalaSourceFile, ScalaElement, LazyToplevelClass}
-import scala.tools.eclipse.properties.OrganizeImportsPreferences._
-import scala.tools.nsc.io.AbstractFile
+import scala.tools.eclipse.properties.OrganizeImportsPreferences.{getWildcardImportsForProject, getOrganizeImportStrategy, getGroupsForProject, PreserveExistingGroups, ExpandImports, CollapseImports}
 import scala.tools.refactoring.implementations.{OrganizeImports, AddImportStatement}
 
 /**
@@ -216,7 +215,7 @@ class OrganizeImportsAction extends RefactoringAction with ActionWithNoWizard {
     
     lazy val compilationUnitHasProblems = file.getProblems != null && file.getProblems.exists(_.isError)
                   
-    val refactoring = withCompiler( c => new OrganizeImports { val global = c })
+    val refactoring = withCompiler( c => new OrganizeImports with FormattingOverrides { val global = c })
 
     override def checkInitialConditions(pm: IProgressMonitor) = {
       val status = super.checkInitialConditions(pm)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ScalaIdeRefactoring.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ScalaIdeRefactoring.scala
@@ -42,7 +42,8 @@ import scala.tools.refactoring.MultiStageRefactoring
  * @param getName The displayable name of this refactoring.
  * @param file The file this refactoring started from.
  */
-abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFile, selectionStart: Int, selectionEnd: Int) extends LTKRefactoring {
+abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFile, selectionStart: Int, selectionEnd: Int) 
+  extends LTKRefactoring with UserPreferencesFormatting {
       
   /**
    * Every refactoring subclass needs to provide a specific refactoring instance.

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/UserPreferencesFormatting.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/UserPreferencesFormatting.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 LAMP/EPFL
+ */
+
+package scala.tools.eclipse
+package refactoring
+
+import scala.tools.eclipse.formatter.FormatterPreferences
+import scala.tools.refactoring.Refactoring
+
+import scalariform.formatter.preferences.SpaceInsideParentheses
+
+/**
+ * Enables passing the user's source formatting preferences to the refactoring library's
+ * source code generation.
+ */
+trait UserPreferencesFormatting {
+  this: ScalaIdeRefactoring =>
+  
+  /**
+   * Refactoring actions should mix in this trait when creating a refactoring instance to
+   * automatically pass the user's formatting preferences to the refactoring implementation.
+   */
+  trait FormattingOverrides {
+    this: Refactoring =>
+      
+    override val spacingAroundMultipleImports: String = {
+      for {
+        javaProject <- Option(file.getJavaProject)
+        val prefs = FormatterPreferences.getPreferences(javaProject)
+        if  prefs(SpaceInsideParentheses)
+      } yield " "
+    } getOrElse ""
+    
+    // TODO: Create more overrides here and in the refactoring library.
+  }
+}


### PR DESCRIPTION
At the moment, only for Organize Imports, but more will be added in
the future.

Fixes #1001073
