### PR TITLE
Warn the user if JDT Weaving is OFF

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/DiagnosticDialog.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/DiagnosticDialog.scala
@@ -20,7 +20,9 @@ import org.eclipse.ui.browser.IWorkbenchBrowserSupport
 import scala.tools.eclipse.logging.LogManager
 import scala.tools.eclipse.logging.HasLogger
 
-class DiagnosticDialog(shell: Shell) extends Dialog(shell) {
+class DiagnosticDialog(configurer: WeavingStateConfigurer, shell: Shell) extends Dialog(shell) {
+
+  def this(shell: Shell) = this(new WeavingStateConfigurer, shell)
 
   /* Dialog logic:
      * if current settings do not match default settings: 
@@ -30,8 +32,6 @@ class DiagnosticDialog(shell: Shell) extends Dialog(shell) {
            1) save all values
            2) "use other settings" is enabled.
   */
-  
-  protected val configurer = new WeavingStateConfigurer
   
   val heapSize = Runtime.getRuntime.maxMemory / (1024 * 1024)
   val recommendedHeap = 1024

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/StartupDiagnostics.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/diagnostic/StartupDiagnostics.scala
@@ -7,14 +7,18 @@ import org.eclipse.jface.dialogs.MessageDialog
 import org.eclipse.jface.dialogs.IDialogConstants
 import util.SWTUtils.asyncExec
 import scala.tools.eclipse.logging.HasLogger
+import scala.tools.eclipse.contribution.weaving.jdt.configuration.WeavingStateConfigurer
+import org.eclipse.ui.PlatformUI
 
 object StartupDiagnostics extends HasLogger {
   import ScalaPlugin.plugin
   
-  val INSTALLED_VERSION_KEY = plugin.pluginId + ".diagnostic.currentPluginVersion" 
-  val ASK_DIAGNOSTICS = plugin.pluginId + ".diagnostic.askOnUpgrade"
+  private val INSTALLED_VERSION_KEY = plugin.pluginId + ".diagnostic.currentPluginVersion" 
+  private val ASK_DIAGNOSTICS = plugin.pluginId + ".diagnostic.askOnUpgrade"
   
-  def run {   
+  private val weavingState = new WeavingStateConfigurer
+  
+  def run {
     val prefStore = plugin.getPreferenceStore
     val previousVersion = prefStore.getString(INSTALLED_VERSION_KEY)
     val currentVersion = plugin.getBundle.getVersion.toString
@@ -24,11 +28,12 @@ object StartupDiagnostics extends HasLogger {
     logger.info("startup diagnostics: previous version = " + previousVersion)
     logger.info("startup diagnostics: CURRENT version = " + currentVersion)
  
-    if (previousVersion != currentVersion) {
-      prefStore.setValue(INSTALLED_VERSION_KEY, currentVersion)
+    
+    asyncExec { 
+      if (previousVersion != currentVersion) {
+        prefStore.setValue(INSTALLED_VERSION_KEY, currentVersion)
       
-      if (askDiagnostics) {
-        asyncExec { 
+        if (askDiagnostics) {
             val labels = Array(IDialogConstants.YES_LABEL, IDialogConstants.NO_LABEL, "Never")
             val dialog = 
               new MessageDialog(ScalaPlugin.getShell, "Run Scala Setup Diagnostics?", 
@@ -37,14 +42,31 @@ object StartupDiagnostics extends HasLogger {
                 MessageDialog.QUESTION, labels, 0)
             dialog.open match {
               case 0 => // user pressed Yes
-                new DiagnosticDialog(ScalaPlugin.getShell).open
+                new DiagnosticDialog(weavingState, ScalaPlugin.getShell).open
               case 2 => // user pressed Never
-                plugin.getPreferenceStore.setValue(ASK_DIAGNOSTICS, false)
+                prefStore.setValue(ASK_DIAGNOSTICS, false)
               case _ => // user pressed close button (-1) or No (1)
             }
             
             ScalaPlugin.plugin.savePluginPreferences // TODO: this method is deprecated, but the solution given in the docs is unclear and is not used by Eclipse itself. -DM
         }
+      }
+      ensureWeavingIsEnabled()
+    }
+  }
+
+  private def ensureWeavingIsEnabled(): Unit = {
+    if(!weavingState.isWeaving) {
+      val forceWeavingOn = MessageDialog.openConfirm(ScalaPlugin.getShell, "JDT Weaving is disabled", 
+"""JDT Weaving is currently disabled. The Scala IDE needs JDT Weaving to be active, or it will not work as expected.
+
+Activate JDT Weaving and restart Eclipse? (Highly Recommended)
+"""
+      )
+      
+      if(forceWeavingOn) {
+        weavingState.changeWeavingState(true)
+        PlatformUI.getWorkbench.restart
       }
     }
   }


### PR DESCRIPTION
At startup, check that JDT Weaving is enabled. If it's not, then
warn the user through a dialog box and programmatically
enable JDT Weaving (and restart the workbench) upon confirmation.

Note that there is no way for the user to silent the dialog. Each time the
Scala IDE plugin is activated the check will be performed, and if JDT
Weaving is OFF the above mentioned message will be displayed. If the
user doesn't want to see the dialog, it will have three options:
- Enable JDT Weaving
- Disable the Scala IDE core bundle (using the OSGi console)
- Uninstall the Scala IDE plugin

Note: I would like to merge this also in release/2.0.x 
