### PR TITLE
Fixed NPE occurring when creating a Scala Application using the wizard

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationPage.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationPage.scala
@@ -1,68 +1,95 @@
 package scala.tools.eclipse.wizards
 
 import org.eclipse.jdt.core.IPackageFragment
+import org.eclipse.jface.wizard.IWizardPage
 import org.eclipse.jface.wizard.WizardPage
-import org.eclipse.swt.layout._
-import org.eclipse.swt.widgets.{ List => _, _}
 import org.eclipse.swt.SWT
+import org.eclipse.swt.layout.GridData
+import org.eclipse.swt.layout.GridLayout
+import org.eclipse.swt.widgets.Combo
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Group
+import org.eclipse.swt.widgets.Text
 
-class NewApplicationPage(packageFragments: List[IPackageFragment]) extends WizardPage("New Scala Application") {
-
+abstract class NewApplicationPage extends WizardPage("New Scala Application") {
   setTitle("New Scala Application")
   setDescription("Create a new top-level Scala application")
 
-  private var nameField: Text = _
-  private var packageComboBox: Combo = _
-
-  def createControl(parent: Composite) {
+  final override def createControl(parent: Composite): Unit = {
     val outerComposite = new Composite(parent, SWT.NONE)
     outerComposite.setLayout(new GridLayout)
+    populateWizard(outerComposite)
     setControl(outerComposite)
+  }
 
-    if (packageFragments.isEmpty)
-      setErrorMessage("Cannot create a top-level Scala application unless a project or package is selected.")
-    else {
-      val packageGroup = makeGroup(outerComposite, "&Package:")
+  protected def populateWizard(container: Composite): Unit
+
+  def getApplicationName: String
+  def getSelectedPackage: Option[IPackageFragment]
+}
+
+object NewApplicationPage {
+
+  def apply(packageFragments: List[IPackageFragment]): NewApplicationPage = {
+    if (packageFragments.isEmpty) new NewApplicationPageError
+    else new NewApplicationPageOk(packageFragments)
+  }
+
+  private class NewApplicationPageOk(packageFragments: List[IPackageFragment]) extends NewApplicationPage {
+    require(packageFragments.nonEmpty)
+
+    private var nameField: Text = _
+    private var packageComboBox: Combo = _
+
+    override protected def populateWizard(container: Composite): Unit = {
+      val packageGroup = makeGroup(container, "&Package:")
       packageGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL))
       packageComboBox = makePackageComboBox(packageGroup)
       packageComboBox.setLayoutData(new GridData(GridData.FILL_HORIZONTAL))
 
-      val nameGroup = makeGroup(outerComposite, "&Object name:")
+      val nameGroup = makeGroup(container, "&Object name:")
       nameGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL))
       nameField = new Text(nameGroup, SWT.LEFT + SWT.BORDER)
       nameField.setLayoutData(new GridData(GridData.FILL_HORIZONTAL))
     }
+
+    override def setVisible(visible: Boolean) {
+      super.setVisible(visible)
+      if (visible)
+        nameField.setFocus()
+    }
+
+    override def getApplicationName: String = {
+      val name = nameField.getText.trim
+      if (name endsWith ".scala")
+        name.substring(0, name.length - ".scala".length)
+      else
+        name
+    }
+
+    override def getSelectedPackage: Option[IPackageFragment] = Some(packageFragments(packageComboBox.getSelectionIndex))
+
+    private def makePackageComboBox(parent: Composite): Combo = {
+      val packageComboBox = new Combo(parent, SWT.SINGLE | SWT.READ_ONLY)
+      for (pkg <- packageFragments)
+        packageComboBox.add(if (pkg.isDefaultPackage) "(default package)" else pkg.getElementName)
+      packageComboBox.select(0)
+      packageComboBox
+    }
+
+    private def makeGroup(parent: Composite, label: String): Group = {
+      val group = new Group(parent, SWT.NONE)
+      group.setText(label)
+      group.setLayout(new GridLayout)
+      group
+    }
   }
 
-  override def setVisible(visible: Boolean) {
-    super.setVisible(visible)
-    if (visible)
-      nameField.setFocus()
+  private class NewApplicationPageError extends NewApplicationPage {
+    override protected def populateWizard(container: Composite): Unit = {
+      setErrorMessage("Cannot create Scala Application unless a project or a package is selected.")
+    }
+    override def getApplicationName: String = "Scala Application Wizard"
+    override def getSelectedPackage: Option[IPackageFragment] = None
   }
-
-  def getApplicationName: String = {
-    val name = nameField.getText.trim
-    if (name endsWith ".scala")
-      name.substring(0, name.length - ".scala".length)
-    else
-      name
-  }
-
-  def getSelectedPackage: IPackageFragment = packageFragments(packageComboBox.getSelectionIndex)
-
-  private def makePackageComboBox(parent: Composite): Combo = {
-    val packageComboBox = new Combo(parent, SWT.SINGLE | SWT.READ_ONLY)
-    for (pkg <- packageFragments)
-      packageComboBox.add(if (pkg.isDefaultPackage) "(default package)" else pkg.getElementName)
-    packageComboBox.select(0)
-    packageComboBox
-  }
-
-  private def makeGroup(parent: Composite, label: String): Group = {
-    val group = new Group(parent, SWT.NONE)
-    group.setText(label)
-    group.setLayout(new GridLayout)
-    group
-  }
-
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
@@ -58,7 +58,7 @@ class NewApplicationWizard extends BasicNewResourceWizard with HasLogger {
       selection = getCurrentEditorAsSelection getOrElse selection
     val packageFragments = getPackageFragments(selection)
 
-    page = new NewApplicationPage(packageFragments)
+    page = NewApplicationPage(packageFragments)
     addPage(page)
   }
 
@@ -91,8 +91,11 @@ class NewApplicationWizard extends BasicNewResourceWizard with HasLogger {
     true
   }
 
-  override def performFinish: Boolean =
-    tryExecute(createApplication(page.getApplicationName, page.getSelectedPackage)).getOrElse(false)
+  override def performFinish: Boolean = page.getSelectedPackage match {
+    case None => true
+    case Some(pkg) =>
+      tryExecute(createApplication(page.getApplicationName, pkg)).getOrElse(false)
+  }    
 
   private def openInEditor(file: IFile) = {
     selectAndReveal(file)
@@ -134,6 +137,7 @@ class NewApplicationWizard extends BasicNewResourceWizard with HasLogger {
       case _ =>
         (for {
           resource <- computeSelectedResources(selection)
+          if resource.getProject.isOpen
           packageFragment <- getPackageFragments(resource.getProject)
         } yield packageFragment).distinct
     }


### PR DESCRIPTION
This could occur if no Scala project was selected, e.g., by clicking on a
closed project (or outside of teh Package Explorer) and File > New > Scala
Application, the reported NPE would have occurred.

Fix #1000797, #1001115

Should also be merged in `release/2.0.x` branch.
