### PR TITLE
Scala debugger working without JDT debugger

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugTargetTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugTargetTest.scala
@@ -31,14 +31,14 @@ class ScalaDebugTargetTest {
     when(event.thread).thenReturn(thread)
     when(thread.name).thenReturn(THREAD_NAME)
     
-    debugTarget.handleEvent(event, null, false, null)
+    debugTarget.eventActor !? event
     
     val threads1= debugTarget.getThreads
     assertEquals("Wrong number of threads", 1, threads1.length)
     assertEquals("Wrong thread name", THREAD_NAME, threads1(0).getName)
     
     // a second start event should not result in a duplicate entry
-    debugTarget.handleEvent(event, null, false, null)
+    debugTarget.eventActor !? event
     
     val threads2= debugTarget.getThreads
     assertEquals("Wrong number of threads", 1, threads2.length)
@@ -46,11 +46,9 @@ class ScalaDebugTargetTest {
   }
   
   def createDebugTarget(): ScalaDebugTarget = {
-    val javaDebugTarget= mock(classOf[JDIDebugTarget])
     val vm= mock(classOf[VirtualMachine])
-    when(javaDebugTarget.getVM).thenReturn(vm)
     when(vm.allThreads).thenReturn(new ArrayList[ThreadReference]())
-    new ScalaDebugTarget(javaDebugTarget, null, null)
+    new ScalaDebugTarget(vm, null, null, null, null)
   }
 
 }

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/AnonFunOnListString.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/AnonFunOnListString.launch
@@ -7,6 +7,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="stepping.AnonFunOnListString"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListInt.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListInt.launch
@@ -2,11 +2,14 @@
 <launchConfiguration type="scala.application">
 <stringAttribute key="bad_container_name" value="/debug/f"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/debug"/>
+<listEntry value="/debug/src/stepping/ForComprehensionListInt.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
+<listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="stepping.ForComprehensionListInt"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListIntOptimized.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListIntOptimized.launch
@@ -7,6 +7,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="stepping.ForComprehensionListIntOptimized"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListObject.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListObject.launch
@@ -7,6 +7,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="stepping.ForComprehensionListObject"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListString.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListString.launch
@@ -7,6 +7,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="stepping.ForComprehensionListString"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListString2.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/ForComprehensionListString2.launch
@@ -7,6 +7,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="stepping.ForComprehensionListString2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/SimpleStepping.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/SimpleStepping.launch
@@ -7,6 +7,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="stepping.SimpleStepping"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/debug/Variables.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/debug/Variables.launch
@@ -6,6 +6,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="debug.Variables"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="debug"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -36,4 +36,17 @@
             modelIdentifier="org.scala-ide.sdt.debug">
       </logicalStructureProvider>
    </extension>
+   <extension
+         point="org.eclipse.debug.core.launchDelegates">
+      <launchDelegate
+            delegate="scala.tools.eclipse.launching.ScalaApplicationLaunchConfigurationDelegate"
+            delegateDescription="The Scala JVM Launcher supports debugging of local Scala using the new Scala debugger"
+            id="scala.application.new"
+            modes="debug"
+            name="Scala Application (new debugger)"
+            sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector"
+            sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer"
+            type="scala.application">
+      </launchDelegate>
+    </extension>
 </plugin>

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/JDIUtil.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/JDIUtil.scala
@@ -1,6 +1,6 @@
 package scala.tools.eclipse.debug
 
-import com.sun.jdi.{Method, AbsentInformationException}
+import com.sun.jdi.{ Method, AbsentInformationException, ReferenceType, Location }
 
 object JDIUtil {
 
@@ -18,6 +18,24 @@ object JDIUtil {
       case e =>
         throw e
     }
+  }
+
+  /**
+   * Return the valid locations in the given reference type, without
+   * throwing AbsentInformationException if the information is missing.
+   */
+  def referenceTypeToLocations(t: ReferenceType): Seq[Location] = {
+    import scala.collection.JavaConverters._
+    t.methods.asScala.flatMap(
+      method =>
+        try {
+          method.allLineLocations.asScala
+        } catch {
+          case e: AbsentInformationException =>
+            Nil
+          case e =>
+            throw e
+        })
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugBreakpointManager.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugBreakpointManager.scala
@@ -1,0 +1,261 @@
+package scala.tools.eclipse.debug
+
+import org.eclipse.debug.core.DebugPlugin
+import org.eclipse.debug.core.IBreakpointsListener
+import com.sun.jdi.VirtualMachine
+import org.eclipse.debug.core.model.IBreakpoint
+import org.eclipse.core.resources.IMarkerDelta
+import scala.actors.Actor
+import org.eclipse.debug.core.IBreakpointListener
+import org.eclipse.jdt.internal.debug.core.breakpoints.JavaBreakpoint
+import org.eclipse.core.resources.IMarker
+import com.sun.jdi.request.ClassPrepareRequest
+import scala.tools.eclipse.debug.model.ScalaDebugTarget
+import com.sun.jdi.event.ClassPrepareEvent
+import com.sun.jdi.ReferenceType
+import com.sun.jdi.request.BreakpointRequest
+import com.sun.jdi.request.EventRequest
+import com.sun.jdi.event.BreakpointEvent
+import com.sun.jdi.Location
+import com.sun.jdi.ThreadReference
+import org.eclipse.debug.core.DebugEvent
+
+object ScalaDebugBreakpointManager {
+  val JDT_DEBUG_UID = "org.eclipse.jdt.debug"
+
+  val ATTRIBUTE_TYPE_NAME = "org.eclipse.jdt.debug.core.typeName"
+}
+
+// Actor messages
+case object InitializeExistingBreakpoints
+case class BreakpointAdded(breakpoint: IBreakpoint)
+case class BreakpointRemoved(breakpoint: IBreakpoint)
+case class BreakpointChanged(breakpoint: IBreakpoint)
+
+/**
+ * Manage the requests for one platform breakpoint.
+ */
+class BreakpointSupport(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget) {
+  import ScalaDebugBreakpointManager._
+  import IMarker._
+
+  val eventActor = new Actor {
+    start
+    def act() {
+      loop {
+        react {
+          case event: ClassPrepareEvent =>
+            classPrepared(event.referenceType)
+            reply(false)
+          case event: BreakpointEvent =>
+            breakpointHit(event.location, event.thread)
+            reply(true)
+          case ActorExit =>
+            exit
+        }
+      }
+    }
+  }
+
+  private var eventRequests = List[EventRequest]()
+
+  /**
+   * Create all the requests needed at the time the breakpoint is added
+   */
+  def init() {
+    val virtualMachine = debugTarget.virtualMachine
+    val eventDispatcher = debugTarget.eventDispatcher
+    val eventRequestManager= virtualMachine.eventRequestManager
+    
+    // class prepare requests for the type and its nested types
+    val classPrepareRequest = eventRequestManager.createClassPrepareRequest()
+    eventRequests ::= classPrepareRequest
+    classPrepareRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL)
+    classPrepareRequest.addClassFilter(getTypeName)
+    val classPrepareRequestDollar = eventRequestManager.createClassPrepareRequest()
+    eventRequests ::= classPrepareRequestDollar
+    classPrepareRequestDollar.setSuspendPolicy(EventRequest.SUSPEND_ALL)
+    classPrepareRequestDollar.addClassFilter(getTypeName + "$*")
+
+    
+    import scala.collection.JavaConverters._
+    // if the type is already loaded, add the breakpoint requests
+    val loadedClasses = virtualMachine.classesByName(getTypeName)
+    loadedClasses.asScala.foreach {
+      loadedClass =>
+        val breakpointRequest = createBreakpointRequest(loadedClass)
+        breakpointRequest.foreach {eventRequests ::= _}
+        
+        // TODO: might be more effective to do the filtering ourselves from 'allClasses'
+        loadedClass.nestedTypes.asScala.foreach{
+          createBreakpointRequest(_).foreach{eventRequests ::= _}
+        }
+    }
+
+    eventRequests.foreach {
+      eventRequest =>
+        eventDispatcher.setActorFor(eventActor, eventRequest)
+        eventRequest.enable
+    }
+  }
+
+  /**
+   * Remove all created requests for this breakpoint
+   */
+  def dispose() {
+    val eventDispatcher = debugTarget.eventDispatcher
+    val eventRequestManager= debugTarget.virtualMachine.eventRequestManager
+    
+    eventRequests.foreach {
+      request =>
+        eventRequestManager.deleteEventRequest(request)
+        eventDispatcher.unsetActorFor(request)
+    }
+    eventActor ! ActorExit
+  }
+
+  def changed() {
+    // TODO: see what can be changed
+    //  - enabled/disabled state
+  }
+
+  /**
+   * Create the line breakpoint on class prepare event
+   */
+  def classPrepared(referenceType: ReferenceType) {
+    val breakpointRequest = createBreakpointRequest(referenceType)
+
+    breakpointRequest.foreach {
+      br =>
+        eventRequests ::= br
+        debugTarget.eventDispatcher.setActorFor(eventActor, br)
+        br.enable
+    }
+  }
+
+  /**
+   * create a line breakpoint on the given type
+   */
+  def createBreakpointRequest(referenceType: ReferenceType): Option[BreakpointRequest] = {
+    import scala.collection.JavaConverters._
+    val lineNumber = getLineNumber
+    val locations = JDIUtil.referenceTypeToLocations(referenceType)
+    // TODO: is it possible to have the same line number in multiple locations? need test case
+    val line = locations.find(_.lineNumber == lineNumber)
+    line.map {
+      l =>
+        val breakpointRequest = debugTarget.virtualMachine.eventRequestManager.createBreakpointRequest(l)
+        breakpointRequest.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD)
+        breakpointRequest
+    }
+  }
+
+  /**
+   * On line breakpoint hit, set the thread as suspended
+   */
+  def breakpointHit(location: Location, thread: ThreadReference) {
+    debugTarget.threadSuspended(thread, DebugEvent.BREAKPOINT)
+  }
+
+  def getTypeName(): String = {
+    breakpoint.getMarker.getAttribute(ATTRIBUTE_TYPE_NAME, "")
+  }
+
+  def getLineNumber(): Int = {
+    breakpoint.getMarker.getAttribute(LINE_NUMBER, -1)
+  }
+
+}
+
+/**
+ * Setup the initial breakpoints, and listen to breakpoint changes, for the given ScalaDebugTarget
+ */
+class ScalaDebugBreakpointManager(debugTarget: ScalaDebugTarget) extends IBreakpointListener {
+  import ScalaDebugBreakpointManager._
+
+  // from org.eclipse.debug.core.IBreakpointsListener
+
+  def breakpointChanged(breakpoint: IBreakpoint, delta: IMarkerDelta): Unit = {
+    eventActor ! BreakpointChanged(breakpoint)
+  }
+
+  def breakpointRemoved(breakpoint: IBreakpoint, delta: IMarkerDelta): Unit = {
+    eventActor ! BreakpointRemoved(breakpoint)
+  }
+
+  def breakpointAdded(breakpoint: IBreakpoint): Unit = {
+    eventActor ! BreakpointAdded(breakpoint)
+  }
+
+  // ------------
+
+  val eventActor = new Actor {
+    start
+
+    var breakpoints = Map[IBreakpoint, BreakpointSupport]()
+
+    /**
+     * process the breakpoint events
+     */
+    def act {
+      loop {
+        react {
+          case InitializeExistingBreakpoints =>
+            DebugPlugin.getDefault.getBreakpointManager.getBreakpoints(JDT_DEBUG_UID).foreach {
+              createBreakpointSupport(_)
+            }
+            reply(None)
+          case BreakpointAdded(breakpoint) =>
+            breakpoints.get(breakpoint) match {
+              case None =>
+                createBreakpointSupport(breakpoint)
+              case _ =>
+              // This is only possible if the message was sent between when the InitializeExistingBreakpoints
+              // message was sent and when the list of the current breakpoint was fetched.
+              // Nothing to do, everything is already in the right state
+            }
+          case BreakpointRemoved(breakpoint) =>
+            breakpoints.get(breakpoint) match {
+              case Some(breakpointSupport) =>
+                breakpointSupport.dispose()
+                breakpoints -= breakpoint
+              case _ =>
+              // see previous comment
+            }
+          case BreakpointChanged(breakpoint) =>
+            breakpoints.get(breakpoint) match {
+              case Some(breakpointSupport) =>
+                breakpointSupport.changed()
+              case _ =>
+              // see previous comment
+            }
+          case ActorExit =>
+            // not cleaning the requests
+            // the connection to the vm is closing or already closed at this point
+            exit
+          case ActorDebug =>
+            reply(None)
+        }
+      }
+    }
+
+    private def createBreakpointSupport(breakpoint: org.eclipse.debug.core.model.IBreakpoint): Unit = {
+      val breakpointSupport = new BreakpointSupport(breakpoint, debugTarget)
+      breakpoints += (breakpoint -> breakpointSupport)
+      breakpointSupport.init()
+    }
+  }
+
+  def init() {
+    val future = eventActor !! InitializeExistingBreakpoints
+    DebugPlugin.getDefault.getBreakpointManager.addBreakpointListener(this)
+    // need to wait for all existing breakpoint to be initialized before continuing, the caller will resume the VM
+    future()
+  }
+  
+  def dispose() {
+    DebugPlugin.getDefault.getBreakpointManager.removeBreakpointListener(this)
+    eventActor ! ActorExit
+  }
+
+}

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugger.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugger.scala
@@ -7,29 +7,24 @@ import scala.tools.eclipse.logging.HasLogger
 import org.eclipse.debug.core.{IDebugEventSetListener, DebugPlugin, DebugEvent}
 import org.eclipse.debug.core.model.{IDebugModelProvider, DebugElement}
 import org.eclipse.debug.core.sourcelookup.ISourceLookupDirector
-import org.eclipse.jdt.debug.core.{IJavaStackFrame, IJavaDebugTarget}
-import org.eclipse.jdt.internal.debug.core.model.{JDIThread, JDIDebugTarget}
 import org.eclipse.jface.viewers.IStructuredSelection
 import org.eclipse.ui.{PlatformUI, ISelectionListener}
 
 import model.{ScalaThread, ScalaStackFrame, ScalaDebugTarget}
 
-object EclipseDebugEvent {
-  def unapply(event: DebugEvent): Option[(Int, DebugElement)] = {
-    event.getSource match {
-      case debugElement: DebugElement =>
-        Some(event.getKind, debugElement)
-      case _ =>
-        None
-    }
-  }
-}
+/**
+ * A generic message to inform that an actor should terminates
+ */
+object ActorExit
 
-object ScalaDebugger extends IDebugEventSetListener with ISelectionListener with HasLogger {
+/**
+ * A debug message used to wait until all required messages have been processed
+ */
+object ActorDebug
+
+object ScalaDebugger extends ISelectionListener with HasLogger {
 
   val classIDebugModelProvider = classOf[IDebugModelProvider]
-  val classIJavaDebugTarget = classOf[IJavaDebugTarget]
-  val classIJavaStackFrame = classOf[IJavaStackFrame]
 
   val modelProvider = new IDebugModelProvider {
     def getModelIdentifiers() = {
@@ -39,26 +34,11 @@ object ScalaDebugger extends IDebugEventSetListener with ISelectionListener with
 
   val modelId = "org.scala-ide.sdt.debug"
 
-  // Members declared in org.eclipse.debug.core.IDebugEventSetListener
-
-  def handleDebugEvents(events: Array[DebugEvent]) {
-    events.foreach(event =>
-      event match {
-        case EclipseDebugEvent(DebugEvent.CREATE, target: JDIDebugTarget) =>
-          if (ScalaDebugPlugin.plugin.getPreferenceStore.getBoolean(DebugPreferencePage.P_ENABLE)) {
-            javaDebugTargetCreated(target)
-          }
-        case EclipseDebugEvent(DebugEvent.SUSPEND, thread: JDIThread) =>
-          javaThreadSuspended(thread, event.getDetail)
-        case EclipseDebugEvent(DebugEvent.TERMINATE, target: JDIDebugTarget) =>
-          javaDebugTargetTerminated(target)
-        case _ =>
-      })
-  }
 
   // Members declared in org.eclipse.ui.ISelectionListener
 
   def selectionChanged(part: org.eclipse.ui.IWorkbenchPart, selection: org.eclipse.jface.viewers.ISelection) {
+    // track the currently selected thread, to be able to invoke methods on the VM
     currentThread = selection match {
       case structuredSelection: IStructuredSelection =>
         structuredSelection.getFirstElement match {
@@ -76,41 +56,13 @@ object ScalaDebugger extends IDebugEventSetListener with ISelectionListener with
 
   // ----
 
-  val debugTargets = Buffer[ScalaDebugTarget]()
-
   var currentThread: ScalaThread = null
 
   def init() {
-    DebugPlugin.getDefault.addDebugEventListener(this)
     if (!ScalaPlugin.plugin.headlessMode) {
       // TODO: really ugly. Need to keep track of current selection per window.
       PlatformUI.getWorkbench.getWorkbenchWindows.apply(0).getSelectionService.addSelectionListener("org.eclipse.debug.ui.DebugView", this)
     }
-  }
-
-  private def javaDebugTargetCreated(target: JDIDebugTarget) {
-    val scalaTarget = ScalaDebugTarget(target)
-    debugTargets += scalaTarget
-    val launch = target.getLaunch
-    launch.removeDebugTarget(target)
-    launch.addDebugTarget(scalaTarget)
-
-    // add the Scala participant to provide source file name
-    // when debugging application with the Scala debugger
-    launch.getSourceLocator match {
-      case sourceLookupDirector: ISourceLookupDirector =>
-        sourceLookupDirector.addParticipants(Array(ScalaSourceLookupParticipant))
-      case sourceLocator =>
-        logger.warn("unable to recognize source locator %s, cannot add Scala participant".format(sourceLocator))
-    }
-  }
-
-  private def javaDebugTargetTerminated(target: JDIDebugTarget) {
-    debugTargets.find(target == _.javaTarget).foreach(_.terminatedFromJava())
-  }
-
-  private def javaThreadSuspended(thread: JDIThread, eventDetail: Int) {
-    debugTargets.find(thread.getDebugTarget == _.javaTarget).foreach(_.javaThreadSuspended(thread, eventDetail))
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
@@ -1,23 +1,25 @@
 package scala.tools.eclipse.debug.command
 
 import scala.tools.eclipse.debug.model.ScalaStackFrame
-import org.eclipse.jdt.internal.debug.core.IJDIEventListener
 import com.sun.jdi.event.EventSet
-import org.eclipse.jdt.internal.debug.core.model.JDIDebugTarget
 import com.sun.jdi.event.Event
 import com.sun.jdi.request.StepRequest
 import com.sun.jdi.request.EventRequest
 import scala.tools.eclipse.debug.model.ScalaThread
 import scala.tools.eclipse.debug.model.ScalaDebugTarget
-import org.eclipse.jdt.internal.debug.core.EventDispatcher
 import org.eclipse.debug.core.DebugEvent
 import com.sun.jdi.event.StepEvent
+import scala.actors.Actor
+import scala.tools.eclipse.debug.ActorExit
 
 object ScalaStepInto {
 
+  /*
+   * Initialize a Scala step into
+   */
   def apply(scalaStackFrame: ScalaStackFrame): ScalaStepInto = {
 
-    val eventRequestManager = scalaStackFrame.stackFrame.virtualMachine.eventRequestManager
+    val eventRequestManager = scalaStackFrame.getScalaDebugTarget.virtualMachine.eventRequestManager
 
     val stepIntoRequest = eventRequestManager.createStepRequest(scalaStackFrame.stackFrame.thread, StepRequest.STEP_LINE, StepRequest.STEP_INTO)
     stepIntoRequest.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD)
@@ -30,77 +32,34 @@ object ScalaStepInto {
 
 }
 
-class ScalaStepInto(target: ScalaDebugTarget, thread: ScalaThread, stepIntoRequest: StepRequest, stepOutRequest: StepRequest, stackDepth: Int, stackLine: Int) extends IJDIEventListener with ScalaStep {
-
-  // Members declared in org.eclipse.jdt.internal.debug.core.IJDIEventListener
-
-  def eventSetComplete(event: Event, target: JDIDebugTarget, suspend: Boolean, eventSet: EventSet): Unit = {
-    // nothing to do
-  }
-
-  def handleEvent(event: Event, javaTarget: JDIDebugTarget, suspendVote: Boolean, eventSet: EventSet): Boolean = {
-    event match {
-      case stepEvent: StepEvent =>
-        event.request match {
-          case `stepIntoRequest` =>
-            if (target.isValidLocation(stepEvent.location)) {
-              stop
-              thread.suspendedFromScala(DebugEvent.STEP_INTO)
-              false
-            } else {
-              if (target.shouldNotStepInto(stepEvent.location)) {
-                // don't step deeper into constructor from 'hidden' entities
-                stepOutStackDepth = stepEvent.thread.frameCount
-                stepIntoRequest.disable
-                stepOutRequest.enable
-              }
-              true
-            }
-          case `stepOutRequest` =>
-            if (stepEvent.thread.frameCount == stackDepth && stepEvent.location.lineNumber != stackLine) {
-              // we are back on the method, but on a different line, stopping the stepping
-              stop
-              thread.suspendedFromScala(DebugEvent.STEP_INTO)
-              false
-            } else {
-              // switch back to step into only if the step return has been effectively done.
-              if (stepEvent.thread.frameCount < stepOutStackDepth) {
-                // launch a new step into
-                stepOutRequest.disable
-                stepIntoRequest.enable
-              }
-              true
-            }
-        }
-      case _ =>
-        suspendVote
-    }
-  }
+class ScalaStepInto(target: ScalaDebugTarget, thread: ScalaThread, stepIntoRequest: StepRequest, stepOutRequest: StepRequest, stackDepth: Int, stackLine: Int) extends ScalaStep {
 
   // Members declared in scala.tools.eclipse.debug.command.ScalaStep
 
   def step() {
-    val eventDispatcher = target.javaTarget.getEventDispatcher
+    val eventDispatcher = target.eventDispatcher
 
-    eventDispatcher.addJDIEventListener(this, stepIntoRequest)
-    eventDispatcher.addJDIEventListener(this, stepOutRequest)
+    eventDispatcher.setActorFor(eventActor, stepIntoRequest)
+    eventDispatcher.setActorFor(eventActor, stepOutRequest)
     stepIntoRequest.enable
     thread.resumedFromScala(DebugEvent.STEP_INTO)
     thread.thread.resume
   }
 
   def stop() {
-    val eventDispatcher = target.javaTarget.getEventDispatcher
+    val eventDispatcher = target.eventDispatcher
 
     val eventRequestManager = thread.thread.virtualMachine.eventRequestManager
 
     stepIntoRequest.disable
     stepOutRequest.disable
-    eventDispatcher.removeJDIEventListener(this, stepIntoRequest)
-    eventDispatcher.removeJDIEventListener(this, stepOutRequest)
+    eventDispatcher.unsetActorFor(stepIntoRequest)
+    eventDispatcher.unsetActorFor(stepOutRequest)
     eventRequestManager.deleteEventRequest(stepIntoRequest)
     eventRequestManager.deleteEventRequest(stepOutRequest)
 
+    eventActor ! ActorExit
+    
   }
 
   // -----
@@ -109,5 +68,52 @@ class ScalaStepInto(target: ScalaDebugTarget, thread: ScalaThread, stepIntoReque
    * Needed to perform a correct step out (see Eclipse bug report #38744)
    */
   var stepOutStackDepth = 0
+
+  /**
+   *  process the debug events
+   */
+  val eventActor = new Actor {
+    start
+    def act() {
+      loop {
+        react {
+          case stepEvent: StepEvent =>
+            reply(stepEvent.request match {
+              case `stepIntoRequest` =>
+                if (target.isValidLocation(stepEvent.location)) {
+                  stop
+                  thread.suspendedFromScala(DebugEvent.STEP_INTO)
+                  true
+                } else {
+                  if (target.shouldNotStepInto(stepEvent.location)) {
+                    // don't step deeper into constructor from 'hidden' entities
+                    stepOutStackDepth = stepEvent.thread.frameCount
+                    stepIntoRequest.disable
+                    stepOutRequest.enable
+                  }
+                  false
+                }
+              case `stepOutRequest` =>
+                if (stepEvent.thread.frameCount == stackDepth && stepEvent.location.lineNumber != stackLine) {
+                  // we are back on the method, but on a different line, stopping the stepping
+                  stop
+                  thread.suspendedFromScala(DebugEvent.STEP_INTO)
+                  true
+                } else {
+                  // switch back to step into only if the step return has been effectively done.
+                  if (stepEvent.thread.frameCount < stepOutStackDepth) {
+                    // launch a new step into
+                    stepOutRequest.disable
+                    stepIntoRequest.enable
+                  }
+                  false
+                }
+            })
+          case ActorExit =>
+            exit
+        }
+      }
+    }
+  }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepReturn.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepReturn.scala
@@ -1,9 +1,7 @@
 package scala.tools.eclipse.debug.command
 
 import com.sun.jdi.event.Event
-import org.eclipse.jdt.internal.debug.core.model.JDIDebugTarget
 import com.sun.jdi.event.EventSet
-import org.eclipse.jdt.internal.debug.core.IJDIEventListener
 import scala.tools.eclipse.debug.model.ScalaStackFrame
 import com.sun.jdi.request.StepRequest
 import com.sun.jdi.request.EventRequest
@@ -11,6 +9,8 @@ import scala.tools.eclipse.debug.model.ScalaThread
 import scala.tools.eclipse.debug.model.ScalaDebugTarget
 import org.eclipse.debug.core.DebugEvent
 import com.sun.jdi.event.StepEvent
+import scala.actors.Actor
+import scala.tools.eclipse.debug.ActorExit
 
 object ScalaStepReturn {
 
@@ -27,48 +27,55 @@ object ScalaStepReturn {
 }
 
 // TODO: when implementing support without filtering, need to workaround problem reported in Eclipse bug #38744
-class ScalaStepReturn(target: ScalaDebugTarget, thread: ScalaThread, stepReturnRequest: StepRequest) extends IJDIEventListener with ScalaStep {
-
-  // Members declared in org.eclipse.jdt.internal.debug.core.IJDIEventListener
-
-  def eventSetComplete(event: Event, target: JDIDebugTarget, suspend: Boolean, eventSet: EventSet): Unit = {
-    // nothing to do
-  }
-
-  def handleEvent(event: Event, javaTarget: JDIDebugTarget, suspendVote: Boolean, eventSet: EventSet): Boolean = {
-    event match {
-      case stepEvent: StepEvent =>
-        if (target.isValidLocation(stepEvent.location)) {
-          stop
-          thread.suspendedFromScala(DebugEvent.STEP_RETURN)
-          false
-        } else {
-          true
-        }
-      case _ =>
-        suspendVote
-    }
-  }
+class ScalaStepReturn(target: ScalaDebugTarget, thread: ScalaThread, stepReturnRequest: StepRequest) extends ScalaStep {
 
   // Members declared in scala.tools.eclipse.debug.command.ScalaStep
 
   def step() {
-    val eventDispatcher = target.javaTarget.getEventDispatcher
+    val eventDispatcher = target.eventDispatcher
 
-    eventDispatcher.addJDIEventListener(this, stepReturnRequest)
+    eventDispatcher.setActorFor(eventActor, stepReturnRequest)
     stepReturnRequest.enable
     thread.resumedFromScala(DebugEvent.STEP_RETURN)
     thread.thread.resume
   }
 
   def stop() {
-    val eventDispatcher = target.javaTarget.getEventDispatcher
+    val eventDispatcher = target.eventDispatcher
 
     val eventRequestManager = thread.thread.virtualMachine.eventRequestManager
 
     stepReturnRequest.disable
-    eventDispatcher.removeJDIEventListener(this, stepReturnRequest)
+    eventDispatcher.unsetActorFor(stepReturnRequest)
     eventRequestManager.deleteEventRequest(stepReturnRequest)
+
+    eventActor ! ActorExit
+  }
+
+  // --------------------
+
+  /**
+   *  process the debug events
+   */  
+  val eventActor = new Actor {
+    start
+    def act() {
+      loop {
+        react {
+          case stepEvent: StepEvent =>
+            reply(
+              if (target.isValidLocation(stepEvent.location)) {
+                stop
+                thread.suspendedFromScala(DebugEvent.STEP_RETURN)
+                true
+              } else {
+                false
+              })
+          case ActorExit =>
+            exit
+        }
+      }
+    }
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
@@ -10,12 +10,24 @@ import com.sun.jdi.event.{ ThreadStartEvent, ThreadDeathEvent, EventSet, Event }
 import com.sun.jdi.request.{ ThreadStartRequest, ThreadDeathRequest, EventRequest }
 import com.sun.jdi.{ ReferenceType, Method, Location }
 import scala.actors.Actor
+import com.sun.jdi.VirtualMachine
+import org.eclipse.debug.core.model.IProcess
+import org.eclipse.debug.core.DebugPlugin
+import com.sun.jdi.request.VMDeathRequest
+import org.eclipse.debug.core.ILaunch
+import com.sun.jdi.event.VMDeathEvent
+import com.sun.jdi.event.VMDisconnectEvent
+import scala.tools.eclipse.debug.ScalaDebugBreakpointManager
+import com.sun.jdi.ThreadReference
+import com.sun.jdi.event.VMStartEvent
+import org.eclipse.debug.core.DebugEvent
+import org.eclipse.debug.core.sourcelookup.ISourceLookupDirector
+import scala.tools.eclipse.debug.ScalaSourceLookupParticipant
+import scala.tools.eclipse.logging.HasLogger
 
-object ScalaDebugTarget {
+object ScalaDebugTarget extends HasLogger {
 
-  def apply(javaTarget: JDIDebugTarget): ScalaDebugTarget = {
-
-    val virtualMachine = javaTarget.getVM
+  def apply(virtualMachine: VirtualMachine, launch: ILaunch, process: IProcess): ScalaDebugTarget = {
 
     val threadStartRequest = virtualMachine.eventRequestManager.createThreadStartRequest
     threadStartRequest.setSuspendPolicy(EventRequest.SUSPEND_NONE)
@@ -23,33 +35,25 @@ object ScalaDebugTarget {
     val threadDeathRequest = virtualMachine.eventRequestManager.createThreadDeathRequest
     threadDeathRequest.setSuspendPolicy(EventRequest.SUSPEND_NONE)
 
-    val target = new ScalaDebugTarget(javaTarget, threadStartRequest, threadDeathRequest)
+    val target = new ScalaDebugTarget(virtualMachine, launch, process, threadStartRequest, threadDeathRequest)
 
-    // enable the requests
-    javaTarget.addJDIEventListener(target, threadStartRequest)
-    threadStartRequest.enable
-    javaTarget.addJDIEventListener(target, threadDeathRequest)
-    threadDeathRequest.enable
+    launch.addDebugTarget(target)
+
+    launch.getSourceLocator match {
+      case sourceLookupDirector: ISourceLookupDirector =>
+        sourceLookupDirector.addParticipants(Array(ScalaSourceLookupParticipant))
+      case sourceLocator =>
+        logger.warn("unable to recognize source locator %s, cannot add Scala participant".format(sourceLocator))
+    }
+
+    target.initialize
 
     target
   }
 
 }
 
-class ScalaDebugTarget(val javaTarget: JDIDebugTarget, threadStartRequest: ThreadStartRequest, threadDeathRequest: ThreadDeathRequest) extends ScalaDebugElement(null) with IDebugTarget with IJDIEventListener {
-
-  // Members declared in org.eclipse.core.runtime.IAdaptable
-
-  override def getAdapter(adapter: Class[_]): Object = {
-    adapter match {
-      case ScalaDebugger.classIJavaDebugTarget =>
-        null
-      case ScalaDebugger.classIJavaStackFrame =>
-        null
-      case _ =>
-        super.getAdapter(adapter)
-    }
-  }
+class ScalaDebugTarget(val virtualMachine: VirtualMachine, launch: ILaunch, process: IProcess, threadStartRequest: ThreadStartRequest, threadDeathRequest: ThreadDeathRequest) extends ScalaDebugElement(null) with IDebugTarget {
 
   // Members declared in org.eclipse.debug.core.IBreakpointListener
 
@@ -60,12 +64,12 @@ class ScalaDebugTarget(val javaTarget: JDIDebugTarget, threadStartRequest: Threa
   // Members declared in org.eclipse.debug.core.model.IDebugElement
 
   override def getDebugTarget(): org.eclipse.debug.core.model.IDebugTarget = this
-  override def getLaunch(): org.eclipse.debug.core.ILaunch = javaTarget.getLaunch
+  override def getLaunch(): org.eclipse.debug.core.ILaunch = launch
 
   // Members declared in org.eclipse.debug.core.model.IDebugTarget
 
   def getName(): String = "Scala Debug Target" // TODO: need better name
-  def getProcess(): org.eclipse.debug.core.model.IProcess = javaTarget.getProcess
+  def getProcess(): org.eclipse.debug.core.model.IProcess = process
   def getThreads(): Array[org.eclipse.debug.core.model.IThread] = threads.toArray // TODO: handle through the actor?
   def hasThreads(): Boolean = !threads.isEmpty
   def supportsBreakpoint(x$1: org.eclipse.debug.core.model.IBreakpoint): Boolean = ???
@@ -93,56 +97,48 @@ class ScalaDebugTarget(val javaTarget: JDIDebugTarget, threadStartRequest: Threa
 
   override def canTerminate(): Boolean = running // TODO: need real logic
   override def isTerminated(): Boolean = !running // TODO: need real logic
-  override def terminate(): Unit = javaTarget.terminate
-
-  // Members declared in org.eclipse.jdt.internal.debug.core.IJDIEventListener
-
-  def eventSetComplete(event: Event, target: JDIDebugTarget, suspend: Boolean, eventSet: EventSet): Unit = {
-    // nothing to do
+  override def terminate(): Unit = {
+    virtualMachine.dispose
+    terminated
   }
 
-  def handleEvent(event: Event, target: JDIDebugTarget, suspendVote: Boolean, eventSet: EventSet): Boolean = {
-    event match {
-      case threadStartEvent: ThreadStartEvent =>
-        actor !? threadStartEvent
-      case threadDeathEvent: ThreadDeathEvent =>
-        actor !? threadDeathEvent
-      case _ =>
-        ???
-    }
-    suspendVote
-  }
-  
   // event handling actor
-  
-  case object TerminatedFromJava
-  
-  case class ThreadSuspendedFromJava(thread: JDIThread, eventDetail: Int)
-  
-  class EventActor extends Actor {
+
+  case class ThreadSuspended(thread: ThreadReference, eventDetail: Int)
+
+  val eventActor= new Actor {
 
     start
 
     def act() {
       loop {
         react {
+          case _: VMStartEvent =>
+            started
+            reply(false)
           case threadStartEvent: ThreadStartEvent =>
             if (!threads.exists(_.thread == threadStartEvent.thread))
               threads = threads :+ new ScalaThread(ScalaDebugTarget.this, threadStartEvent.thread)
-            reply(this)
+            reply(false)
+            fireChangeEvent(DebugEvent.CONTENT)
           case threadDeathEvent: ThreadDeathEvent =>
             val (removed, remainder) = threads.partition(_.thread == threadDeathEvent.thread)
             threads = remainder
             removed.foreach(_.terminatedFromScala)
-            reply(this)
-          case ThreadSuspendedFromJava(thread, eventDetail) =>
-            threads.find(_.thread == thread.getUnderlyingThread).get.suspendedFromJava(eventDetail)
-            reply(this)
-          case TerminatedFromJava =>
-            threads = Nil
-            running = false
-            fireTerminateEvent
+            reply(false)
+            fireChangeEvent(DebugEvent.CONTENT)
+          case _: VMDeathEvent =>
+            terminated
+            reply(false)
             exit
+          case _: VMDisconnectEvent =>
+            terminated
+            reply(false)
+            exit
+          case ThreadSuspended(thread, eventDetail) =>
+            // forward the event to the right thread
+            threads.find(_.thread == thread).get.suspendedFromScala(eventDetail)
+            reply(None)
         }
       }
     }
@@ -151,32 +147,62 @@ class ScalaDebugTarget(val javaTarget: JDIDebugTarget, threadStartRequest: Threa
   // ---
 
   var running: Boolean = true
-  
-  val actor = new EventActor
 
-  var threads = {
-    import scala.collection.JavaConverters._
-    javaTarget.getVM.allThreads.asScala.toList.map(new ScalaThread(this, _))
-  }
+  val eventDispatcher= new ScalaJdiEventDispatcher(virtualMachine, eventActor)
+
+  val breakpointManager = new ScalaDebugBreakpointManager(this)
+
+  var threads = List[ScalaThread]()
 
   fireCreationEvent
 
-  def javaThreadSuspended(thread: JDIThread, eventDetail: Int) {
-    actor !? ThreadSuspendedFromJava(thread, eventDetail)
+  def initialize = {
+    // start the event dispatcher thread
+    DebugPlugin.getDefault.asyncExec(new Runnable() {
+      def run() {
+        val thread = new Thread(eventDispatcher, "Scala debugger JDI event dispatcher")
+        thread.setDaemon(true)
+        thread.start
+      }
+    })
   }
 
-  def terminatedFromJava() {
-    actor ! TerminatedFromJava
+  def started() {
+    import scala.collection.JavaConverters._
+    // enable the thread management requests
+    eventDispatcher.setActorFor(eventActor, threadStartRequest)
+    threadStartRequest.enable
+    eventDispatcher.setActorFor(eventActor, threadDeathRequest)
+    threadDeathRequest.enable
+    // get the current requests
+    threads = virtualMachine.allThreads.asScala.toList.map(new ScalaThread(this, _))
+
+    breakpointManager.init()
+
+    fireChangeEvent(DebugEvent.CONTENT)
+  }
+
+  def terminated() {
+    running = false
+    eventDispatcher.dispose()
+    breakpointManager.dispose()
+    threads.foreach{_.dispose}
+    threads = Nil
+    fireTerminateEvent
+  }
+
+  def threadSuspended(thread: ThreadReference, eventDetail: Int) {
+    eventActor !? ThreadSuspended(thread, eventDetail)
   }
 
   /**
-   * Return the method containing the actual code of the anon func, if it is contained 
+   * Return the method containing the actual code of the anon func, if it is contained
    * in the given range, <code>None</code> otherwise.
    */
   def anonFunctionsInRange(refType: ReferenceType, range: Range): Option[Method] = {
     findAnonFunction(refType).filter(method => range.contains(method.location.lineNumber))
   }
-  
+
   /**
    * Return the method containing the actual code of the anon func.
    * Return <code>None</code> if no method can be identified has being it.
@@ -194,11 +220,11 @@ class ScalaDebugTarget(val javaTarget: JDIDebugTarget, threadStartRequest: Threa
         // this is more complex.
         // the compiler may have 'forgotten' to flag the 'apply' as a bridge method,
         // or both the 'apply' and the 'apply$__$sp' contains the actual code
-        
+
         // if the 'apply' and the 'apply$__$sp' contains the same code, we are in the optimization case, the 'apply' method
         // will be used, otherwise, the 'apply$__$sp" will be used.
-        val applyMethod= methods.find(_.name == "apply")
-        val applySpMethod= methods.find(_.name.startsWith("apply$"))
+        val applyMethod = methods.find(_.name == "apply")
+        val applySpMethod = methods.find(_.name.startsWith("apply$"))
         if (applyMethod.isDefined) {
           if (applySpMethod.isDefined) {
             if (applyMethod.get.bytecodes.sameElements(applySpMethod.get.bytecodes)) {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaJdiEventDispatcher.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaJdiEventDispatcher.scala
@@ -1,0 +1,171 @@
+package scala.tools.eclipse.debug.model
+
+import com.sun.jdi.VirtualMachine
+import scala.actors.Actor
+import com.sun.jdi.request.EventRequest
+import scala.tools.eclipse.logging.HasLogger
+import com.sun.jdi.event.EventSet
+import com.sun.jdi.event.Event
+import scala.actors.Future
+import com.sun.jdi.VMDisconnectedException
+import com.sun.jdi.event.VMDisconnectEvent
+import com.sun.jdi.event.VMDeathEvent
+import com.sun.jdi.event.VMStartEvent
+import scala.tools.eclipse.debug.ActorExit
+
+case class SetActorFor(actor: Actor, request: EventRequest)
+case class UnsetActorFor(request: EventRequest)
+
+/**
+ * Actor based system pulling event from the vm event queue, and dispatching
+ * them to the registered actors
+ */
+class ScalaJdiEventDispatcher(virtualMachine: VirtualMachine, scalaDebugTargetActor: Actor) extends Runnable with HasLogger {
+
+  var running = true
+
+  def run() {
+    // the polling loop
+    val eventQueue = virtualMachine.eventQueue
+    while (running) {
+      try {
+        // use a timeout of 1s, so it cleaning terminate on shut down
+        val eventSet = eventQueue.remove(1000)
+        if (eventSet != null) {
+          eventActor ! eventSet
+        }
+      } catch {
+        case e: VMDisconnectedException =>
+          logger.error("Error in jdi event loop", e)
+          running = false
+        case e =>
+          logger.error("Error in jdi event loop", e)
+      }
+    }
+  }
+
+  val eventActor= new Actor {
+    start
+
+    /**
+     * event request to actor map
+     */
+    var eventActorMap = Map[EventRequest, Actor]()
+
+    def act() {
+      loop {
+        react {
+          case SetActorFor(actor, request) =>
+            setActorFor_(actor, request)
+          case UnsetActorFor(request) =>
+            unsetActorFor_(request)
+          case eventSet: EventSet =>
+            processEventSet(eventSet)
+          case ActorExit =>
+            exit
+        }
+      }
+    }
+
+    /**
+     * store the actor for the request
+     */
+    def setActorFor_(actor: Actor, request: EventRequest) {
+      eventActorMap += (request -> actor)
+    }
+
+    /**
+     * clear the actor for the request
+     */
+    def unsetActorFor_(request: EventRequest) {
+      eventActorMap -= request
+    }
+
+    /**
+     * go through the events of the EventSet, and forward them to the registered
+     * actors.
+     * Resume or not the stopped thread depending on actor's answers
+     */
+    def processEventSet(eventSet: EventSet) {
+      var staySuspended = false
+
+      import scala.collection.JavaConverters._
+
+      var futures = List[Future[Boolean]]()
+
+      def addToFutures(future: Future[Any]): Unit = {
+        futures ::= future.asInstanceOf[Future[Boolean]]
+      }
+
+      /* Cannot use the eventSet directly. The JDI specification says it should implement java.util.Set,
+       * but the eclipse implementation doesn't.
+       * 
+       * see eclipse bug #383625 */
+      eventSet.eventIterator.asScala.foreach {
+        case event: VMStartEvent =>
+          logger.debug("Processing event: %s".format(event))
+          addToFutures(scalaDebugTargetActor !! event)
+        case event: VMDisconnectEvent =>
+          logger.debug("Processing event: %s".format(event))
+          running = false
+          addToFutures(scalaDebugTargetActor !! event)
+        case event: VMDeathEvent =>
+          logger.debug("Processing event: %s".format(event))
+          running = false
+          addToFutures(scalaDebugTargetActor !! event)
+        case event =>
+          val interestedActor = eventActorMap.get(event.request)
+          logger.debug("Processing event: %s for %s".format(event, interestedActor))
+          if (interestedActor.isDefined) {
+            addToFutures(interestedActor.get !! event)
+          }
+      }
+
+      /**
+       * wait for the answers of the actors and resume
+       * the threads if needed
+       */
+      val it = futures.iterator
+      loopWhile(it.hasNext) {
+        val future = it.next
+        future.inputChannel.react {
+          case result: Boolean =>
+            staySuspended |= result
+        }
+      }.andThen {
+        if (!staySuspended) {
+          eventSet.resume
+        }
+        this ! None
+      }
+
+      react {
+        case None =>
+      }
+    }
+  }
+
+  /**
+   * release all resources
+   */
+  def dispose() {
+    running = false
+    eventActor ! ActorExit
+  }
+
+  /**
+   * Register the actor as recipient of the call back for the given request
+   */
+  def setActorFor(actor: Actor, request: EventRequest) {
+    eventActor ! SetActorFor(actor, request)
+  }
+
+  /**
+   * Remove the call back target for the given request
+   */
+  def unsetActorFor(request: EventRequest) {
+    eventActor ! UnsetActorFor(request)
+  }
+
+}
+

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/ScalaApplicationLaunchConfigurationDelegate.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/ScalaApplicationLaunchConfigurationDelegate.scala
@@ -1,0 +1,19 @@
+package scala.tools.eclipse.launching
+
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.debug.core.model.LaunchConfigurationDelegate
+import org.eclipse.debug.core.ILaunch
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.jdt.launching.IVMRunner
+
+/**
+ * Launch configuration delegate starting Scala applications with the Scala debugger.
+ */
+class ScalaApplicationLaunchConfigurationDelegate extends ScalaLaunchDelegate {
+
+  override def getVMRunner(configuration: ILaunchConfiguration, mode: String): IVMRunner = {
+    val vm = verifyVMInstall(configuration);
+    new StandardVMScalaDebugger(vm)
+  }
+
+}

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/StandardVMScalaDebugger.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/StandardVMScalaDebugger.scala
@@ -1,0 +1,22 @@
+package scala.tools.eclipse.launching
+
+import org.eclipse.jdt.internal.launching.StandardVMDebugger
+import org.eclipse.jdt.launching.IVMInstall
+import org.eclipse.jdt.launching.VMRunnerConfiguration
+import org.eclipse.debug.core.ILaunch
+import com.sun.jdi.VirtualMachine
+import org.eclipse.debug.core.model.IProcess
+import org.eclipse.debug.core.model.IDebugTarget
+import scala.tools.eclipse.debug.model.ScalaDebugTarget
+
+/**
+ * Launcher for debug Scala applications using the Scala debugger.
+ * Extends the Java debugger launcher, but use the Scala debug model instead of the Java one.
+ */
+class StandardVMScalaDebugger(vm: IVMInstall) extends StandardVMDebugger(vm) {
+  
+  override def createDebugTarget(configuration: VMRunnerConfiguration, launch: ILaunch, port: Int, process: IProcess, virtualMachine: VirtualMachine): IDebugTarget = {
+    ScalaDebugTarget(virtualMachine, launch, process)
+  }
+
+}


### PR DESCRIPTION
Reworked the Scala debugger so it doesn't use the JDT debugger to
communicate with the VM.
A new launch delegate is added to the Scala application launch configuration type.
It creates a ScalaDebugTarget from the JDI connection to the vm.
Added a breakpoint manager, to create and delete the JDI requests needed.
Added a JDI event dispatcher, to pull the events from the JDI event queue and forwarding
them to the interested parties.
The management of the events is base on Scala actors.

The pull request for the documentation update is https://github.com/scala-ide/docs/pull/21
