### PR TITLE
Make standard output/error redirection optional.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
@@ -218,6 +218,17 @@ class ScalaPlugin extends AbstractUIPlugin with PluginLogConfigurator with IReso
     }
   }
   
+  /** Restart all presentation compilers in the workspace. Need to do it in order
+   *  for them to pick up the new std out/err streams.
+   */
+  def resetAllPresentationCompilers() {
+    for {
+      iProject <- ResourcesPlugin.getWorkspace.getRoot.getProjects
+      if iProject.isOpen
+      scalaProject <- asScalaProject(iProject)
+    } scalaProject.resetPresentationCompiler()
+  }
+
   /**
    * Return Some(ScalaProject) if the project has the Scala nature, None otherwise.
    */

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/logging/StreamRedirect.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/logging/StreamRedirect.scala
@@ -16,6 +16,7 @@ private[logging] object StreamRedirect {
       val logger = LogManager.getLogger("System.out")
       val outStream = redirect(msg => logger.debug(msg))
       System.setOut(outStream)
+      Console.setOut(outStream)
       isStdOutRedirected = true
     }
   }
@@ -23,6 +24,7 @@ private[logging] object StreamRedirect {
   def disableRedirectStdOutput(): Unit = synchronized {
     if(isStdOutRedirected) {
       System.setOut(defaultStdOut)
+      Console.setOut(defaultStdOut)
       isStdOutRedirected = false
     }
   }
@@ -32,6 +34,7 @@ private[logging] object StreamRedirect {
       val logger = LogManager.getLogger("System.err")
       val errStream = redirect(msg => logger.error(msg))
       System.setErr(errStream)
+      Console.setErr(errStream)
       isStdErrRedirected = true
     }
   }
@@ -39,6 +42,7 @@ private[logging] object StreamRedirect {
   def disableRedirectStdError(): Unit = synchronized {
     if(isStdErrRedirected) {
       System.setErr(defaultStdErr)
+      Console.setErr(defaultStdErr)
       isStdErrRedirected = false
     }
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/logging/ui/properties/LoggingPreferenceConstants.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/logging/ui/properties/LoggingPreferenceConstants.scala
@@ -4,4 +4,5 @@ private[logging] object LoggingPreferenceConstants {
   private final val Prefix = "scala.tools.eclipse.logging.ui.properties."
   final val LogLevel = Prefix + "LogLevel"
   final val IsConsoleAppenderEnabled = Prefix + "ConsoleAppenderEnabled"
+  final val RedirectStdErrOut = Prefix + "RedirectSdtErrOut"
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/logging/ui/properties/LoggingPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/logging/ui/properties/LoggingPreferencePage.scala
@@ -28,6 +28,7 @@ class LoggingPreferencePage extends FieldEditorPreferencePage with IWorkbenchPre
     
     addField(new ComboFieldEditor(LoggingPreferenceConstants.LogLevel, "Log Level", namesAndValues, getFieldEditorParent))
     addField(new BooleanFieldEditor(LoggingPreferenceConstants.IsConsoleAppenderEnabled, "Output log in terminal", getFieldEditorParent))
+    addField(new BooleanFieldEditor(LoggingPreferenceConstants.RedirectStdErrOut, "Redirect standard out/err to log file", getFieldEditorParent))
   }
 
   override def createContents(parent: Composite): Control = {
@@ -49,10 +50,12 @@ class LoggingPreferencePageInitializer extends AbstractPreferenceInitializer {
     if(ScalaPlugin.plugin.headlessMode) {
       store.setDefault(LoggingPreferenceConstants.LogLevel, Level.DEBUG.toString)
       store.setDefault(LoggingPreferenceConstants.IsConsoleAppenderEnabled, true)
+      store.setDefault(LoggingPreferenceConstants.RedirectStdErrOut, false)
     } 
     else {
       store.setDefault(LoggingPreferenceConstants.LogLevel, LogManager.defaultLogLevel.toString)
       store.setDefault(LoggingPreferenceConstants.IsConsoleAppenderEnabled, false)
+      store.setDefault(LoggingPreferenceConstants.RedirectStdErrOut, true)
     }
   }
 }


### PR DESCRIPTION
By default, std out and error are redirected to the log file. This makes it
difficult to do println debugging, and often each printed character ends up
on a separate line in the log file. This PR makes it an option.

Fixes #1001133
