### PR TITLE
New option for Organize Imports to always omit/prepend the scala package

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/OrganizeImportsPreferences.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/OrganizeImportsPreferences.scala
@@ -19,6 +19,7 @@ import scala.tools.eclipse.ScalaPlugin
 import org.eclipse.jface.preference.RadioGroupFieldEditor
 import org.eclipse.jface.preference.FieldEditor
 import scala.tools.eclipse.util.Utils
+import org.eclipse.jface.preference.BooleanFieldEditor
 
 
 
@@ -130,6 +131,7 @@ class OrganizeImportsPreferencesPage extends PropertyPage with IWorkbenchPrefere
       )
       new RadioGroupFieldEditor(expandCollapseKey, "Multiple imports from the same package or type:", 1, options, parent, true) {
         allEnableDisableControls += getRadioBoxControl(parent)
+        allEnableDisableControls ++= getRadioBoxControl(parent).getChildren
       }
     }
     
@@ -155,6 +157,12 @@ class OrganizeImportsPreferencesPage extends PropertyPage with IWorkbenchPrefere
             null
           }
         }
+      }
+    }
+    
+    fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent => 
+      new BooleanFieldEditor(omitScalaPackage, "Omit the scala package prefix", parent) {
+        allEnableDisableControls += getChangeControl(parent)
       }
     }
 
@@ -190,6 +198,8 @@ object OrganizeImportsPreferences extends Enumeration {
   val groupsKey         = PREFIX +".groups"
   val wildcardsKey      = PREFIX +".wildcards"
   val expandCollapseKey = PREFIX +".expandcollapse"
+  
+  val omitScalaPackage = PREFIX +".scalapackage"
 
   private def getPreferenceStore(project: IProject): IPreferenceStore = {
     val workspaceStore = ScalaPlugin.prefStore
@@ -201,6 +211,10 @@ object OrganizeImportsPreferences extends Enumeration {
   
   def getGroupsForProject(project: IProject) = {
     getPreferenceStore(project).getString(groupsKey).split("\\$")
+  }
+  
+  def shouldOmitScalaPackage(project: IProject) = {
+    getPreferenceStore(project).getBoolean(omitScalaPackage)
   }
   
   def getWildcardImportsForProject(project: IProject) = {
@@ -223,6 +237,7 @@ class OrganizeImportsPreferencesInitializer extends AbstractPreferenceInitialize
     
     Utils.tryExecute {
       val node = new DefaultScope().getNode(ScalaPlugin.plugin.pluginId)
+      node.put(OrganizeImportsPreferences.omitScalaPackage, "false")      
       node.put(OrganizeImportsPreferences.groupsKey, "java$scala$org$com")      
       node.put(OrganizeImportsPreferences.wildcardsKey, "scalaz$scalaz.Scalaz")      
       node.put(OrganizeImportsPreferences.expandCollapseKey, OrganizeImportsPreferences.ExpandImports.toString)      

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
@@ -20,7 +20,7 @@ import org.eclipse.jface.action.IAction
 import org.eclipse.jface.window.Window
 
 import scala.tools.eclipse.javaelements.{ScalaSourceFile, ScalaElement, LazyToplevelClass}
-import scala.tools.eclipse.properties.OrganizeImportsPreferences.{getWildcardImportsForProject, getOrganizeImportStrategy, getGroupsForProject, PreserveExistingGroups, ExpandImports, CollapseImports}
+import scala.tools.eclipse.properties.OrganizeImportsPreferences._
 import scala.tools.refactoring.implementations.{OrganizeImports, AddImportStatement}
 
 /**
@@ -241,7 +241,13 @@ class OrganizeImportsAction extends RefactoringAction with ActionWithNoWizard {
         
         val groups = getGroupsForProject(project).toList
         
-        expandOrCollapse ::: List(wildcards, refactoring.SortImports, refactoring.GroupImports(groups))
+        val scalaPackageStrategy = if (shouldOmitScalaPackage(project)){
+          refactoring.DropScalaPackage
+        } else {
+          refactoring.PrependScalaPackage
+        }
+        
+        expandOrCollapse ::: List(scalaPackageStrategy, wildcards, refactoring.SortImports, refactoring.GroupImports(groups))
       }
       
       val deps = {


### PR DESCRIPTION
The default value is set to false, but that's up for discussion, as is the naming of the setting in the UI.

Fixes #1001127
