### PR TITLE
Correct indexing of method references for methods definition that take default arguments 

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTester.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTester.scala
@@ -15,7 +15,7 @@ trait FindReferencesTester {
 
   case class Method(fullName: String) extends Element
   object Method {
-    def apply(fullName: String, args: List[String]): Method = Method(fullName + args.mkString("(", "'", ")"))
+    def apply(fullName: String, args: List[String]): Method = Method(fullName + args.mkString("(", ", ", ")"))
   }
   case class FieldVar(fullName: String) extends Element
   case class FieldVal(fullName: String) extends Element

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTests.scala
@@ -108,13 +108,13 @@ class FindReferencesTests extends FindReferencesTester with HasLogger {
 
   private def jdtElement2testElement(e: JavaElement): Element = {
     val testElement: String => Element = e match {
-      case e: ScalaDefElement => Method.apply _
-      case e: ScalaVarElement => FieldVar.apply _
-      case e: ScalaValElement => FieldVal.apply _
-      case e: ScalaClassElement => Clazz.apply _
-      case e: ScalaTypeElement => TypeAlias.apply _
+      case e: ScalaDefElement    => Method.apply _
+      case e: ScalaVarElement    => FieldVar.apply _
+      case e: ScalaValElement    => FieldVal.apply _
+      case e: ScalaClassElement  => Clazz.apply _
+      case e: ScalaTypeElement   => TypeAlias.apply _
       case e: ScalaModuleElement => Module.apply _
-      case e: SourceType => Clazz.apply _
+      case e: SourceType         => Clazz.apply _
       case _ =>
         val msg = "Don't know how to convert element `%s` of type `%s`".format(e.getElementName, e.getClass)
         throw new IllegalArgumentException(msg)
@@ -184,10 +184,22 @@ class FindReferencesTests extends FindReferencesTester with HasLogger {
     val expected = method("foo.Bar$.configure", List("java.lang.String")) isReferencedBy method("foo.Foo.configure")
     runTest("bug1001135", "foo/Bar.scala", expected)
   }
-  
+
   @Test
   def findReferencesInClassFields() {
     val expected = fieldVal("Bar$.v") isReferencedBy fieldVal("Foo.v")
     runTest("field-ref", "Bar.scala", expected)
+  }
+
+  @Test
+  def findReferencesOfCurriedMethod_bug1001146() {
+    val expected = method("util.EclipseUtils$.workspaceRunnableIn", List("java.lang.String", "java.lang.Object", "scala.Function1<java.lang.Object,scala.runtime.BoxedUnit>")) isReferencedBy method("util.FileUtils$.foo")
+    runTest("bug1001146", "util/EclipseUtils.scala", expected)
+  }
+
+  @Test
+  def findReferencesOfMethodDeclaredWithDefaultArgs_bug1001146_1() {
+    val expected = method("util.EclipseUtils$.workspaceRunnableIn", List("java.lang.String", "java.lang.Object", "scala.Function1<java.lang.Object,scala.runtime.BoxedUnit>")) isReferencedBy method("util.FileUtils$.foo")
+    runTest("bug1001146_1", "util/EclipseUtils.scala", expected)
   }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146/src/util/EclipseUtils.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146/src/util/EclipseUtils.scala
@@ -1,0 +1,5 @@
+package util
+
+object EclipseUtils {
+  def workspaceRunnableIn/*ref*/(s: String, t: Any = null)(f: Any => Unit): Unit = ()
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146/src/util/FileUtils.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146/src/util/FileUtils.scala
@@ -1,0 +1,9 @@
+package util
+
+import util.EclipseUtils._
+
+object FileUtils {
+  def foo() {
+    workspaceRunnableIn("", null) { m => () }
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146_1/src/util/EclipseUtils.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146_1/src/util/EclipseUtils.scala
@@ -1,0 +1,5 @@
+package util
+
+object EclipseUtils {
+  def workspaceRunnableIn/*ref*/(s: String, t: Any = null)(f: Any => Unit): Unit = ()
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146_1/src/util/FileUtils.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/bug1001146_1/src/util/FileUtils.scala
@@ -1,0 +1,9 @@
+package util
+
+import util.EclipseUtils._
+
+object FileUtils {
+  def foo() {
+    workspaceRunnableIn("") { m => () }
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -32,7 +32,9 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
         lazy val methName = meth.getElementName
         lazy val symName = (if(sym.isConstructor) sym.owner.simpleName.toString + (if (sym.owner.isModuleClass) "$" else "") else sym.name.toString)
         lazy val sameName = methName == symName
-        lazy val sameParams = meth.getParameterTypes.map(tp => getTypeErasure(getElementType(tp))).sameElements(sym.tpe.paramTypes.map(mapParamTypeSignature))
+        lazy val methParamsTpe = meth.getParameterTypes.map(tp => getTypeErasure(getElementType(tp)))
+        lazy val symParamsTpe = sym.paramss.flatten.map(param => mapParamTypeSignature(param.tpe))
+        lazy val sameParams = methParamsTpe.sameElements(symParamsTpe)
         sameName && sameParams
       }.getOrElse(false)
     }
@@ -138,9 +140,6 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
     
     jdtMods
   }
-  
-  /** Returns the fully-qualified name for the passed type tree*/ 
-  def mapType(typeTree: Tree): String = mapType(typeTree.symbol)
 
   /** Returns the fully-qualified name for the passed symbol (it expects the symbol to be a type).*/
   def mapType(s: Symbol): String = mapType(s, javaClassName(_))


### PR DESCRIPTION
Correctly index method references for methods definition that take default arguments

Fix #1001146
