### PR TITLE
Fixed warnings.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -150,7 +150,7 @@ class ScalaPresentationCompiler(project : ScalaProject, settings : Settings)
             eclipseLog.error("Error during askOption", e)
             None
         }
-      case e =>
+      case e: Throwable =>
         eclipseLog.error("Error during askOption", e)
         None
     }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -59,7 +59,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
           failedCompilerInitialization("could not find a required class: " + required)
           eclipseLog.error(ex)
           None
-        case ex =>
+        case ex: Throwable =>
           logger.info("Throwable when intializing presentation compiler!!! " + ex.getMessage)
           ex.printStackTrace()
           if (underlying.isOpen)
@@ -306,13 +306,13 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
               try {
                 cntnr.delete(true, monitor) // might not work.
               } catch {
-                case _ =>
+                case _: Exception =>
                   delete(cntnr, deleteDirs)(f)
                   if (deleteDirs)
                     try {
                       cntnr.delete(true, monitor) // try again
                     } catch {
-                      case t => eclipseLog.error(t)
+                      case t: Exception => eclipseLog.error(t)
                     }
               }
             } else
@@ -321,7 +321,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
             try {
               file.delete(true, monitor)
             } catch {
-              case t => eclipseLog.error(t)
+              case t: Exception => eclipseLog.error(t)
             }
           case _ =>
         }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/RunSelectionAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/RunSelectionAction.scala
@@ -9,6 +9,7 @@ import org.eclipse.ui.IWorkbenchWindow
 import org.eclipse.ui.IWorkbenchWindowActionDelegate
 import org.eclipse.ui.IFileEditorInput
 import interpreter.ReplConsoleView
+import util.Utils._
 
 class RunSelectionAction extends ActionDelegate with IWorkbenchWindowActionDelegate {
   var workbenchWindow: IWorkbenchWindow = null
@@ -16,20 +17,13 @@ class RunSelectionAction extends ActionDelegate with IWorkbenchWindowActionDeleg
   def init(window: IWorkbenchWindow) {
     workbenchWindow = window
   }
-     
-  def doCast[T](obj: Any): Option[T] = {
-    obj match {
-      case t: T => Some(t)
-      case _ => None
-    }
-  }
-  
+
   override def run(action: IAction) {
 
     for (editor <- Option(workbenchWindow.getActivePage.getActiveEditor);
-        input <- doCast[IFileEditorInput](editor.getEditorInput);
-        textEditor <- doCast[ITextEditor](editor);
-        selection <- doCast[ITextSelection](textEditor.getSelectionProvider.getSelection)) 
+        input <- editor.getEditorInput.asInstanceOfOpt[IFileEditorInput];
+        textEditor <- editor.asInstanceOfOpt[ITextEditor];
+        selection <- textEditor.getSelectionProvider.getSelection.asInstanceOfOpt[ITextSelection]) 
     {
       val project = input.getFile.getProject
       var text = selection.getText

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/refined/EclipseRefinedBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/refined/EclipseRefinedBuildManager.scala
@@ -79,7 +79,7 @@ class EclipseRefinedBuildManager(project: ScalaProject, settings0: Settings)
     try {
       super.update(toBuild, removedFiles)
     } catch {
-      case e =>
+      case e: Throwable =>
         hasErrors = true
         BuildProblemMarker.create(project, e)
         eclipseLog.error("Error in Scala compiler", e)
@@ -145,7 +145,7 @@ class EclipseRefinedBuildManager(project: ScalaProject, settings0: Settings)
     else {
       try {
         !loadFrom(EclipseResource(depFile), EclipseResource.fromString(_).getOrElse(null))
-      } catch { case _ => true }
+      } catch { case _: Throwable => true }
     }
   }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/AnalysisCompile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/AnalysisCompile.scala
@@ -162,7 +162,7 @@ class AnalysisCompile(conf: BasicConfiguration, bm: EclipseSbtBuildManager, cont
         reporter.log(SbtConverter.convertToSbt(NoPosition), "could not find a required class (incomplete classpath?): " + required, xsbti.Severity.Error)
         null
 
-      case ex =>
+      case ex: Throwable =>
         eclipseLog.error("Crash in the build compiler.", ex)
         reporter.log(SbtConverter.convertToSbt(NoPosition), "The SBT builder crashed while compiling your project. This is a bug in the Scala compiler or SBT. Check the Erorr Log for details. The error message is: " + ex.getMessage(), xsbti.Severity.Error)
         null

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
@@ -240,7 +240,7 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
     try {
       update(toBuild, removedFiles)
     } catch {
-      case e =>
+      case e: Throwable =>
         hasErrors = true
         BuildProblemMarker.create(project, e)
         eclipseLog.error("Error in Scala compiler", e)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/hyperlink/text/detector/DeclarationHyperlinkDetector.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/hyperlink/text/detector/DeclarationHyperlinkDetector.scala
@@ -11,8 +11,9 @@ import scala.tools.eclipse.ScalaWordFinder
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.eclipse.javaelements.ScalaSelectionEngine
 import scala.tools.eclipse.javaelements.ScalaSelectionRequestor
+import scala.tools.eclipse.logging.HasLogger
 
-class DeclarationHyperlinkDetector extends BaseHyperlinkDetector {
+class DeclarationHyperlinkDetector extends BaseHyperlinkDetector with HasLogger {
 
   private val resolver: ScalaDeclarationHyperlinkComputer = new ScalaDeclarationHyperlinkComputer
 
@@ -39,7 +40,9 @@ class DeclarationHyperlinkDetector extends BaseHyperlinkDetector {
       lazy val openAction = new OpenAction(textEditor.asInstanceOf[JavaEditor])
       elements.map(new JavaElementHyperlink(wordRegion, openAction, _, qualify))
     } catch {
-      case _ => List[IHyperlink]()
+      case t: Throwable => 
+        logger.debug("Exception while computing hyperlink", t)
+        Nil
     }
   }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/EclipseRepl.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/EclipseRepl.scala
@@ -250,7 +250,7 @@ class EclipseRepl(client: Client, builder: Builder) extends Actor
     val b = new BAOS
     Console.withOut(b) { Console.withErr(b) {
       try work(r, b)
-      catch { case t =>
+      catch { case t: Throwable =>
         try {
           val o = b.toString ; b.reset()
           client.failed(r, t, o)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
@@ -132,7 +132,7 @@ trait ScalaCompilationUnit extends Openable with env.ICompilationUnit with Scala
           new compiler.IndexBuilderTraverser(indexer).traverse(tree)
         }
       } catch {
-        case ex => handleCrash("Compiler crash during indexing of %s".format(getResource()), ex)
+        case ex: Throwable => handleCrash("Compiler crash during indexing of %s".format(getResource()), ex)
       }
     }
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaOverrideIndicatorBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaOverrideIndicatorBuilder.scala
@@ -76,7 +76,7 @@ trait ScalaOverrideIndicatorBuilder { self : ScalaPresentationCompiler =>
               } else annotationMap.put(ScalaIndicator(scu, text, base, isOverwrite), position)
             }
           } catch {
-            case ex => eclipseLog.error("Error creating override indicators for %s".format(scu.file.path), ex) 
+            case ex: Throwable => eclipseLog.error("Error creating override indicators for %s".format(scu.file.path), ex) 
           }
         case _ =>
       }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSourceFile.scala
@@ -20,6 +20,7 @@ import scala.tools.eclipse.util.EclipseFile
 import org.eclipse.jdt.core.compiler.CharOperation
 import scala.tools.nsc.interactive.Response
 import scala.tools.eclipse.reconciliation.ReconciliationParticipantsExtensionPoint
+import org.eclipse.jdt.core.JavaModelException
 
 object ScalaSourceFile {
   val handleFactory = new HandleFactory
@@ -87,7 +88,7 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
   override def getProblemRequestor = getPerWorkingCopyInfo
 
   override lazy val file : AbstractFile = { 
-    val res = try { getCorrespondingResource } catch { case _ => null }
+    val res = try { getCorrespondingResource } catch { case _: JavaModelException => null }
     res match {
       case f : IFile => new EclipseFile(f)
       case _ => new VirtualFile(getElementName, getPath.toString)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
@@ -888,7 +888,7 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
                 case cpos => cpos.startOrPoint
               }
             } catch {
-              case _ => pos0.startOrPoint
+              case _: Exception => pos0.startOrPoint
             }
           (start0, pos0.endOrPoint-1)
         }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
@@ -227,7 +227,7 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
     buildIfNecessary()
     true
   } catch {
-    case ex => eclipseLog.error(ex); false
+    case ex: Throwable => eclipseLog.error(ex); false
   }
 
   //Make sure apply button isn't available until it should be

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaPreferences.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaPreferences.scala
@@ -65,7 +65,7 @@ class ScalaPreferences extends PropertyPage with IWorkbenchPreferencePage with E
     save()
     true
   } catch {
-    case ex => eclipseLog.error(ex); false
+    case ex: Throwable => eclipseLog.error(ex); false
   }
   
   def updateApply = updateApplyButton

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ImportCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ImportCompletionProposal.scala
@@ -28,7 +28,7 @@ case class ImportCompletionProposal(val importName: String) extends IJavaComplet
     try {
       applyByASTTransformation(document)
     } catch {
-      case t => {
+      case t: Exception => {
         eclipseLog.error("failed to update import by AST transformation, fallback to text implementation", t)
         applyByTextTransformation(document)
       }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractLocalAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractLocalAction.scala
@@ -67,7 +67,7 @@ class ExtractLocalAction extends RefactoringAction {
             runRefactoring(createWizardForRefactoring(Some(r)), shell)
         }
         
-      case None => runRefactoring(createWizardForRefactoring(None), shell)
+      case _ => runRefactoring(createWizardForRefactoring(None), shell)
     }
   }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassification.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassification.scala
@@ -127,7 +127,7 @@ class SymbolClassification(protected val sourceFile: SourceFile, val global: Sca
         case rangePosition: RangePosition => Region(rangePosition.start, rangePosition.end - rangePosition.start)
       }
     catch {
-      case e => None
+      case e: Exception => None
     }
 
   private def getSymbolInfosFromSyntax(syntacticInfo: SyntacticInfo, localVars: Set[Region], all: Set[Region]): List[SymbolInfo] = {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaIndenter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaIndenter.scala
@@ -27,6 +27,8 @@ import scala.tools.eclipse.ScalaPlugin
 import scala.tools.eclipse.formatter.FormatterPreferences
 import scalariform.formatter.preferences.IndentSpaces
 
+import scala.util.control.Exception
+
 // TODO Move this out into a new file
 trait PreferenceProvider {
   private val preferences = Map.empty[String, String]
@@ -275,13 +277,9 @@ class ScalaIndenter(
     DefaultCodeFormatterConstants.NEXT_LINE_SHIFTED.equals(getCoreFormatterOption(DefaultCodeFormatterConstants.FORMATTER_BRACE_POSITION_FOR_TYPE_DECLARATION))
 
   private def prefContinuationIndent: Int = {
-    try {
-      return Integer.parseInt(getCoreFormatterOption(DefaultCodeFormatterConstants.FORMATTER_CONTINUATION_INDENTATION))
-    } catch {
-      case _ => // ignore and return default
+    Exception.failAsValue(classOf[Exception])(2) {
+      Integer.parseInt(getCoreFormatterOption(DefaultCodeFormatterConstants.FORMATTER_CONTINUATION_INDENTATION))
     }
-
-    return 2 // sensible default
   }
 
   private def hasGenerics: Boolean = true

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
@@ -33,7 +33,7 @@ object Utils extends HasLogger {
   def tryExecute[T](action: => T, msgIfError: => Option[String] = None): Option[T] = {
     try Some(action)
     catch {
-      case t =>
+      case t: Throwable =>
         msgIfError match {
           case Some(errMsg) => eclipseLog.error(errMsg, t)
           case None         => eclipseLog.error(t)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/NewApplicationWizard.scala
@@ -63,7 +63,7 @@ class NewApplicationWizard extends BasicNewResourceWizard with HasLogger {
   }
 
   private def createSource(applicationName: String, pkg: IPackageFragment): String = {
-    val appExists = try { Class.forName("scala.App"); true } catch { case _ => false }
+    val appExists = try { Class.forName("scala.App"); true } catch { case _: Throwable => false }
     val packageDeclaration = if (pkg.isDefaultPackage) "" else "package " + pkg.getElementName + "\n\n"
     val objectTemplate = if (appExists) TEMPLATE_WITH_APP else TEMPLATE_WITHOUT_APP
     val unformatted = packageDeclaration + objectTemplate.format(applicationName)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/support.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/support.scala
@@ -128,7 +128,7 @@ trait QualifiedNameSupport extends SuperTypeSupport {
   def concat(vals: Any, sep: String = ".") = {
     vals match {
       case l: List[_] => l.mkString(sep)
-      case t: (String, String) => t._1 + sep + t._2
+      case (v1, v2) => v1 + sep + v2
     }
   }
   


### PR DESCRIPTION
- catching `Throwable` (in 2.10 only). I tried to make sense of each case, and where safe replace `Throwable` by a smaller type. Not always possible
- unchecked warnings (in one case it was completely wrong) in pattern matches
- missing cases in a pattern match
