### PR TITLE
Fixed defaults:

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -428,7 +428,7 @@
      <specification
           annotationType="scala.tools.eclipse.semantichighlighting.implicits.implicitConversionsOrArgsAnnotation"
           colorPreferenceKey="scala.tools.eclipse.ui.preferences.implicit.color"
-          colorPreferenceValue="51,102,0"
+          colorPreferenceValue="153,153,153"
           contributesToHeader="false"
           includeOnPreferencePage="true"
           icon="icons/full/elcl16/implicit_co.gif"
@@ -1232,7 +1232,7 @@
          commandId="scala.tools.eclipse.editor.ShowTypeOfSelection"
          contextId="scala.tools.eclipse.scalaEditorScope"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-         sequence="M2+M1+S T">
+         sequence="M2+M1+W T">
    </key>
    <key
          commandId="scala.tools.eclipse.editor.OpenImplicit"

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ImplicitsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ImplicitsPreferencePage.scala
@@ -36,7 +36,7 @@ Set the highlighting for implicit conversions and implicit parameters.
   }
 
   override def createFieldEditors() {
-    addField(new BooleanFieldEditor(P_ACTIVE, "Active", getFieldEditorParent))
+    addField(new BooleanFieldEditor(P_ACTIVE, "Enabled", getFieldEditorParent))
     addField(new BooleanFieldEditor(P_BOLD, "Bold", getFieldEditorParent))
     addField(new BooleanFieldEditor(P_ITALIC, "Italic", getFieldEditorParent))
     addField(new BooleanFieldEditor(P_CONVERSIONS_ONLY, "Only highlight implicit conversions", getFieldEditorParent))


### PR DESCRIPTION
- CMD-Shift-S T was conflicting with `Save all`. Now it's CMD-Shift-W T (Show Type)
- lighter shade of grey for implicit highlighting
- Renamed 'Active' to 'Enabled' on the preference page.

Fixed #1001023.
