### PR TITLE
Added alternative launch delegates for Scala Eclipse applications

### DIFF
--- a/org.scala-ide.sdt.build/pom.xml
+++ b/org.scala-ide.sdt.build/pom.xml
@@ -61,6 +61,12 @@
       <layout>p2</layout>
       <url>${repo.scalariform}</url>
     </repository>
+    <repository>
+      <id>equinox.launcher</id>
+      <name>Equinox weaving launcher p2 repository</name>
+      <layout>p2</layout>
+      <url>${repo.equinox.launcher}</url>
+    </repository>
   </repositories>
 
   <dependencies>

--- a/org.scala-ide.sdt.debug/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.debug/META-INF/MANIFEST.MF
@@ -46,7 +46,8 @@ Require-Bundle:
  scalariform,
  org.junit4;bundle-version="4.5.0",
  org.eclipse.ui.browser;bundle-version="3.3.0",
- org.scala-ide.sdt.core;bundle-version="[2.1.0, 2.2.0)"
+ org.scala-ide.sdt.core;bundle-version="[2.1.0, 2.2.0)",
+ org.scala-ide.equinox-weaving-launcher;bundle-version="[1.1.0,2.0.0)";resolution:=optional
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -33,5 +33,25 @@
             sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer"
             type="scala.application">
       </launchDelegate>
+      <launchDelegate
+            delegate="scala.tools.eclipse.launching.ScalaEclipseApplicationLaunchConfigurationDelegate"
+            delegateDescription="The Scala JVM Launcher supports debugging of Eclipse Scala using the new Scala debugger"
+            id="scala.eclipse.application.new"
+            modes="debug"
+            name="Scala Application (new debugger)"
+            sourceLocatorId="org.eclipse.pde.ui.launcher.PDESourceLookupDirector"
+            sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer"
+            type="org.scala-ide.ew.launcher.RuntimeWorkbench">
+      </launchDelegate>
+      <launchDelegate
+            delegate="scala.tools.eclipse.launching.ScalaEclipseJUnitLaunchConfigurationDelegate"
+            delegateDescription="The Scala JVM Launcher supports debugging of JUnit Eclipse Scala using the new Scala debugger"
+            id="scala.junit.eclipse.application.new"
+            modes="debug"
+            name="Scala Application (new debugger)"
+            sourceLocatorId="org.eclipse.pde.ui.launcher.PDESourceLookupDirector"
+            sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer"
+            type="org.scala-ide.ew.launcher.JunitLaunchConfig">
+      </launchDelegate>
     </extension>
 </plugin>

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/ScalaEclipseApplicationLaunchConfigurationDelegate.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/ScalaEclipseApplicationLaunchConfigurationDelegate.scala
@@ -1,0 +1,18 @@
+package scala.tools.eclipse.launching
+
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.jdt.launching.IVMRunner
+import org.scalaide.ew.launcher.EquinoxWeavingApplicationLaunchConfiguration
+import org.eclipse.pde.internal.launching.launcher.VMHelper
+
+/**
+ * Launch configuration delegate starting Scala applications with the Scala debugger.
+ */
+class ScalaEclipseApplicationLaunchConfigurationDelegate extends EquinoxWeavingApplicationLaunchConfiguration {
+
+  override def getVMRunner(configuration: ILaunchConfiguration, mode: String): IVMRunner = {
+    val vm = VMHelper.createLauncher(configuration)
+    new StandardVMScalaDebugger(vm)
+  }
+
+}

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/ScalaEclipseJUnitLaunchConfigurationDelegate.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/ScalaEclipseJUnitLaunchConfigurationDelegate.scala
@@ -1,0 +1,18 @@
+package scala.tools.eclipse.launching
+
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.jdt.launching.IVMRunner
+import org.eclipse.pde.internal.launching.launcher.VMHelper
+import org.scalaide.ew.launcher.EquinoxWeavingJUnitLaunchConfigurationDelegate
+
+/**
+ * Launch configuration delegate starting Scala applications with the Scala debugger.
+ */
+class ScalaEclipseJUnitLaunchConfigurationDelegate extends EquinoxWeavingJUnitLaunchConfigurationDelegate {
+
+  override def getVMRunner(configuration: ILaunchConfiguration, mode: String): IVMRunner = {
+    val vm = VMHelper.createLauncher(configuration)
+    new StandardVMScalaDebugger(vm)
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <repo.eclipse.indigo>http://download.eclipse.org/releases/indigo/</repo.eclipse.indigo>
     <repo.eclipse.juno>http://download.eclipse.org/eclipse/updates/4.2milestones</repo.eclipse.juno>
     <repo.ajdt.indigo>http://download.eclipse.org/tools/ajdt/37/dev/update</repo.ajdt.indigo>
+    <repo.equinox.launcher>http://www.chuusai.com/eclipse/equinox-weaving-launcher/</repo.equinox.launcher>
     <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
 
     <!-- fixed versions -->


### PR DESCRIPTION
The new launch delegates are added to the Equinox weaving launch
configurations, if available in the Eclipse setup.

Fix #1001158

Users who already installed the 'Equinox Weaving Launcher' will have to update to at least 1.1.0.201207141204. It cannot be enforced in the MANIFEST.MF because the dependency is optional.

I'll send a message to the mailing list explaining the problem after the merge is done.
