### PR TITLE
added a testcase for lazy vals for `find references`

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTests.scala
@@ -173,6 +173,12 @@ class FindReferencesTests extends FindReferencesTester with HasLogger {
     val expected = fieldVal("Referred.aVal") isReferencedBy method("Referring.anotherMethod") and method("Referring.yetAnotherMethod")
     runTest("bug1000067_3", "FindReferencesOfClassFieldVal.scala", expected)
   }
+  
+  @Test
+  def findReferencesOfClassFieldLazyVal() {
+    val expected = fieldVal("Foo.x") isReferencedBy method("Bar.meth")
+    runTest("lazy-val", "FindReferencesOfClassFieldLazyVal.scala", expected)
+  }
 
   @Test
   def findReferencesOfClassConstructor_bug1000063_1() {

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/lazy-val/src/FindReferencesOfClassFieldLazyVal.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/lazy-val/src/FindReferencesOfClassFieldLazyVal.scala
@@ -1,0 +1,10 @@
+class Foo {
+  lazy val x/*ref*/ = 0
+}
+
+class Bar {
+  def meth {
+    val obj = new Foo
+    obj.x
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
@@ -566,7 +566,7 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
         val display = elemName.toString+" : "+sym.info.resultType.toString
 
         val valElem =
-          if(sym.hasFlag(Flags.MUTABLE))
+          if(sym.isMutable && !sym.isLazy)
             new ScalaVarElement(element, elemName.toString, display)
           else
             new ScalaValElement(element, elemName.toString, display)


### PR DESCRIPTION
fix for the lazy val testcase in `find references` (see commit #8a31a704421093131)
