### PR TITLE
Guard against NPE when finding the depth of the element

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
@@ -146,7 +146,7 @@ trait ScalaCompilationUnit extends Openable
        To avoid this, we look for deepest element containing the position
      */
     
-    def depth(e: IJavaElement): Int = if (e == element) 0 else (depth(e.getParent()) + 1)
+    def depth(e: IJavaElement): Int = if (e == element || e == null) 0 else (depth(e.getParent()) + 1)
     
     element match {
       case parent: IParent => {


### PR DESCRIPTION
I hit this annoying thing when using (Java) debugger on scala compiler. I was just clicking on the stacktrace and it wouldn't locate the appropriate line in the source code but rather throw NPE.

This looked like an easy and reasonable fix to me so here you go.
