### PR TITLE
Fixed build against Scala 2.10.0-SNAPSHOT

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaJavaCompletionProposalComputer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaJavaCompletionProposalComputer.scala
@@ -121,7 +121,7 @@ class ScalaJavaCompletionProposalComputer extends IJavaCompletionProposalCompute
 
       compiler.askOption { () =>
         val currentClass = definitions.getClass(newTypeName(referencedTypeName))
-        val proposals = currentClass.info.members.filter(mixedInMethod)
+        val proposals = currentClass.info.members.filter(mixedInMethod).toList
 
         for (sym <- proposals if sym.name.startsWith(prefix)) yield {
           val prop = compiler.mkCompletionProposal(start, sym = sym, tpe = sym.info, inherited = true, viaView = NoSymbol)


### PR DESCRIPTION
In Scala 2.10, the return value of `Type.member` has been changed from
`List[Symbol]` to Scope. Inserting `toList` fixes the compilation error.

Related discussion on scala-internals
http://groups.google.com/group/scala-internals/browse_thread/thread/9ee8df2ae9d43169
