### PR TITLE
Fix for ticket #1001198

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TypeParameterTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TypeParameterTest.scala
@@ -28,4 +28,46 @@ class TypeParameterTest extends AbstractSymbolClassifierTest {
       }""",
       Map("TPARAM" -> TypeParameter))
   }
+
+  @Test
+  def parameterized_type_param() {
+    checkSymbolClassification("""
+      trait X {
+        def xs[TypeParam]: Seq[TypeParam]
+      }
+      """, """
+      trait X {
+        def xs[$TPARAM $]: $T$[$TPARAM $]
+      }
+      """,
+      Map("TPARAM" -> TypeParameter, "T" -> Type))
+  }
+
+  @Test
+  def nested_parameterized_type_param() {
+    checkSymbolClassification("""
+      trait X {
+        def xs[TypeParam]: Seq[Seq[TypeParam]]
+      }
+      """, """
+      trait X {
+        def xs[$TPARAM $]: $T$[$T$[$TPARAM $]]
+      }
+      """,
+      Map("TPARAM" -> TypeParameter, "T" -> Type))
+  }
+
+  @Test
+  def multiple_parameterized_type_param() {
+    checkSymbolClassification("""
+      trait X {
+        def xs[TypeParam]: Map[TypeParam, Seq[TypeParam]]
+      }
+      """, """
+      trait X {
+        def xs[$TPARAM $]: $T$[$TPARAM $, $T$[$TPARAM $]]
+      }
+      """,
+      Map("TPARAM" -> TypeParameter, "T" -> Type))
+  }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SafeSymbol.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SafeSymbol.scala
@@ -76,6 +76,9 @@ trait SafeSymbol extends CompilerAccess with PimpedTrees {
         else List((sym1, pos))
       }).flatten
 
+    case AppliedTypeTree(tpe, args) =>
+      tpe.symbol -> tpe.namePosition :: args.flatMap(safeSymbol)
+
     case _ =>
       // the local variable backing a lazy value is called 'originalName$lzy'. We swap it here for its
       // accessor, otherwise this symbol would fail the test in `getNameRegion`


### PR DESCRIPTION
Fixes the issue that parameterized types are not semantically highlighted
if they occur on the call side.
