### PR TITLE
Add semantic highlighting for object members in type params

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ObjectTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ObjectTest.scala
@@ -58,4 +58,16 @@ class ObjectTest extends AbstractSymbolClassifierTest {
         """,
       Map("OBJ" -> Object, "PKG" -> Package))
   }
+
+  @Test
+  def object_member_within_type_param() {
+    checkSymbolClassification("""
+      object TypeA { class TypeB }
+      trait Trait extends Seq[TypeA.TypeB]
+      """, """
+      object TypeA { class TypeB }
+      trait Trait extends $T$[$OBJ$.$CLS$]
+      """,
+      Map("CLS" -> Class, "OBJ" -> Object, "T" -> Type))
+  }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SafeSymbol.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SafeSymbol.scala
@@ -104,6 +104,9 @@ trait SafeSymbol extends CompilerAccess with PimpedTrees {
     case ExistentialTypeTree(tpt, whereClauses) =>
       (tpt :: whereClauses).flatMap(safeSymbol)
 
+    case tpe @ Select(qualifier, _) =>
+      global.askOption(() => tpe.symbol -> tpe.namePosition).toList ::: safeSymbol(qualifier)
+
     case _ =>
       // the local variable backing a lazy value is called 'originalName$lzy'. We swap it here for its
       // accessor, otherwise this symbol would fail the test in `getNameRegion`


### PR DESCRIPTION
Fix #1001209
