### PR TITLE
Improve performance of Mark Occurrences

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/occurrences/OccurrencesFinderTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/occurrences/OccurrencesFinderTest.scala
@@ -42,9 +42,8 @@ class OccurrencesFinderTest {
       println("looking at position %d for %d occurrences".format(pos, count))
       val region = ScalaWordFinder.findWord(contents, pos - 1)
       println("using word region: " + region)
-      val finder = new ScalaOccurrencesFinder(unit, region.getOffset, region.getLength)
-      val occurrences = finder.findOccurrences
-      assertTrue(finder.findOccurrences.isDefined)
+      val occurrences = ScalaOccurrencesFinder.findOccurrences(unit, region.getOffset, region.getLength, 1)
+      assertTrue(occurrences.isDefined)
       assertEquals(count, occurrences.get.locations.size)
     }
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/markoccurrences/ScalaOccurrencesFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/markoccurrences/ScalaOccurrencesFinder.scala
@@ -1,29 +1,46 @@
 package scala.tools.eclipse
 package markoccurrences
 
+import org.eclipse.jface.text.Region
+
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
+import scala.tools.nsc.util.SourceFile
 import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.implementations.MarkOccurrences
 
-import org.eclipse.jface.text.Region
-
 case class Occurrences(name: String, locations: List[Region])
 
-class ScalaOccurrencesFinder(file: ScalaCompilationUnit, offset: Int, length: Int) {
-
-  def findOccurrences(): Option[Occurrences] = {
+object ScalaOccurrencesFinder {
+  
+  private var indexCache: Option[(SourceFile, Long, MarkOccurrences with GlobalIndexes)] = None
+  
+  private def getCachedIndex(sourceFile: SourceFile, lastModified: Long) = indexCache match {
+    case Some(Triple(`sourceFile`, `lastModified`, index)) => Some(index)
+    case _ => None
+  }
+  
+  private def cacheIndex(sourceFile: SourceFile, lastModified: Long, index: MarkOccurrences with GlobalIndexes) {
+    indexCache = Some(Triple(sourceFile, lastModified, index))
+  }
+  
+  def findOccurrences(file: ScalaCompilationUnit, offset: Int, length: Int, lastModified: Long): Option[Occurrences] = {
     val (from, to) = (offset, offset + length)
     file.withSourceFile { (sourceFile, compiler) =>
       compiler.askOption { () =>
-        val mo = new MarkOccurrences with GlobalIndexes {
-          val global = compiler
-          lazy val index = GlobalIndex(global.body(sourceFile))
+        
+        val occurrencesIndex = getCachedIndex(sourceFile, lastModified) getOrElse {
+          val occurrencesIndex = new MarkOccurrences with GlobalIndexes {
+            val global = compiler
+            lazy val index = GlobalIndex(global.body(sourceFile))
+          }
+          cacheIndex(sourceFile, lastModified, occurrencesIndex)
+          occurrencesIndex
         }
-
+        
         if (!compiler.unitOfFile.contains(sourceFile.file)) 
           None 
         else {
-          val (selectedTree, occurrences) = mo.occurrencesOf(sourceFile.file, from, to)       
+          val (selectedTree, occurrences) = occurrencesIndex.occurrencesOf(sourceFile.file, from, to)       
           
           Option(selectedTree.symbol) filter (!_.name.isOperatorName) map { sym =>
             val locations = occurrences map { pos => 


### PR DESCRIPTION
Two simple performance improvements for Mark Occurrences:
- Only update the occurrence annotations if the file is in the active
  editor. Previously, annotations were updated for all open files when
  the caret in the active editor changed.
- Cache the most recently created index so that just browsing a file
  does not create a new index every time the caret position changes.

Fixes #1001213
