### PR TITLE
Added test for ticket Re #1001215 - No hyperlinking on `List` (only in 2.10)

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkDetectorTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkDetectorTests.scala
@@ -87,4 +87,11 @@ class HyperlinkDetectorTests {
     val oracle = List(Link("type util.Box.myInt"), Link("method util.Full.apply", "object util.Full"))
     loadTestUnit("bug1000656/Client.scala").andCheckAgainst(oracle)
   }
+  
+  @Test
+  def hyperlinkOnList_t1001215() {
+    val oracle = List(Link("method scala.collection.immutable.List.apply", "object scala.collection.immutable.List"))
+    
+    loadTestUnit("t1001215/A.scala").andCheckAgainst(oracle)
+  }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/t1001215/A.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/t1001215/A.scala
@@ -1,0 +1,5 @@
+package t1001215
+
+class A {
+  List/*^*/()
+}


### PR DESCRIPTION
From a quick debug session, it looks like this could be a regression in the
compiler. But we should create a presentation compiler test before asking
the Scala team to have a look at it. In the meanwhile, let's add the test
to our regression suite.
