### PR TITLE
Fixes #1001219

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ImplicitsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ImplicitsPreferencePage.scala
@@ -66,6 +66,6 @@ class ImplicitsPagePreferenceInitializer extends AbstractPreferenceInitializer {
     store.setDefault(P_BOLD, false)
     store.setDefault(P_ITALIC, false)
     store.setDefault(P_CONVERSIONS_ONLY, true)
-    store.setDefault(P_FIRST_LINE_ONLY, false)
+    store.setDefault(P_FIRST_LINE_ONLY, true)
   }
 }


### PR DESCRIPTION
Made the "Only highlight the first line in an implicit conversion"
option the default.

https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1001219--only-highlight-the-first-line-in-an-implicit-conversion--should-be-the-default

https://groups.google.com/group/scala-ide-user/browse_thread/thread/9ea8b20ec67876f2
