### PR TITLE
Add the facility to debug incremental compilation.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
@@ -12,9 +12,10 @@ import xsbti.compile.CompileProgress
 import xsbti.{ Logger, F0 }
 import sbt.{Process, ClasspathOptions}
 import scala.tools.eclipse.util.{ EclipseResource, FileUtils }
+import scala.tools.eclipse.properties.ScalaPluginSettings
 import org.eclipse.core.resources.IResource
 import scala.tools.eclipse.logging.HasLogger
-import sbt.inc.{ AnalysisStore, Analysis, FileBasedStore }
+import sbt.inc.{ AnalysisStore, Analysis, FileBasedStore, Incremental }
 import sbt.compiler.{ IC, CompileFailed }
 import org.eclipse.core.resources.IProject
 import java.lang.ref.SoftReference
@@ -119,6 +120,8 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
   }
 
   private def runCompiler(sources: Seq[File]) {
+    System.setProperty(Incremental.incDebugProp,
+      project.storage.getString(SettingConverterUtil.convertNameToProperty(ScalaPluginSettings.debugIncremental.name)))
     val inputs = new SbtInputs(sources.toSeq, project, monitor, new SbtProgress, cacheFile, sbtReporter, sbtLogger)
     val analysis =
       try

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
@@ -33,7 +33,7 @@ object IDESettings {
   }
   
   def buildManagerSettings: List[Box] =
-    List(Box("Build manager", List(buildManager, compileOrder, stopBuildOnErrors)))
+    List(Box("Build manager", List(buildManager, compileOrder, stopBuildOnErrors, debugIncremental)))
 }
 
 object ScalaPluginSettings extends Settings {
@@ -41,4 +41,5 @@ object ScalaPluginSettings extends Settings {
   val compileOrder = ChoiceSetting("-compileorder", "which", "Compilation order",
       List("Mixed", "JavaThenScala", "ScalaThenJava"), "Mixed")
   val stopBuildOnErrors = BooleanSetting("-stopBuildOnError", "Stop build if dependent projects have errors.")
+  val debugIncremental = BooleanSetting("-debugIncremental", "Explain incremental compilation (sbt builder only)")
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
@@ -44,6 +44,7 @@ class ScalaCompilerPreferenceInitializer extends AbstractPreferenceInitializer {
       IDESettings.shownSettings(ScalaPlugin.defaultScalaSettings).foreach {_.userSettings.foreach (defaultPreference)}
       IDESettings.buildManagerSettings.foreach {_.userSettings.foreach(defaultPreference)}
       store.setDefault(convertNameToProperty(ScalaPluginSettings.stopBuildOnErrors.name), true)
+      store.setDefault(convertNameToProperty(ScalaPluginSettings.debugIncremental.name), false)
     }
   }
 }


### PR DESCRIPTION
Add the option to enable more detailed sbt incremental compilation logging. Currently the logging is done to stdout, though https://github.com/harrah/xsbt/pull/521 addresses this.
