### PR TITLE
Call the right method for package name completion

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
@@ -217,4 +217,22 @@ class CompletionTests {
 
     runTest("t1001014/F.scala", false)(oracle)
   }
+
+  @Test
+  def t1001207() {
+    val unit = scalaCompilationUnit("ticket_1001207/T1207.scala")
+    reload(unit)
+
+    withCompletions("ticket_1001207/T1207.scala") {
+      (index, position, completions) =>
+        assertEquals("There is only one completion location", 0, index)
+        assertTrue("The completion should return java.util", completions.exists(
+          _ match {
+            case CompletionProposal(MemberKind.Package, _, "util", _, _, _, _, _, _, _, _, _) =>
+              true
+            case _ =>
+              false
+          }))
+    }
+  }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/completion/src/ticket_1001207/T1207.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/completion/src/ticket_1001207/T1207.scala
@@ -1,0 +1,7 @@
+package ticket_1001207
+
+import java.u /*!*/
+
+class T1207 {
+
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -41,7 +41,7 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
 
     if (sym.isPackage) {
       val fullName = sym.fullName
-      val results = projects.map(p => Option(p.findPackageFragment(new Path(fullName))))
+      val results = projects.map(p => Option(p.findElement(new Path(fullName.replace('.', '/')))))
       results.flatten.headOption
     } else if (sym.isClass || sym.isModule) {
       val fullClassName = mapType(sym)


### PR DESCRIPTION
It was using the wrong method, and bad parameters. The result was a thrown exception.

Fix #1001207
