### PR TITLE
Added support for code specific to 2.9 or 2.10

### DIFF
--- a/org.scala-ide.sdt.core/.classpath
+++ b/org.scala-ide.sdt.core/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src"/>
+	<classpathentry kind="src" path="src-2.9"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>

--- a/org.scala-ide.sdt.core/pom.xml
+++ b/org.scala-ide.sdt.core/pom.xml
@@ -83,6 +83,23 @@
           </execution>
         </executions>
       </plugin>
+      <!-- added source folder containing the code specific to the scala version -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals><goal>add-source</goal></goals>
+            <configuration>
+              <sources>
+                <source>src-${scala.major.minor.version}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/org.scala-ide.sdt.core/src-2.10/scala/tools/eclipse/SymbolsCompatibility.scala
+++ b/org.scala-ide.sdt.core/src-2.10/scala/tools/eclipse/SymbolsCompatibility.scala
@@ -1,0 +1,17 @@
+package scala.tools.eclipse
+
+import scala.reflect.internal.Symbols
+
+/**
+ * Trait used to keep 2.9-2.10 source compatibility
+ */
+trait SymbolsCompatibility { self: Symbols =>
+
+  /**
+   * This class as been removed in 2.10, but we need its real implementation in 2.9
+   */
+  case class InvalidCompanions(sym1: Symbol, sym2: Symbol) extends Throwable {
+
+  }
+
+}

--- a/org.scala-ide.sdt.core/src-2.9/scala/tools/eclipse/SymbolsCompatibility.scala
+++ b/org.scala-ide.sdt.core/src-2.9/scala/tools/eclipse/SymbolsCompatibility.scala
@@ -1,0 +1,10 @@
+package scala.tools.eclipse
+
+import scala.tools.nsc.symtab.Symbols
+
+/**
+ * Trait used to keep 2.9-2.10 source compatibility
+ */
+trait SymbolsCompatibility { self: Symbols =>
+
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -41,7 +41,8 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings)
   with JavaSig
   with JVMUtils
   with LocateSymbol
-  with HasLogger { self =>
+  with HasLogger
+  with SymbolsCompatibility { self =>
 
   def presentationReporter = reporter.asInstanceOf[ScalaPresentationCompiler.PresentationReporter]
   presentationReporter.compiler = this


### PR DESCRIPTION
Maven is configure to add an extra source folder in sdt.core,
the one matching the scala version.

Added code to manage the missing InvalidCompanions class in 2.10

Fix #1001243
