### PR TITLE
Add test cases for semantic highlighting

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/CaseClassTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/CaseClassTest.scala
@@ -53,4 +53,21 @@ class CaseClassTest extends AbstractSymbolClassifierTest {
       Map("CC" -> CaseClass))
   }
 
+  @Test
+  @Ignore("Enable when ticket #1001171 is fixed")
+  def infix_notation_for_extractors() {
+    checkSymbolClassification("""
+        class X {
+          val a Foo b = Foo(1, 2)
+        }
+        case class Foo(a: Int, b: Int)
+        """, """
+        class X {
+          val a $C$ b = $C$(1, 2)
+        }
+        case class $C$(a: Int, b: Int)
+        """,
+        Map("C" -> CaseClass))
+  }
+
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ClassTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ClassTest.scala
@@ -128,4 +128,21 @@ class ClassTest extends AbstractSymbolClassifierTest {
         """,
       Map("CL" -> Class))
   }
+
+  @Test
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001260)")
+  def early_initializer_in_combination_with_trait() {
+    checkSymbolClassification("""
+      object X extends {
+        val o = new Object
+      } with T
+      trait T
+      """, """
+      object X extends {
+        val o = new $CLS $
+      } with T
+      trait T
+      """,
+      Map("CLS" -> Class))
+  }
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/MethodTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/MethodTest.scala
@@ -99,4 +99,66 @@ class MethodTest extends AbstractSymbolClassifierTest {
       }""",
       Map("METH" -> Method))
   }
+
+  @Test
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001223)")
+  def param_of_classOf() {
+    checkSymbolClassification("""
+      object X {
+        val x = classOf[Int]
+      }
+      """, """
+      object X {
+        val x = classOf[$T$]
+      }
+      """,
+      Map("T" -> Type))
+  }
+
+  @Test
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001228)")
+  def combination_of_implicit_conversion_and_higher_order_method_call() {
+    checkSymbolClassification("""
+      object X {
+        val s: String = Seq(1).map(param=>param)
+        implicit def l2s(i: Seq[Int]): String = i.mkString
+      }
+      """, """
+      object X {
+        val s: String = $O$(1).$M$($P  $=>$P  $)
+        implicit def l2s(i: Seq[Int]): String = i.mkString
+      }
+      """,
+      Map("O" -> Object, "M" -> Method, "P" -> Param))
+  }
+
+  @Test
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001242)")
+  def internal_notation_of_operator_names() {
+    checkSymbolClassification("""
+      object X {
+        val xs = Nil $colon$colon 0
+      }
+      """, """
+      object X {
+        val xs = Nil $METHOD    $ 0
+      }
+      """,
+      Map("METHOD" -> Method))
+  }
+
+  @Test
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001259)")
+  def param_of_super() {
+    checkSymbolClassification("""
+      object X {
+        val bool = super[Object].equals(this)
+      }
+      """, """
+      object X {
+        val bool = super[$CLS $].equals(this)
+      }
+      """,
+      Map("CLS" -> Class))
+  }
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ObjectTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ObjectTest.scala
@@ -70,4 +70,17 @@ class ObjectTest extends AbstractSymbolClassifierTest {
       """,
       Map("CLS" -> Class, "OBJ" -> Object, "T" -> Type))
   }
+
+  @Test
+  @Ignore("Enable when ticket #1001024 is fixed")
+  def companion_object_should_not_be_treated_as_case_class() {
+    checkSymbolClassification("""
+      case class FooBar()
+      object FooBar
+      """, """
+      case class $CCLS$()
+      object $OBJ $
+      """,
+      Map("OBJ" -> Object, "CCLS" -> CaseClass))
+  }
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TemplateValTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TemplateValTest.scala
@@ -171,18 +171,24 @@ class TemplateValTest extends AbstractSymbolClassifierTest {
   }
 
   @Test
-  @Ignore("Package object symbols are special, need to investigate")
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001261)")
   def in_package_object() {
     checkSymbolClassification("""
+      object X {
+        val pv = packageObject.packageVal
+      }
       package object packageObject {
         val packageVal = 42
-        packageObject.packageVal
-      }""", """
-      package object packageObject {
-        val $  TVAL  $ = 42
-        packageObject.$  TVAL  $
-      }""",
-      Map("TVAL" -> TemplateVal))
+      }
+      """, """
+      object X {
+        val pv = $POBJ       $.$TVAL    $
+      }
+      package object $POBJ       $ {
+        val $TVAL    $ = 42
+      }
+      """,
+      Map("TVAL" -> TemplateVal, "POBJ" -> Package))
   }
 
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TraitTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TraitTest.scala
@@ -41,4 +41,28 @@ class TraitTest extends AbstractSymbolClassifierTest {
       Map("TRAIT" -> Trait))
   }
 
+  @Test
+  @Ignore("Enable when ticket #1001176 is fixed")
+  def imported_self_reference_is_classified_as_trait() {
+    checkSymbolClassification("""
+        package ab {
+          trait TheTrait
+        }
+        package cd {
+          trait K { self: ab.TheTrait => }
+          import ab.TheTrait
+          trait M { self: TheTrait => }
+        }
+        """, """
+        package ab {
+          trait $TRAIT $
+        }
+        package cd {
+          trait K { self: ab.$TRAIT $ => }
+          import ab.$TRAIT $
+          trait M { self: $TRAIT $ => }
+        }
+        """,
+        Map("TRAIT" -> Trait))
+  }
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TypeTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TypeTest.scala
@@ -28,23 +28,6 @@ class TypeTest extends AbstractSymbolClassifierTest {
   }
 
   @Test
-  @Ignore("Fails with 2.10. Need to investigate.")
-  def set_is_a_type() {
-    checkSymbolClassification("""
-      case class Bob(s: Set[Int])
-      object X {
-        val Bob(s) = Bob(Set())
-      }
-      """, """
-      case class Bob(s: $T$[$C$])
-      object X {
-        val Bob(s) = Bob($V$())
-      }
-      """,
-      Map("T" -> Type, "V" -> TemplateVal, "C" -> Class))
-  }
-
-  @Test
   def path_dependent_type() {
     checkSymbolClassification("""
       trait MTrait { trait KTrait[A] }
@@ -74,5 +57,37 @@ class TypeTest extends AbstractSymbolClassifierTest {
       }
       """,
       Map("C" -> Class, "TT" -> Trait))
+  }
+
+  @Test
+  @Ignore("Enable when ticket #1001239 is fixed")
+  def deep_type_projection() {
+    checkSymbolClassification("""
+      trait MTrait { trait KTrait[A] { trait HTrait } }
+      trait X {
+        def xs(m: MTrait#KTrait[Int]#HTrait)
+      }
+      """, """
+      trait MTrait { trait KTrait[A] { trait HTrait } }
+      trait X {
+        def xs(m: $TT  $#$TT  $[$C$]#$TT  $)
+      }
+      """,
+      Map("C" -> Class, "TT" -> Trait))
+  }
+
+  @Test
+  @Ignore("Enable when ticket #1001046 is fixed")
+  def classify_type_in_abstract_val() {
+    checkSymbolClassification("""
+      trait X {
+        val s: String
+      }
+      """, """
+      trait X {
+        val s: $TPE $
+      }
+      """,
+      Map("TPE" -> Type))
   }
 }


### PR DESCRIPTION
There are some symbols that can not yet highlighted due to too
less information provided by the compiler. Once the compiler
stores more information in the AST the test cases should be
activated and implemented (if necessary).

The test case TypeTest#set_is_a_type is not needed any more, the
problem seems to be fixed.

Review by @dotta:
The ignored test is introduced in 7d3710d7bf4c98b020671a42582079621d3dd9ff, I deleted it because it looks like it is complete superseded by other test cases.
