### PR TITLE
Faster completions for Java symbols.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -289,8 +289,8 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings)
       if section.nonEmpty && !section.head.isImplicit
     } yield for (param <- section) yield param.name.toString
 
-    val paramNames = if (sym.isJavaDefined) {
-      getJavaElement(sym) collect {
+    val paramNames = if (sym.isJavaDefined && sym.isMethod) {
+      getJavaElement(sym, project.javaProject) collect {
         case method: IMethod => List(method.getParameterNames.toList)
       } getOrElse scalaParamNames
     } else scalaParamNames


### PR DESCRIPTION
Fixed two sources of slow behavior in `mkCompletions`, both related to inserting parameter 
names as suggestions for the chosen completion.
- don't retrieve method parameter names for Java symbols that are not methods (they can't have parameter names anyway)
- when calling `getJavaElement` pass the current project (makes no sense to look up types in other projects).
