### PR TITLE
Disable AbstractMethodVerifierTest because it's too flaky.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/jcompiler/AbstractMethodVerifierTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/jcompiler/AbstractMethodVerifierTest.scala
@@ -90,6 +90,7 @@ object AbstractMethodVerifierTest extends TestProjectSetup("jcompiler") {
   private def one: VerificationMode = times(1)
 }
 
+@Ignore("Failing randomly, re-enable when fixed.")
 class AbstractMethodVerifierTest {
   import AbstractMethodVerifierTest._
 


### PR DESCRIPTION
My heart breaks to disable a test, but I think it's just noise until we get to fix it. I think we should have a "Build and Tests" sprint and tackle a few common issues, including this one.
- move to released versions of scalariform, scala-refactoring, aspectj, scala compiler 2.9.x
- fix flaky tests
- etc.

Until then, I created [#1001293](https://scala-ide-portfolio.assembla.com/spaces/ae55a-oWSr36hpeJe5avMc/tickets/1001293)
