### PR TITLE
Moved out askType from inside `ask`. 

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/markoccurrences/ScalaOccurrencesFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/markoccurrences/ScalaOccurrencesFinder.scala
@@ -39,24 +39,24 @@ class ScalaOccurrencesFinder(unit: InteractiveCompilationUnit) extends HasLogger
   def findOccurrences(region: IRegion, lastModified: Long): Option[Occurrences] = {
     unit.withSourceFile { (sourceFile, compiler) =>
 
-        def isNotLoadedInPresentationCompiler(source: SourceFile): Boolean =
-          !compiler.unitOfFile.contains(source.file)
+      def isNotLoadedInPresentationCompiler(source: SourceFile): Boolean =
+        !compiler.unitOfFile.contains(source.file)
 
-        if (isNotLoadedInPresentationCompiler(sourceFile)) {
-          logger.info("Source %s is not loded in the presentation compiler. Aborting occurrences update." format (sourceFile.file.name))
-          None
-        } else {
-          val occurrencesIndex = getCachedIndex(lastModified) getOrElse {
-            val occurrencesIndex = new MarkOccurrencesIndex {
-              val global = compiler
-              override lazy val index: IndexLookup = Utils.debugTimed("Time elapsed for building mark occurrences index in source " + sourceFile.file.name) {
-                val tree = global.loadedType(sourceFile)
-                compiler.askOption { () => GlobalIndex(tree) } getOrElse EmptyIndex
-              }
+      if (isNotLoadedInPresentationCompiler(sourceFile)) {
+        logger.info("Source %s is not loded in the presentation compiler. Aborting occurrences update." format (sourceFile.file.name))
+        None
+      } else {
+        val occurrencesIndex = getCachedIndex(lastModified) getOrElse {
+          val occurrencesIndex = new MarkOccurrencesIndex {
+            val global = compiler
+            override lazy val index: IndexLookup = Utils.debugTimed("Time elapsed for building mark occurrences index in source " + sourceFile.file.name) {
+              val tree = global.loadedType(sourceFile)
+              compiler.askOption { () => GlobalIndex(tree) } getOrElse EmptyIndex
             }
-            cacheIndex(lastModified, occurrencesIndex)
-            occurrencesIndex
           }
+          cacheIndex(lastModified, occurrencesIndex)
+          occurrencesIndex
+        }
         compiler.askOption { () =>
           val (from, to) = (region.getOffset, region.getOffset + region.getLength)
           val (selectedTree, occurrences) = occurrencesIndex.occurrencesOf(sourceFile.file, from, to)


### PR DESCRIPTION
The presentation compiler is not designed to handle a call to `askType` inside an
ask. The `ask` is run during type-checking, and `askType` will usually trigger a complete
re-type-check of the (possible same) file. This may lead to spurious errors and bring
the compiler to a bad state.

See [SI-6578](https://issues.scala-lang.org/browse/SI-6578)
