### PR TITLE
Simplify the ScalaStep hierarchy

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStep.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStep.scala
@@ -16,7 +16,7 @@ trait ScalaStep {
   def stop()
 }
 
-abstract class BaseScalaStep[T <: BaseDebuggerActor] protected(eventActor: T) extends ScalaStep {
+class ScalaStepImpl(eventActor: BaseDebuggerActor) extends ScalaStep {
   override def step(): Unit = eventActor ! ScalaStep.Step
   override def stop(): Unit = eventActor ! ScalaStep.Stop
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
@@ -30,7 +30,7 @@ object ScalaStepInto {
     val stackFrames = scalaStackFrame.thread.getStackFrames
     val depth = stackFrames.length - stackFrames.indexOf(scalaStackFrame)
     val actor = new ScalaStepIntoActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepIntoRequest, stepOutRequest, depth, scalaStackFrame.stackFrame.location.lineNumber) {
-      override val scalaStep: ScalaStepInto = new ScalaStepInto(this)
+      override val scalaStep: ScalaStep = new ScalaStepImpl(this)
     }
     actor.start()
     
@@ -38,12 +38,6 @@ object ScalaStepInto {
   }
 
 }
-
-/**
- * A step into in the Scala debug model.
- * This class is thread safe. Instances have be created through its companion object.
- */
-private class ScalaStepInto private (eventActor: ScalaStepIntoActor) extends BaseScalaStep[ScalaStepIntoActor](eventActor)
 
 /**
  * Actor used to manage a Scala step into. It keeps track of the request needed to perform this step.
@@ -55,7 +49,7 @@ private[command] abstract class ScalaStepIntoActor(debugTarget: ScalaDebugTarget
    */
   private var stepOutStackDepth = 0
   
-  protected[command] def scalaStep: ScalaStepInto
+  protected[command] def scalaStep: ScalaStep
 
   override protected def postStart(): Unit = link(thread.eventActor)
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepOver.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepOver.scala
@@ -29,7 +29,7 @@ object ScalaStepOver {
     val actor = if (location.lineNumber == LINE_NUMBER_UNAVAILABLE) {
 
       new ScalaStepOverActor(scalaStackFrame.getDebugTarget, null, scalaStackFrame.thread, requests) {
-        override val scalaStep: ScalaStepOver = new ScalaStepOver(this)
+        override val scalaStep: ScalaStep = new ScalaStepImpl(this)
       }
 
     } else {
@@ -54,7 +54,7 @@ object ScalaStepOver {
       requests ++= loadedAnonFunctionsInRange.map(JdiRequestFactory.createMethodEntryBreakpoint(_, scalaStackFrame.thread))
 
       new ScalaStepOverActor(scalaStackFrame.getDebugTarget, range, scalaStackFrame.thread, requests) {
-        override val scalaStep: ScalaStepOver = new ScalaStepOver(this)
+        override val scalaStep: ScalaStep = new ScalaStepImpl(this)
       }
     }
 
@@ -65,18 +65,12 @@ object ScalaStepOver {
 }
 
 /**
- * A step over in the Scala debug model.
- * This class is thread safe. Instances have be created through its companion object.
- */
-private class ScalaStepOver private (eventActor: ScalaStepOverActor) extends BaseScalaStep[ScalaStepOverActor](eventActor)
-
-/**
  * Actor used to manage a Scala step over. It keeps track of the request needed to perform this step.
  * This class is thread safe. Instances are not to be created outside of the ScalaStepOver object.
  */
 private[command] abstract class ScalaStepOverActor(target: ScalaDebugTarget, range: Range, thread: ScalaThread, requests: ListBuffer[EventRequest]) extends BaseDebuggerActor {
 
-  protected[command] def scalaStep: ScalaStepOver
+  protected[command] def scalaStep: ScalaStep
 
   override protected def postStart(): Unit = link(thread.eventActor)
   

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepReturn.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepReturn.scala
@@ -15,7 +15,8 @@ object ScalaStepReturn {
     val stepReturnRequest = JdiRequestFactory.createStepRequest(StepRequest.STEP_LINE, StepRequest.STEP_OUT, scalaStackFrame.thread)
 
     val actor = new ScalaStepReturnActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepReturnRequest) {
-      override val scalaStep: ScalaStepReturn = new ScalaStepReturn(this) 
+      // TODO: when implementing support without filtering, need to workaround problem reported in Eclipse bug #38744
+      override val scalaStep: ScalaStep = new ScalaStepImpl(this) 
     }
     actor.start()
 
@@ -24,20 +25,12 @@ object ScalaStepReturn {
 }
 
 /**
- * A step return in the Scala debug model.
- * This class is thread safe. Instances have be created through its companion object.
- */
-private class ScalaStepReturn private (eventActor: ScalaStepReturnActor) extends BaseScalaStep[ScalaStepReturnActor](eventActor) {
-// TODO: when implementing support without filtering, need to workaround problem reported in Eclipse bug #38744
-}
-
-/**
  * Actor used to manage a Scala step return. It keeps track of the request needed to perform this step.
  * This class is thread safe. Instances are not to be created outside of the ScalaStepReturn object.
  */
 private[command] abstract class ScalaStepReturnActor(debugTarget: ScalaDebugTarget, thread: ScalaThread, stepReturnRequest: StepRequest) extends BaseDebuggerActor {
   
-  protected[command] def scalaStep: ScalaStepReturn
+  protected[command] def scalaStep: ScalaStep
 
   override protected def postStart(): Unit = link(thread.eventActor)
 


### PR DESCRIPTION
I noticed that each type of Scala step (over, into, return) induced some unnecessary code
ceremony: a private empty class extending a class having all the functionality. Moreover,
each private class had to prevent others from instantiating it, by making the constructor
private. Seemed that it was working more like a _value_ member than a class.

Since all steps work the same way, by sending two messages to an actor, I turned the `Base` class
into the implementation class used by all kinds of steps.
