### PR TITLE
Correctly shutdown actor after tests

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugTargetTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugTargetTest.scala
@@ -15,14 +15,27 @@ import com.sun.jdi.request.ThreadStartRequest
 import com.sun.jdi.request.ThreadDeathRequest
 import org.eclipse.debug.core.Launch
 import com.sun.jdi.event.EventQueue
+import scala.tools.eclipse.debug.BaseDebuggerActor
+import org.junit.After
+import scala.tools.eclipse.debug.PoisonPill
 
 class ScalaDebugTargetTest {
+
+  /**
+   * The actor associated to the debug target currently being tested.
+   */
+  var actor: Option[BaseDebuggerActor] = None
 
   @Before
   def initializeDebugPlugin() {
     if (DebugPlugin.getDefault == null) {
       new DebugPlugin
     }
+  }
+
+  @After
+  def actorCleanup() {
+    actor.foreach(_ ! PoisonPill)
   }
 
   @Test
@@ -62,7 +75,9 @@ class ScalaDebugTargetTest {
     when(eventRequestManager.createThreadStartRequest).thenReturn(threadStartRequest)
     val threadDeathRequest = mock(classOf[ThreadDeathRequest])
     when(eventRequestManager.createThreadDeathRequest).thenReturn(threadDeathRequest)
-    ScalaDebugTarget(virtualMachine, mock(classOf[Launch]), null)
+    val debugTarget = ScalaDebugTarget(virtualMachine, mock(classOf[Launch]), null)
+    actor = Some(debugTarget.eventActor)
+    debugTarget
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
@@ -125,7 +125,7 @@ abstract class ScalaDebugTarget private (val virtualMachine: VirtualMachine, lau
   protected[debug] val eventDispatcher: ScalaJdiEventDispatcher
 
   protected[debug] val breakpointManager: ScalaDebugBreakpointManager
-  private[debug] val eventActor: Actor
+  private[debug] val eventActor: BaseDebuggerActor
 
   /**
    * Initialize the dependent components


### PR DESCRIPTION
Added an @After method to shutdown the actors created during
the debugger unit tests.

Fix #1001322
