### PR TITLE
Fixed #1001327 - Infinite "Update Occurrences" error dialog

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/markoccurrences/ScalaOccurrencesFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/markoccurrences/ScalaOccurrencesFinder.scala
@@ -50,8 +50,10 @@ class ScalaOccurrencesFinder(unit: InteractiveCompilationUnit) extends HasLogger
           val occurrencesIndex = new MarkOccurrencesIndex {
             val global = compiler
             override val index: IndexLookup = Utils.debugTimed("Time elapsed for building mark occurrences index in source " + sourceFile.file.name) {
-              val tree = global.loadedType(sourceFile)
-              compiler.askOption { () => GlobalIndex(tree) } getOrElse EmptyIndex
+              global.loadedType(sourceFile) match {
+                case Left(tree) => compiler.askOption { () => GlobalIndex(tree) } getOrElse EmptyIndex
+                case Right(ex)  => EmptyIndex
+              }
             }
           }
           cacheIndex(lastModified, occurrencesIndex)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassification.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassification.scala
@@ -56,8 +56,8 @@ class SymbolClassification(protected val sourceFile: SourceFile, val global: Sca
   protected lazy val syntacticInfo =
     if (useSyntacticHints) SyntacticInfo.getSyntacticInfo(sourceFile.content.mkString) else SyntacticInfo.noSyntacticInfo
 
-  private lazy val unitTree = global.loadedType(sourceFile)
-  
+  private lazy val unitTree: global.Tree = global.loadedType(sourceFile).fold(identity, _ => global.EmptyTree)
+
   private def canSymbolBeReferencedInSource(sym: Symbol): Boolean = {
     def isSyntheticMethodParam(sym: Symbol): Boolean = sym.isSynthetic && sym.isValueParameter
     
@@ -75,7 +75,7 @@ class SymbolClassification(protected val sourceFile: SourceFile, val global: Sca
         if canSymbolBeReferencedInSource(sym)
       } yield (sym, pos)
     }
-    
+
     if (debug) printSymbolInfo()
 
     val rawSymbolInfos: Seq[SymbolInfo] = debugTimed("rawSymbolInfos") {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ImplicitHighlightingPresenter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ImplicitHighlightingPresenter.scala
@@ -200,7 +200,7 @@ object ImplicitHighlightingPresenter {
         }
         super.traverse(t)
       }
-    }.traverse(compiler.loadedType(sourceFile))
+    }.traverse(compiler.loadedType(sourceFile).fold(identity, _ => compiler.EmptyTree))
 
     implicits
   }


### PR DESCRIPTION
Basically, calling `global.loadedType` could throw an exception, and any
unhandled exception occurring in an Eclipse thread result in an error dialog
being displayed to the user. This is extremely annoying when the exception
keeps occurring, as it prevents typing in the editor!

The fix I implemented is to change the return type of the following
`ScalaPresentationCompiler`'s methods: `body`, `loadedType` and `withStructure`
to return a `Either[T, Throwable], and let the caller decide how they want to
handle the error.

Which brings me to the actual implemented fix. As you'll see in the committed
code, I'm simply ignoring any exception that may have occurred in the
Presentation Compiler side, and simply map the exception into a meaningful
NullObject (e.g., `EmptyTree`).
It is worth noting that the exception is simply swallowed, i.e., it's not even
logged! The reason why I do so is to avoid generating noise in the logger for
something that is supposed to automagically heal itself (and, if it can't heal,
it usually means that the presentation compiler is in a bad state, and the
reason for this should be found elsewhere).

One last bit of information, this ticket is somewhat related to commit
15b66bbc0e8010275089ee967c128fa98e135be8. In the mentioned commit there has
been a refactoring for disallowing `loadedType` calls inside an `askOption` (as
this can bring the presentation compiler in a bad state). The side-effect of
running `loadedType` _outside_ of `askOption` is that exception thrown inside
`loadedType` were hence left unhandled, and this resulted in the infinite
"Update Occurrences" error dialog to be displayed to the user.
