### PR TITLE
Use the proper platform methods in the Scala launcher

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
@@ -100,6 +100,9 @@ class ScalaPlugin extends AbstractUIPlugin with PluginLogConfigurator with IReso
   def classpathProblemMarkerId = pluginId + ".classpathProblem"
   def settingProblemMarkerId = pluginId + ".settingProblem"
 
+  /** All Scala error markers. */
+  val scalaErrorMarkers = Set(classpathProblemMarkerId, problemMarkerId, settingProblemMarkerId)
+
   // Retained for backwards compatibility
   val oldPluginId = "ch.epfl.lamp.sdt.core"
   val oldLibraryPluginId = "scala.library"

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/MainClassVerifier.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/MainClassVerifier.scala
@@ -18,27 +18,16 @@ class MainClassVerifier(reporter: MainClassVerifier.type#ErrorReporter) {
    * @typeName The fully-qualified main type name.
    */
   def execute(project: ScalaProject, mainTypeName: String): IStatus = {
-    // 1. No binaries are produced if the project contains compilation errors.
-    if (project.buildManager.hasErrors) {
-      return projectHasBuildErrors(project.underlying.getName)
-    }
-
     // Try to locate the type
     val element = project.javaProject.findType(mainTypeName)
 
-    // 2. The main type won't be found if the provided ``mainTypeName`` (fully-qualified name) doesn't 
-    //    reference an existing type. (this is a workaround for #1000541).
+    // The main type won't be found if the provided ``mainTypeName`` (fully-qualified name) doesn't
+    //  reference an existing type. (this is a workaround for #1000541).
     if (element == null) {
       return mainTypeCannotBeLocated(project.underlying.getName, mainTypeName)
     }
 
     new Status(IStatus.OK, ScalaPlugin.plugin.pluginId, "")
-  }
-
-  private def projectHasBuildErrors(projectName: String): IStatus = {
-    val errMsg = "Project '%s' contains compilation errors (therefore, no binaries have been produced).".format(projectName)
-    reporter.report(errMsg)
-    new Status(IStatus.ERROR, ScalaPlugin.plugin.pluginId, errMsg)
   }
 
   private def mainTypeCannotBeLocated(projectName: String, mainTypeName: String): IStatus = {


### PR DESCRIPTION
This is a small refactoring that improves a bit the Scala launcher:
- the existence of the main class is checked in `finalLaunchCheck`, instead of inside `launch`
- compilation errors are done through markers, and integrates with the platform error message. This check is also done during `finalLaunchCheck` and now prompts the user if any required project has compilation errors before launching.

Fixed #100740, possibly others. :)
