### PR TITLE
Small Refactoring

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/BreakpointSupport.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/BreakpointSupport.scala
@@ -19,23 +19,23 @@ import com.sun.jdi.request.EventRequest
 private[debug] object BreakpointSupport {
   // Initialize a breakpoint support instance
   def apply(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget): BreakpointSupport = {
-    val actor = BreakpointSupportActor(breakpoint, debugTarget)
-    new BreakpointSupport(actor)
+    val companionActor = BreakpointSupportActor(breakpoint, debugTarget)
+    new BreakpointSupport(companionActor)
   }
 }
 
 /**
  * Manage the requests for one platform breakpoint.
  */
-private[debug] class BreakpointSupport private (eventActor: Actor) {
+private[debug] class BreakpointSupport private (companionActor: Actor) {
   import BreakpointSupportActor.Changed
 
   def changed() {
-    eventActor ! Changed
+    companionActor ! Changed
   }
 
   def dispose() {
-    eventActor ! PoisonPill
+    companionActor ! PoisonPill
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStep.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStep.scala
@@ -16,7 +16,7 @@ trait ScalaStep {
   def stop()
 }
 
-class ScalaStepImpl(eventActor: BaseDebuggerActor) extends ScalaStep {
-  override def step(): Unit = eventActor ! ScalaStep.Step
-  override def stop(): Unit = eventActor ! ScalaStep.Stop
+class ScalaStepImpl(companionActor: BaseDebuggerActor) extends ScalaStep {
+  override def step(): Unit = companionActor ! ScalaStep.Step
+  override def stop(): Unit = companionActor ! ScalaStep.Stop
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
@@ -29,12 +29,12 @@ object ScalaStepInto {
 
     val stackFrames = scalaStackFrame.thread.getStackFrames
     val depth = stackFrames.length - stackFrames.indexOf(scalaStackFrame)
-    val actor = new ScalaStepIntoActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepIntoRequest, stepOutRequest, depth, scalaStackFrame.stackFrame.location.lineNumber) {
+    val companionActor = new ScalaStepIntoActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepIntoRequest, stepOutRequest, depth, scalaStackFrame.stackFrame.location.lineNumber) {
       override val scalaStep: ScalaStep = new ScalaStepImpl(this)
     }
-    actor.start()
+    companionActor.start()
     
-    actor.scalaStep
+    companionActor.scalaStep
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepReturn.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepReturn.scala
@@ -14,13 +14,13 @@ object ScalaStepReturn {
   def apply(scalaStackFrame: ScalaStackFrame): ScalaStep = {
     val stepReturnRequest = JdiRequestFactory.createStepRequest(StepRequest.STEP_LINE, StepRequest.STEP_OUT, scalaStackFrame.thread)
 
-    val actor = new ScalaStepReturnActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepReturnRequest) {
+    val companionActor = new ScalaStepReturnActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepReturnRequest) {
       // TODO: when implementing support without filtering, need to workaround problem reported in Eclipse bug #38744
       override val scalaStep: ScalaStep = new ScalaStepImpl(this) 
     }
-    actor.start()
+    companionActor.start()
 
-    actor.scalaStep
+    companionActor.scalaStep
   }
 }
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/MethodClassifier.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/MethodClassifier.scala
@@ -18,6 +18,8 @@ object MethodClassifier extends Enumeration {
  *        a proper class does not play out because it would move detection strategies
  *        in the companion object, preventing caching (like the constant pool)
  *
+ *  This class needs to be thread-safe.
+ *
  *  TODO: Cache expensive operations (currently `Forwarder` is the most expensive).
  */
 class MethodClassifier {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaJdiEventDispatcher.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaJdiEventDispatcher.scala
@@ -14,8 +14,8 @@ import scala.actors.Actor
 
 object ScalaJdiEventDispatcher {
   def apply(virtualMachine: VirtualMachine, scalaDebugTargetActor: BaseDebuggerActor): ScalaJdiEventDispatcher = {
-    val actor = ScalaJdiEventDispatcherActor(scalaDebugTargetActor)
-    new ScalaJdiEventDispatcher(virtualMachine, actor)
+    val companionActor = ScalaJdiEventDispatcherActor(scalaDebugTargetActor)
+    new ScalaJdiEventDispatcher(virtualMachine, companionActor)
   }
 }
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
@@ -20,7 +20,7 @@ class ThreadNotSuspendedException extends Exception
 object ScalaThread {
   def apply(target: ScalaDebugTarget, thread: ThreadReference): ScalaThread = {
     val scalaThread = new ScalaThread(target, thread) {
-      override val eventActor = ScalaThreadActor(this, thread)
+      override val companionActor = ScalaThreadActor(this, thread)
     }
     scalaThread.fireCreationEvent()
     scalaThread
@@ -97,7 +97,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   @volatile
   private var name: String = null
   
-  protected[debug] val eventActor: BaseDebuggerActor
+  protected[debug] val companionActor: BaseDebuggerActor
 
   val isSystemThread: Boolean = {
     try Option(thread.threadGroup).exists(_.name == "system")
@@ -107,16 +107,16 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
     }
   }
 
-  def suspendedFromScala(eventDetail: Int): Unit = eventActor !? SuspendedFromScala(eventDetail)
+  def suspendedFromScala(eventDetail: Int): Unit = companionActor !? SuspendedFromScala(eventDetail)
 
-  def resumeFromScala(eventDetail: Int): Unit = eventActor ! ResumeFromScala(None, eventDetail)
+  def resumeFromScala(eventDetail: Int): Unit = companionActor ! ResumeFromScala(None, eventDetail)
 
-  def resumeFromScala(step: ScalaStep, eventDetail: Int): Unit = eventActor ! ResumeFromScala(Some(step), eventDetail)
+  def resumeFromScala(step: ScalaStep, eventDetail: Int): Unit = companionActor ! ResumeFromScala(Some(step), eventDetail)
 
   def terminatedFromScala(): Unit = dispose()
 
   def invokeMethod(objectReference: ObjectReference, method: Method, args: Value*): Value = {
-    val future = eventActor !! InvokeMethod(objectReference, method, args.toList)
+    val future = companionActor !! InvokeMethod(objectReference, method, args.toList)
 
     future.inputChannel.receive {
       case value: Value =>
@@ -130,7 +130,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   def dispose() {
     running = false
     stackFrames= Nil
-    eventActor ! TerminatedFromScala
+    companionActor ! TerminatedFromScala
   }
   
   /*
@@ -194,7 +194,7 @@ private[model] class ScalaThreadActor private(scalaThread: ScalaThread, thread: 
   // step management
   private var currentStep: Option[ScalaStep] = None
 
-  override protected def postStart(): Unit = link(scalaThread.getDebugTarget.eventActor)
+  override protected def postStart(): Unit = link(scalaThread.getDebugTarget.companionActor)
   
   override protected def behavior = {
     case SuspendedFromScala(eventDetail) =>
@@ -227,6 +227,6 @@ private[model] class ScalaThreadActor private(scalaThread: ScalaThread, thread: 
   override protected def preExit(): Unit = {
     // before shutting down the actor we need to unlink it from the `debugTarget` actor to prevent that normal termination of 
     // a `ScalaThread` leads to shutting down the whole debug session.
-    unlink(scalaThread.getDebugTarget.eventActor)
+    unlink(scalaThread.getDebugTarget.companionActor)
   }
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/StepFilters.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/StepFilters.scala
@@ -9,7 +9,9 @@ import scala.tools.eclipse.debug.preferences.DebuggerPreferences
 import org.eclipse.core.internal.localstore.IsSynchronizedVisitor
 
 /** Utility methods for deciding when a location should be filtered out from stepping into.
- */
+  * 
+  * This class needs to be thread-safe.
+  */
 class StepFilters extends HasLogger {
 
   val classifier = new MethodClassifier


### PR DESCRIPTION
- Renamed `eventActor` into `companionActor`.
- Added a note on classes that need to be thread-safe.
- Passing an optional `Range` to `ScalaStepOver` (let's avoid using null).
