### PR TITLE
Refactoring

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/DebugTargetTerminationTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/DebugTargetTerminationTest.scala
@@ -149,7 +149,7 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def abruptTerminationOf_DebugTargetActor_is_gracefully_handled() {
-    val debugTargetActor = debugTarget.eventActor
+    val debugTargetActor = debugTarget.companionActor
 
     checkGracefulTerminationOf(debugTargetActor) when {
       debugTarget.terminate()
@@ -159,7 +159,7 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def normalTerminationOf_DebugTargetActor() {
-    val debugTargetActor = debugTarget.eventActor
+    val debugTargetActor = debugTarget.companionActor
 
     checkGracefulTerminationOf(debugTargetActor) when {
       debugTargetActor ! PoisonPill
@@ -168,8 +168,8 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def normalTerminationOf_DebugTargetActor_triggers_BreakpointManagerActor_termination() {
-    val debugTargetActor = debugTarget.eventActor
-    val breapointManagerActor = debugTarget.breakpointManager.eventActor
+    val debugTargetActor = debugTarget.companionActor
+    val breapointManagerActor = debugTarget.breakpointManager.companionActor
 
     checkGracefulTerminationOf(breapointManagerActor) when {
       debugTargetActor ! PoisonPill
@@ -178,8 +178,8 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def normalTerminationOf_BreakpointManagerActor_triggers_DebugTargetActor_termination() {
-    val debugTargetActor = debugTarget.eventActor
-    val breapointManagerActor = debugTarget.breakpointManager.eventActor
+    val debugTargetActor = debugTarget.companionActor
+    val breapointManagerActor = debugTarget.breakpointManager.companionActor
 
     checkGracefulTerminationOf(debugTargetActor) when {
       breapointManagerActor ! PoisonPill
@@ -188,8 +188,8 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def normalTerminationOf_DebugTargetActor_triggers_JdiEventDispatcherActor_termination() {
-    val debugTargetActor = debugTarget.eventActor
-    val jdiEventDispatcherActor = debugTarget.eventDispatcher.eventActor
+    val debugTargetActor = debugTarget.companionActor
+    val jdiEventDispatcherActor = debugTarget.eventDispatcher.companionActor
 
     checkGracefulTerminationOf(jdiEventDispatcherActor) when {
       debugTargetActor ! PoisonPill
@@ -198,8 +198,8 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def normalTerminationOf_JdiEventDispatcherActor_triggers_DebugTargetActor_termination() {
-    val debugTargetActor = debugTarget.eventActor
-    val jdiEventDispatcherActor = debugTarget.eventDispatcher.eventActor
+    val debugTargetActor = debugTarget.companionActor
+    val jdiEventDispatcherActor = debugTarget.eventDispatcher.companionActor
 
     checkGracefulTerminationOf(debugTargetActor) when {
       jdiEventDispatcherActor ! PoisonPill
@@ -208,8 +208,8 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def throwing_VMDisconnectedException_in_JdiEventDispatcher_triggers_DebugTargetActor_termination() {
-    val debugTargetActor = debugTarget.eventActor
-    val jdiEventDispatcherActor = debugTarget.eventDispatcher.eventActor
+    val debugTargetActor = debugTarget.companionActor
+    val jdiEventDispatcherActor = debugTarget.eventDispatcher.companionActor
 
     checkGracefulTerminationOf(debugTargetActor, jdiEventDispatcherActor) when {
       //eventQueue.remove happens every 1sec 
@@ -251,7 +251,7 @@ class DebugTargetTerminationTest extends HasLogger {
 
   @Test
   def anUnhandledExceptionGrafeullyTerminatesAllLinkedActors() {
-    val debugTargetActor = debugTarget.eventActor
+    val debugTargetActor = debugTarget.companionActor
 
     val sut = new BaseDebuggerActor {
       override protected def postStart(): Unit = link(debugTargetActor)

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentationTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentationTest.scala
@@ -49,7 +49,7 @@ class ScalaDebugModelPresentationTest {
 
   private def createThread(jdiThread: ThreadReference): ScalaThread = {
     val scalaThread = ScalaThread(null, jdiThread)
-    actor = Some(scalaThread.eventActor)
+    actor = Some(scalaThread.companionActor)
     scalaThread
   }
 

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugTargetTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaDebugTargetTest.scala
@@ -49,14 +49,14 @@ class ScalaDebugTargetTest {
     when(event.thread).thenReturn(thread)
     when(thread.name).thenReturn(ThreadName)
 
-    debugTarget.eventActor !? event
+    debugTarget.companionActor !? event
 
     val threads1 = debugTarget.getThreads
     assertEquals("Wrong number of threads", 1, threads1.length)
     assertEquals("Wrong thread name", ThreadName, threads1(0).getName)
 
     // a second start event should not result in a duplicate entry
-    debugTarget.eventActor !? event
+    debugTarget.companionActor !? event
 
     val threads2 = debugTarget.getThreads
     assertEquals("Wrong number of threads", 1, threads2.length)
@@ -72,7 +72,7 @@ class ScalaDebugTargetTest {
     
     val debugTarget= createDebugTarget
 
-    debugTarget.eventActor ! mock(classOf[VMDeathEvent])
+    debugTarget.companionActor ! mock(classOf[VMDeathEvent])
     debugTarget.getThreads
 
   }
@@ -91,7 +91,7 @@ class ScalaDebugTargetTest {
     val threadDeathRequest = mock(classOf[ThreadDeathRequest])
     when(eventRequestManager.createThreadDeathRequest).thenReturn(threadDeathRequest)
     val debugTarget = ScalaDebugTarget(virtualMachine, mock(classOf[Launch]), null)
-    actor = Some(debugTarget.eventActor)
+    actor = Some(debugTarget.companionActor)
     debugTarget
   }
 

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaThreadTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaThreadTest.scala
@@ -60,13 +60,13 @@ class ScalaThreadTest {
   private def anonDebugTarget: ScalaDebugTarget = {
     val debugTarget = mock(classOf[ScalaDebugTarget])
     val debugTargetActor = mock(classOf[BaseDebuggerActor])
-    when(debugTarget.eventActor).thenReturn(debugTargetActor)
+    when(debugTarget.companionActor).thenReturn(debugTargetActor)
     debugTarget
   }
 
   private def createThread(jdiThread: ThreadReference): ScalaThread = {
     val thread = ScalaThread(anonDebugTarget, jdiThread)
-    actor = Some(thread.eventActor)
+    actor = Some(thread.companionActor)
     thread
   }
 
@@ -141,7 +141,7 @@ class ScalaThreadTest {
 
     val thread = createThread(jdiThread)
 
-    thread.eventActor ! ScalaThreadActor.TerminatedFromScala
+    thread.companionActor ! ScalaThreadActor.TerminatedFromScala
     thread.getStackFrames
   }
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/BreakpointSupport.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/BreakpointSupport.scala
@@ -19,23 +19,23 @@ import com.sun.jdi.request.EventRequest
 private[debug] object BreakpointSupport {
   // Initialize a breakpoint support instance
   def apply(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget): BreakpointSupport = {
-    val actor = BreakpointSupportActor(breakpoint, debugTarget)
-    new BreakpointSupport(actor)
+    val companionActor = BreakpointSupportActor(breakpoint, debugTarget)
+    new BreakpointSupport(companionActor)
   }
 }
 
 /**
  * Manage the requests for one platform breakpoint.
  */
-private[debug] class BreakpointSupport private (eventActor: Actor) {
+private[debug] class BreakpointSupport private (companionActor: Actor) {
   import BreakpointSupportActor.Changed
 
   def changed() {
-    eventActor ! Changed
+    companionActor ! Changed
   }
 
   def dispose() {
-    eventActor ! PoisonPill
+    companionActor ! PoisonPill
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStep.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStep.scala
@@ -16,7 +16,7 @@ trait ScalaStep {
   def stop()
 }
 
-class ScalaStepImpl(eventActor: BaseDebuggerActor) extends ScalaStep {
-  override def step(): Unit = eventActor ! ScalaStep.Step
-  override def stop(): Unit = eventActor ! ScalaStep.Stop
+class ScalaStepImpl(companionActor: BaseDebuggerActor) extends ScalaStep {
+  override def step(): Unit = companionActor ! ScalaStep.Step
+  override def stop(): Unit = companionActor ! ScalaStep.Stop
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepInto.scala
@@ -29,12 +29,12 @@ object ScalaStepInto {
 
     val stackFrames = scalaStackFrame.thread.getStackFrames
     val depth = stackFrames.length - stackFrames.indexOf(scalaStackFrame)
-    val actor = new ScalaStepIntoActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepIntoRequest, stepOutRequest, depth, scalaStackFrame.stackFrame.location.lineNumber) {
+    val companionActor = new ScalaStepIntoActor(scalaStackFrame.getDebugTarget, scalaStackFrame.thread, stepIntoRequest, stepOutRequest, depth, scalaStackFrame.stackFrame.location.lineNumber) {
       override val scalaStep: ScalaStep = new ScalaStepImpl(this)
     }
-    actor.start()
+    companionActor.start()
     
-    actor.scalaStep
+    companionActor.scalaStep
   }
 
 }
@@ -51,7 +51,7 @@ private[command] abstract class ScalaStepIntoActor(debugTarget: ScalaDebugTarget
   
   protected[command] def scalaStep: ScalaStep
 
-  override protected def postStart(): Unit = link(thread.eventActor)
+  override protected def postStart(): Unit = link(thread.companionActor)
 
   override protected def behavior = {
     // JDI event triggered when a step has been performed
@@ -107,7 +107,7 @@ private[command] abstract class ScalaStepIntoActor(debugTarget: ScalaDebugTarget
 
   private def dispose(): Unit = {
     poison()
-    unlink(thread.eventActor)
+    unlink(thread.companionActor)
     val eventDispatcher = debugTarget.eventDispatcher
     val eventRequestManager = debugTarget.virtualMachine.eventRequestManager
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepOver.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/command/ScalaStepOver.scala
@@ -26,9 +26,9 @@ object ScalaStepOver {
 
     val requests = ListBuffer[EventRequest](stepOverRequest)
 
-    val actor = if (location.lineNumber == LINE_NUMBER_UNAVAILABLE) {
+    val companionActor = if (location.lineNumber == LINE_NUMBER_UNAVAILABLE) {
 
-      new ScalaStepOverActor(scalaStackFrame.getDebugTarget, null, scalaStackFrame.thread, requests) {
+      new ScalaStepOverActor(scalaStackFrame.getDebugTarget, rangeOpt = None, scalaStackFrame.thread, requests) {
         override val scalaStep: ScalaStep = new ScalaStepImpl(this)
       }
 
@@ -53,13 +53,13 @@ object ScalaStepOver {
 
       requests ++= loadedAnonFunctionsInRange.map(JdiRequestFactory.createMethodEntryBreakpoint(_, scalaStackFrame.thread))
 
-      new ScalaStepOverActor(scalaStackFrame.getDebugTarget, range, scalaStackFrame.thread, requests) {
+      new ScalaStepOverActor(scalaStackFrame.getDebugTarget, Some(range), scalaStackFrame.thread, requests) {
         override val scalaStep: ScalaStep = new ScalaStepImpl(this)
       }
     }
 
-    actor.start()
-    actor.scalaStep
+    companionActor.start()
+    companionActor.scalaStep
   }
 
 }
@@ -68,21 +68,24 @@ object ScalaStepOver {
  * Actor used to manage a Scala step over. It keeps track of the request needed to perform this step.
  * This class is thread safe. Instances are not to be created outside of the ScalaStepOver object.
  */
-private[command] abstract class ScalaStepOverActor(debugTarget: ScalaDebugTarget, range: Range, thread: ScalaThread, requests: ListBuffer[EventRequest]) extends BaseDebuggerActor {
+private[command] abstract class ScalaStepOverActor(debugTarget: ScalaDebugTarget, rangeOpt: Option[Range], thread: ScalaThread, requests: ListBuffer[EventRequest]) extends BaseDebuggerActor {
 
   protected[command] def scalaStep: ScalaStep
 
-  override protected def postStart(): Unit = link(thread.eventActor)
+  override protected def postStart(): Unit = link(thread.companionActor)
   
   override protected def behavior = {
     // JDI event triggered when a class has been loaded
     case classPrepareEvent: ClassPrepareEvent =>
-      debugTarget.stepFilters.anonFunctionsInRange(classPrepareEvent.referenceType, range).foreach(method => {
+      for {
+        range <- rangeOpt
+        method <- debugTarget.stepFilters.anonFunctionsInRange(classPrepareEvent.referenceType, range)
+      } {
         val breakpoint = JdiRequestFactory.createMethodEntryBreakpoint(method, thread)
         requests += breakpoint
         debugTarget.eventDispatcher.setActorFor(this, breakpoint)
         breakpoint.enable()
-      })
+      }
       reply(false)
     // JDI event triggered when a step has been performed
     case stepEvent: StepEvent =>
@@ -120,7 +123,7 @@ private[command] abstract class ScalaStepOverActor(debugTarget: ScalaDebugTarget
 
   private def dispose(): Unit = {
     poison()
-    unlink(thread.eventActor)
+    unlink(thread.companionActor)
     val eventDispatcher = debugTarget.eventDispatcher
     val eventRequestManager = debugTarget.virtualMachine.eventRequestManager
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/MethodClassifier.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/MethodClassifier.scala
@@ -18,6 +18,8 @@ object MethodClassifier extends Enumeration {
  *        a proper class does not play out because it would move detection strategies
  *        in the companion object, preventing caching (like the constant pool)
  *
+ *  This class is thread-safe.
+ *
  *  TODO: Cache expensive operations (currently `Forwarder` is the most expensive).
  */
 class MethodClassifier {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
@@ -20,7 +20,7 @@ class ThreadNotSuspendedException extends Exception
 object ScalaThread {
   def apply(target: ScalaDebugTarget, thread: ThreadReference): ScalaThread = {
     val scalaThread = new ScalaThread(target, thread) {
-      override val eventActor = ScalaThreadActor(this, thread)
+      override val companionActor = ScalaThreadActor(this, thread)
     }
     scalaThread.fireCreationEvent()
     scalaThread
@@ -97,7 +97,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   @volatile
   private var name: String = null
   
-  protected[debug] val eventActor: BaseDebuggerActor
+  protected[debug] val companionActor: BaseDebuggerActor
 
   val isSystemThread: Boolean = {
     try Option(thread.threadGroup).exists(_.name == "system")
@@ -107,16 +107,16 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
     }
   }
 
-  def suspendedFromScala(eventDetail: Int): Unit = eventActor !? SuspendedFromScala(eventDetail)
+  def suspendedFromScala(eventDetail: Int): Unit = companionActor !? SuspendedFromScala(eventDetail)
 
-  def resumeFromScala(eventDetail: Int): Unit = eventActor ! ResumeFromScala(None, eventDetail)
+  def resumeFromScala(eventDetail: Int): Unit = companionActor ! ResumeFromScala(None, eventDetail)
 
-  def resumeFromScala(step: ScalaStep, eventDetail: Int): Unit = eventActor ! ResumeFromScala(Some(step), eventDetail)
+  def resumeFromScala(step: ScalaStep, eventDetail: Int): Unit = companionActor ! ResumeFromScala(Some(step), eventDetail)
 
   def terminatedFromScala(): Unit = dispose()
 
   def invokeMethod(objectReference: ObjectReference, method: Method, args: Value*): Value = {
-    val future = eventActor !! InvokeMethod(objectReference, method, args.toList)
+    val future = companionActor !! InvokeMethod(objectReference, method, args.toList)
 
     future.inputChannel.receive {
       case value: Value =>
@@ -130,7 +130,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   def dispose() {
     running = false
     stackFrames= Nil
-    eventActor ! TerminatedFromScala
+    companionActor ! TerminatedFromScala
   }
   
   /*
@@ -194,7 +194,7 @@ private[model] class ScalaThreadActor private(scalaThread: ScalaThread, thread: 
   // step management
   private var currentStep: Option[ScalaStep] = None
 
-  override protected def postStart(): Unit = link(scalaThread.getDebugTarget.eventActor)
+  override protected def postStart(): Unit = link(scalaThread.getDebugTarget.companionActor)
   
   override protected def behavior = {
     case SuspendedFromScala(eventDetail) =>
@@ -227,6 +227,6 @@ private[model] class ScalaThreadActor private(scalaThread: ScalaThread, thread: 
   override protected def preExit(): Unit = {
     // before shutting down the actor we need to unlink it from the `debugTarget` actor to prevent that normal termination of 
     // a `ScalaThread` leads to shutting down the whole debug session.
-    unlink(scalaThread.getDebugTarget.eventActor)
+    unlink(scalaThread.getDebugTarget.companionActor)
   }
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/StepFilters.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/StepFilters.scala
@@ -9,7 +9,9 @@ import scala.tools.eclipse.debug.preferences.DebuggerPreferences
 import org.eclipse.core.internal.localstore.IsSynchronizedVisitor
 
 /** Utility methods for deciding when a location should be filtered out from stepping into.
- */
+  * 
+  * This class is thread-safe.
+  */
 class StepFilters extends HasLogger {
 
   val classifier = new MethodClassifier


### PR DESCRIPTION
- Renamed `eventActor` into `companionActor`.
- Added a note on classes that need to be thread-safe.
- Passing an optional `Range` to `ScalaStepOver` (let's avoid using null).
