### PR TITLE
Fix #1001330 - Race condition in ``ScalaDeclarationHyperlinkComputer``

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/hyperlink/text/detector/ScalaDeclarationHyperlinkComputer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/hyperlink/text/detector/ScalaDeclarationHyperlinkComputer.scala
@@ -76,14 +76,7 @@ class ScalaDeclarationHyperlinkComputer extends HasLogger {
                   DeclarationHyperlinkFactory.create(Hyperlink.withText("Open Declaration (%s)".format(sym.toString)), icu, sym, wordRegion).toList ::: links
               })
           }
-        }.flatten.headOption match {
-          case links @ Some(List()) =>
-            for(tree <- typed.left)
-              logger.info("Falling back to selection engine for %s!".format(tree.shortClass))
-            links
-          case links =>
-            links
-        }
+        }.flatten.headOption
       }
     })(None)
   }


### PR DESCRIPTION
It turns out that calling `Tree.toString` outside of the Presentation
Compiler Thread can trigger lazy evaluation of Tree's members, which is a problem
since the compiler's data structure are not thread-safe.

I'm hoping that `Tree.shortClass` will provide enough information when the
list of hyperlinks is empty (if you have a better candidate, please say
something, or open a pull request).
