### PR TITLE
Add test cases for semantic highlighting

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/AnnotationTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/AnnotationTest.scala
@@ -41,4 +41,20 @@ class AnnotationTest extends AbstractSymbolClassifierTest {
         "PKG" -> Package))
   }
 
+
+  @Test
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001352)")
+  def annotated_type() {
+    checkSymbolClassification("""
+      trait X {
+        def f[TPE](a: TPE): TPE @ annotation.unchecked.uncheckedVariance
+      }
+      """, """
+      trait X {
+        def f[$T$](a: $T$): $T$ @ annotation.unchecked.$ANNOT          $
+      }
+      """,
+      Map("T" -> Type, "ANNOT" -> Annotation))
+  }
+
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ClassTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/ClassTest.scala
@@ -145,4 +145,21 @@ class ClassTest extends AbstractSymbolClassifierTest {
       """,
       Map("CLS" -> Class))
   }
+  
+  @Test
+  @Ignore("does not work until presentation compiler stores more information in the AST (ticket #1001334)")
+  def default_arguments() {
+    checkSymbolClassification("""
+      class Foo(val f: Int = Bar.value)
+      object Bar {
+        val value = 0
+      }
+      """, """
+      class Foo(val f: Int = $C$.$VAL$)
+      object Bar {
+        val value = 0
+      }
+      """,
+      Map("C" -> Class, "VAL" -> TemplateVal))
+  }
 }


### PR DESCRIPTION
Further testcases that do not work due to too less information
in the AST provided by the compiler. The test cases should be
activated and implemented once the compiler stores more information.

I hope someday I can say that I found all possible syntax combinations that need an update in order to work for semantic highlighting. And then if I can fix them all I would be really happy... ;)
