### PR TITLE
Correctly cleanup 'fake' waiting process.

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/launching/RemoteConnectorTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/launching/RemoteConnectorTest.scala
@@ -220,6 +220,8 @@ class RemoteConnectorTest {
 
     // this command actually launch the debugger
     application = session.runToLine(TYPENAME_HELLOWORLD + "$", 6, () => launchInRunMode("HelloWorld attaching", port))
+    
+    assertEquals("The 'fake' process should have been removed after connection", session.debugTarget.getLaunch().getProcesses().length, 0)
 
     session.checkStackFrame(TYPENAME_HELLOWORLD + "$", "main([Ljava/lang/String;)V", 6)
   }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketListenConnectorScala.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketListenConnectorScala.scala
@@ -186,6 +186,7 @@ class ListenForConnectionJob(launch: ILaunch, process: ListenForConnectionProces
 
       ScalaDebugTarget(virtualMachine, launch, null, true, allowTerminate(launch))
 
+      connectionSuccesful()
       Status.OK_STATUS
     } catch {
       case e: TransportTimeoutException =>


### PR DESCRIPTION
Some how one line of code went missing while handling the review comments in #220.
The result is that the 'fake' process used to indicate the user that the debugger is waiting for a connection from the VM is never removed.

Added missing line.
Added check in test.
