### PR TITLE
Add semantic highlighting for symbols

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TypeTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/TypeTest.scala
@@ -90,4 +90,18 @@ class TypeTest extends AbstractSymbolClassifierTest {
       """,
       Map("TPE" -> Type))
   }
+
+  @Test
+  def symbols() {
+    checkSymbolClassification("""
+      object X {
+        val sym = 'symbol
+      }
+      """, """
+      object X {
+        val sym = $SYM  $
+      }
+      """,
+      Map("SYM" -> Symbol))
+  }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ColourPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ColourPreferenceInitializer.scala
@@ -119,6 +119,7 @@ class ColourPreferenceInitializer extends AbstractPreferenceInitializer {
     setDefaultsForSyntaxClass(PACKAGE, new RGB(0, 110, 4), enabled = false)
     setDefaultsForSyntaxClass(TYPE, new RGB(50, 147, 153), italic = true, enabled = false)
     setDefaultsForSyntaxClass(TYPE_PARAMETER, new RGB(23, 0, 129), underline = true, enabled = false)
+    setDefaultsForSyntaxClass(SYMBOL, new RGB(173, 142, 0), enabled = false)
   }
 
   // Mirror across the colour preferences into the Java preference store so that they can be read by the annotation

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ScalaSyntaxClasses.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ScalaSyntaxClasses.scala
@@ -42,6 +42,7 @@ object ScalaSyntaxClasses {
   val TRAIT = ScalaSyntaxClass("Trait", "syntaxColouring.semantic.trait", canBeDisabled = true)
   val TYPE = ScalaSyntaxClass("Type", "syntaxColouring.semantic.type", canBeDisabled = true)
   val TYPE_PARAMETER = ScalaSyntaxClass("Type parameter", "syntaxColouring.semantic.typeParameter", canBeDisabled = true)
+  val SYMBOL = ScalaSyntaxClass("Symbol", "syntaxColouring.semantic.symbol", canBeDisabled = true)
 
   case class Category(name: String, children: List[ScalaSyntaxClass])
 
@@ -51,7 +52,7 @@ object ScalaSyntaxClasses {
   val scalaSemanticCategory = Category("Scala (semantic)", List(
     ANNOTATION, CASE_CLASS, CASE_OBJECT, CLASS, LAZY_LOCAL_VAL, LAZY_TEMPLATE_VAL,
     LOCAL_VAL, LOCAL_VAR, METHOD, OBJECT, PACKAGE, PARAM, TEMPLATE_VAL, TEMPLATE_VAR,
-    TRAIT, TYPE, TYPE_PARAMETER))
+    TRAIT, TYPE, TYPE_PARAMETER, SYMBOL))
 
   val commentsCategory = Category("Comments", List(
     SINGLE_LINE_COMMENT, MULTI_LINE_COMMENT, SCALADOC))

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/SemanticHighlightingAnnotations.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/SemanticHighlightingAnnotations.scala
@@ -82,6 +82,7 @@ object SemanticHighlightingAnnotations {
       case Trait => TRAIT
       case Type => TYPE
       case TypeParameter => TYPE_PARAMETER
+      case Symbol => SYMBOL
     }
   }
   

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassification.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassification.scala
@@ -3,21 +3,7 @@ package scala.tools.eclipse.semantichighlighting.classifier
 import scala.PartialFunction.condOpt
 import scala.collection.mutable
 import scala.tools.eclipse.logging.HasLogger
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.Annotation
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.CaseClass
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.CaseObject
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.Class
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.LazyLocalVal
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.LazyTemplateVal
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.LocalVal
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.LocalVar
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.Method
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.Object
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.Param
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.TemplateVal
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.TemplateVar
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.Type
-import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes.Package
+import scala.tools.eclipse.semantichighlighting.classifier.SymbolTypes._
 import scala.tools.eclipse.ScalaPresentationCompiler
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.util.RangePosition
@@ -131,14 +117,15 @@ class SymbolClassification(protected val sourceFile: SourceFile, val global: Sca
     }
 
   private def getSymbolInfosFromSyntax(syntacticInfo: SyntacticInfo, localVars: Set[Region], all: Set[Region]): List[SymbolInfo] = {
-    val SyntacticInfo(namedArgs, forVals, maybeSelfRefs, maybeClassOfs, annotations, packages) = syntacticInfo
+    val SyntacticInfo(namedArgs, forVals, maybeSelfRefs, maybeClassOfs, annotations, packages, symbols) = syntacticInfo
     List(
       SymbolInfo(LocalVal, forVals toList, deprecated = false),
       SymbolInfo(Param, namedArgs filterNot localVars toList, deprecated = false),
       SymbolInfo(TemplateVal, maybeSelfRefs filterNot all toList, deprecated = false),
       SymbolInfo(Method, maybeClassOfs filterNot all toList, deprecated = false),
       SymbolInfo(Annotation, annotations filterNot all toList, deprecated = false),
-      SymbolInfo(Package, packages filterNot all toList, deprecated = false))
+      SymbolInfo(Package, packages filterNot all toList, deprecated = false),
+      SymbolInfo(Symbol, symbols.toList, deprecated = false))
   }
 
   private def prune(rawSymbolInfos: Seq[SymbolInfo]): Seq[SymbolInfo] = {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolInfo.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolInfo.scala
@@ -23,5 +23,6 @@ object SymbolTypes {
   case object Trait extends SymbolType
   case object Type extends SymbolType
   case object TypeParameter extends SymbolType
+  case object Symbol extends SymbolType
 
 }


### PR DESCRIPTION
Scala symbols do not have their own representation by a Symbol
type stored in the AST. Thus, they are highlighted as methods because
internally they are only passed as the apply method of class scala.Symbol.

To avoid highlighting symbols as methods scalariform is used to parse
them correctly and to make it possible to give them their own color in
the preferences.

Fixes #1001364
