### PR TITLE
Fix #1001202 - Unable to set breakpoint in source attachment

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/CompilationUnitAdapter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/CompilationUnitAdapter.scala
@@ -6,7 +6,6 @@
 package scala.tools.eclipse.javaelements
 
 import java.util.{ HashMap => JHashMap, Map => JMap }
-
 import org.eclipse.core.resources.{ IMarker, IResource }
 import org.eclipse.core.runtime.{ IAdaptable, IPath, IProgressMonitor, IStatus }
 import org.eclipse.core.runtime.jobs.ISchedulingRule
@@ -19,6 +18,7 @@ import org.eclipse.jdt.internal.compiler.env
 import org.eclipse.jdt.internal.core.{ BufferManager, DefaultWorkingCopyOwner, JavaElement, Openable, OpenableElementInfo, PackageFragmentRoot }
 import org.eclipse.jdt.internal.core.util.MementoTokenizer
 import org.eclipse.text.edits.{ TextEdit, UndoEdit }
+import org.eclipse.jdt.internal.core.PackageDeclaration
 
 class CompilationUnitAdapter(classFile : ScalaClassFile) extends Openable(classFile.getParent.asInstanceOf[JavaElement]) with ICompilationUnit with env.ICompilationUnit {
   override def getAdapter(adapter : Class[_]) : AnyRef = (classFile : IAdaptable).getAdapter(adapter)
@@ -161,7 +161,7 @@ class CompilationUnitAdapter(classFile : ScalaClassFile) extends Openable(classF
   def getPrimary() : ICompilationUnit = this
   def getOwner() : WorkingCopyOwner = DefaultWorkingCopyOwner.PRIMARY
   def getPackageDeclaration(name : String) : IPackageDeclaration = throw new UnsupportedOperationException
-  def getPackageDeclarations() : Array[IPackageDeclaration] = throw new UnsupportedOperationException
+  def getPackageDeclarations() : Array[IPackageDeclaration] = Array(new CompilationUnitAdapter.ScalaPackageDeclaration(classFile.getPackage))
   def getType(name : String) : IType = if (name == classFile.getTypeName()) classFile.getType() else throw new UnsupportedOperationException
   def getTypes() : Array[IType] = Array(classFile.getType())
   def getWorkingCopy(monitor : IProgressMonitor) : ICompilationUnit = classFile.getWorkingCopy(null, monitor)
@@ -171,4 +171,39 @@ class CompilationUnitAdapter(classFile : ScalaClassFile) extends Openable(classF
   def reconcile(astLevel : Int, forceProblemDetection : Boolean, enableStatementsRecovery : Boolean, owner : WorkingCopyOwner, monitor : IProgressMonitor) : CompilationUnit = null
   def reconcile(astLevel : Int, reconcileFlags : Int, owner : WorkingCopyOwner, monitor : IProgressMonitor) : CompilationUnit = null
   def getNameRange() : ISourceRange = throw new UnsupportedOperationException
+}
+
+object CompilationUnitAdapter {
+  import org.eclipse.jdt.internal.core.PackageFragment
+  import org.eclipse.jdt.core.IAnnotation
+
+  private class ScalaPackageDeclaration(_package: PackageFragment) extends IPackageDeclaration {
+    override def getElementName(): String = _package.getElementName()
+
+    override def getAnnotation(name: String): IAnnotation = throw new UnsupportedOperationException
+    override def getAnnotations(): Array[IAnnotation] = throw new UnsupportedOperationException
+    override def getNameRange: ISourceRange = throw new UnsupportedOperationException
+    override def getSourceRange: ISourceRange = throw new UnsupportedOperationException
+    override def getSource: String = throw new UnsupportedOperationException
+    override def exists(): Boolean = throw new UnsupportedOperationException
+
+    override def isStructureKnown: Boolean = throw new UnsupportedOperationException
+    override def isReadOnly: Boolean = throw new UnsupportedOperationException
+    override def getUnderlyingResource: IResource = throw new UnsupportedOperationException
+    override def getSchedulingRule: ISchedulingRule = throw new UnsupportedOperationException
+    override def getResource: IResource = throw new UnsupportedOperationException
+    override def getPrimaryElement: IJavaElement = throw new UnsupportedOperationException
+    override def getPath: IPath = throw new UnsupportedOperationException
+    override def getParent: IJavaElement = throw new UnsupportedOperationException
+    override def getOpenable: IOpenable = throw new UnsupportedOperationException
+    override def getJavaProject: IJavaProject = throw new UnsupportedOperationException
+    override def getJavaModel: IJavaModel = throw new UnsupportedOperationException
+    override def getHandleIdentifier: String = throw new UnsupportedOperationException
+    override def getElementType: Int = throw new UnsupportedOperationException
+    override def getCorrespondingResource: IResource = throw new UnsupportedOperationException
+    override def getAttachedJavadoc(monitor: IProgressMonitor): String = throw new UnsupportedOperationException
+    override def getAncestor(ancestorType: Int): IJavaElement = throw new UnsupportedOperationException
+    
+    override def getAdapter(adapter: Class[_]): AnyRef = throw new UnsupportedOperationException
+  }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFile.scala
@@ -60,12 +60,13 @@ class ScalaClassFile(parent : PackageFragment, name : String, sourceFile : Strin
     Util.concatWith(pkgFrag.names, sourceFile, '/')
   }
 
+  def getPackage(): PackageFragment = parent
+
   def getPackageName() : Array[Array[Char]] = {
-    val packageFragment = getParent.asInstanceOf[PackageFragment]
-    if (packageFragment == null)
+    if (getPackage == null)
       CharOperation.NO_CHAR_CHAR
     else
-      Util.toCharArrays(packageFragment.names)
+      Util.toCharArrays(getPackage.names)
   }
 
   class ScalaBinaryType(name : String) extends BinaryType(this, name) {


### PR DESCRIPTION
It turns out that setting a breakpoint on a module declaration could sometime
fail badly (an error dialog was displayed to the user).

The reason why this fails is really simple, a call to
`CompilationUnitAdapter.getPackageDeclarations` is performed while trying to
toggle the line breakpoint in the editor. And, because the existing
implementation of `CompilationUnitAdapter.getPackageDeclarations` used to
throw an `UnsupportedOperationException`, it's not a surpise that this used
to fail badly.

The quick fix was to implement that method so that the `PackageDeclaration`
for the opened classfile source is returned. And, in the specific case, the
`PackageDeclaration` is only needed to find the raw package name, which is
why I have only implemented the `getElementName` (look at
`ToggleBreakpointAdapter.createQualifiedTypeName`, at some point you will see
a call to `pd[0].getElementName();`, where `pd` is the
`PackageDeclaration`). This seems to be enough for fixing this specific
issue, and all considered, this fix can only improve on the status quo (simply
because the former implementation thrown an exception right away).

This PR doesn't come with test because the functionality is in the editor, and
we currently don't have a way to create UI tests.

That said, the whole logic we use to handle classfile sources looks a bit
broken.  First, why do we need `ScalaClassFile` to extend
`ScalaCompilationUnit`?  That does not quite make sense to me. And the fact
that the JDT `ClassFile` does not extend the JDT `ICompilationUnit` just
give one more indication that this is likely not needed. And, if we could make
`ScalaClassFile` not to extends `ScalaCompilationUnit`, we could then get
rid of the `CompilationUnitAdapter`. I've been spending a bit of time looking
into this, but unfortunately I don't have time to experiment this any further
at the moment. I've pushed what I have
[here](https://github.com/dotta/scala-ide/tree/wip/classfile-not-a-compilation-unit),
it's not clean but it should give an idea of where I am heading with this (and
hopefully I'll work on this during my spare time some time in the future).
