### PR TITLE
Small refactoring in ``ScalaThread``

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/JdiRequestFactory.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/JdiRequestFactory.scala
@@ -25,7 +25,7 @@ object JdiRequestFactory {
 
     val breakpointRequest = thread.getDebugTarget.virtualMachine.eventRequestManager.createBreakpointRequest(method.location)
     breakpointRequest.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD)
-    breakpointRequest.addThreadFilter(thread.thread)
+    breakpointRequest.addThreadFilter(thread.threadRef)
 
     breakpointRequest
   }
@@ -34,7 +34,7 @@ object JdiRequestFactory {
    * create a step request on the given thread
    */
   def createStepRequest(size: Int, depth: Int, thread: ScalaThread): StepRequest = {
-    val stepOverRequest = thread.getDebugTarget.virtualMachine.eventRequestManager.createStepRequest(thread.thread, size, depth)
+    val stepOverRequest = thread.getDebugTarget.virtualMachine.eventRequestManager.createStepRequest(thread.threadRef, size, depth)
     stepOverRequest.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD)
     stepOverRequest
   }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
@@ -127,9 +127,8 @@ abstract class ScalaDebugTarget private (val virtualMachine: VirtualMachine, lau
   @volatile
   private var threads = List[ScalaThread]()
 
-  protected[debug] val eventDispatcher: ScalaJdiEventDispatcher
-
-  protected[debug] val breakpointManager: ScalaDebugBreakpointManager
+  private[debug] val eventDispatcher: ScalaJdiEventDispatcher
+  private[debug] val breakpointManager: ScalaDebugBreakpointManager
   private[debug] val companionActor: BaseDebuggerActor
 
   /**
@@ -187,7 +186,7 @@ abstract class ScalaDebugTarget private (val virtualMachine: VirtualMachine, lau
    * FOR THE COMPANION ACTOR ONLY.
    */
   private[model] def addThread(thread: ThreadReference) {
-    if (!threads.exists(_.thread == thread))
+    if (!threads.exists(_.threadRef eq thread))
       threads = threads :+ ScalaThread(this, thread)
   }
 
@@ -196,7 +195,7 @@ abstract class ScalaDebugTarget private (val virtualMachine: VirtualMachine, lau
    * FOR THE COMPANION ACTOR ONLY.
    */
   private[model] def removeThread(thread: ThreadReference) {
-    val (removed, remainder) = threads.partition(_.thread eq thread)
+    val (removed, remainder) = threads.partition(_.threadRef eq thread)
     threads = remainder
     removed.foreach(_.terminatedFromScala())
   }
@@ -253,7 +252,7 @@ private class ScalaDebugTargetActor private (threadStartRequest: ThreadStartRequ
       reply(false)
     case ThreadSuspended(thread, eventDetail) =>
       // forward the event to the right thread
-      debugTarget.getScalaThreads.find(_.thread == thread).get.suspendedFromScala(eventDetail)
+      debugTarget.getScalaThreads.find(_.threadRef eq thread).get.suspendedFromScala(eventDetail)
   }
 
   private def vmStarted() {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
@@ -20,7 +20,7 @@ class ThreadNotSuspendedException extends Exception
 object ScalaThread {
   def apply(target: ScalaDebugTarget, thread: ThreadReference): ScalaThread = {
     val scalaThread = new ScalaThread(target, thread) {
-      override val companionActor = ScalaThreadActor(this, thread)
+      override val companionActor = ScalaThreadActor(this)
     }
     scalaThread.fireCreationEvent()
     scalaThread
@@ -31,7 +31,7 @@ object ScalaThread {
  * A thread in the Scala debug model.
  * This class is thread safe. Instances have be created through its companion object.
  */
-abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val thread: ThreadReference) extends ScalaDebugElement(target) with IThread {
+abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val threadRef: ThreadReference) extends ScalaDebugElement(target) with IThread {
   import ScalaThreadActor._
 
   // Members declared in org.eclipse.debug.core.model.IStep
@@ -53,17 +53,17 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
 
   override def resume(): Unit = resumeFromScala(DebugEvent.CLIENT_REQUEST)
   override def suspend(): Unit = {
-    thread.suspend()
+    threadRef.suspend()
     suspendedFromScala(DebugEvent.CLIENT_REQUEST)
   }
 
   // Members declared in org.eclipse.debug.core.model.IThread
 
-  override def getBreakpoints: Array[IBreakpoint] = Array() // TODO: need real logic
+  override def getBreakpoints: Array[IBreakpoint] = Array.empty // TODO: need real logic
 
   override def getName: String = {
     try {
-      name = thread.name
+      name = threadRef.name
     } catch {
       case e: ObjectCollectedException =>
         name = "<garbage collected>"
@@ -100,7 +100,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   protected[debug] val companionActor: BaseDebuggerActor
 
   val isSystemThread: Boolean = {
-    try Option(thread.threadGroup).exists(_.name == "system")
+    try Option(threadRef.threadGroup).exists(_.name == "system")
     catch {
       // some thread get created when a program terminates, and connection already closed
       case e: VMDisconnectedException => false
@@ -143,7 +143,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
    * FOR THE COMPANION ACTOR ONLY.
    */
   private[model] def suspend(eventDetail: Int) { 
-    stackFrames= thread.frames.asScala.map(ScalaStackFrame(this, _)).toList
+    stackFrames= threadRef.frames.asScala.map(ScalaStackFrame(this, _)).toList
     suspended = true
     fireSuspendEvent(eventDetail)
   }
@@ -164,7 +164,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
    * FOR THE COMPANION ACTOR ONLY.
    */
   private[model] def rebindScalaStackFrames() {
-    thread.frames.asScala.zip(stackFrames).foreach {
+    threadRef.frames.asScala.zip(stackFrames).foreach {
       case (jdiStackFrame, scalaStackFrame) => scalaStackFrame.rebind(jdiStackFrame)
     }    
   }
@@ -177,8 +177,8 @@ private[model] object ScalaThreadActor {
   case class InvokeMethod(objectReference: ObjectReference, method: Method, args: List[Value])
   case object TerminatedFromScala
   
-  def apply(scalaThread: ScalaThread, thread: ThreadReference): BaseDebuggerActor = {
-    val actor = new ScalaThreadActor(scalaThread, thread)
+  def apply(thread: ScalaThread): BaseDebuggerActor = {
+    val actor = new ScalaThreadActor(thread)
     actor.start()
     actor
   }
@@ -188,44 +188,44 @@ private[model] object ScalaThreadActor {
  * Actor used to manage a Scala thread. It keeps track of the existing stack frames, and of the execution status.
  * This class is thread safe. Instances are not to be created outside of the ScalaThread object.
  */
-private[model] class ScalaThreadActor private(scalaThread: ScalaThread, thread: ThreadReference) extends BaseDebuggerActor {
+private[model] class ScalaThreadActor private(thread: ScalaThread) extends BaseDebuggerActor {
   import ScalaThreadActor._
 
   // step management
   private var currentStep: Option[ScalaStep] = None
 
-  override protected def postStart(): Unit = link(scalaThread.getDebugTarget.companionActor)
+  override protected def postStart(): Unit = link(thread.getDebugTarget.companionActor)
   
   override protected def behavior = {
     case SuspendedFromScala(eventDetail) =>
       currentStep.foreach(_.stop())
       currentStep = None
-      scalaThread.suspend(eventDetail)
+      thread.suspend(eventDetail)
     case ResumeFromScala(step, eventDetail) =>
       currentStep = step
-      scalaThread.resume(eventDetail)
-      thread.resume()
+      thread.resume(eventDetail)
+      thread.threadRef.resume()
     case InvokeMethod(objectReference, method, args) =>
-      if (!scalaThread.isSuspended) {
+      if (!thread.isSuspended) {
         //FIXME: ticket #1001310
         throw new ThreadNotSuspendedException()
       } else {
         import scala.collection.JavaConverters._
-        val result = objectReference.invokeMethod(thread, method, args.asJava, ObjectReference.INVOKE_SINGLE_THREADED)
-        scalaThread.rebindScalaStackFrames()
+        val result = objectReference.invokeMethod(thread.threadRef, method, args.asJava, ObjectReference.INVOKE_SINGLE_THREADED)
+        thread.rebindScalaStackFrames()
         // update the stack frames
         reply(result)
       }
     case TerminatedFromScala =>
       currentStep.foreach(_.stop())
       currentStep = None
-      scalaThread.fireTerminateEvent()
+      thread.fireTerminateEvent()
       poison()
   }
   
   override protected def preExit(): Unit = {
     // before shutting down the actor we need to unlink it from the `debugTarget` actor to prevent that normal termination of 
     // a `ScalaThread` leads to shutting down the whole debug session.
-    unlink(scalaThread.getDebugTarget.companionActor)
+    unlink(thread.getDebugTarget.companionActor)
   }
 }


### PR DESCRIPTION
- Renamed `ScalaThread.thread` into `ScalaThread.threadRef`
- No need to pass the `threadRef` to the `ScalaThreadActor` constructor.
