### PR TITLE
Fixed #1001304 - NSDHO when hovering the Scala launch shortcut

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchShortcut.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchShortcut.scala
@@ -165,9 +165,11 @@ object ScalaLaunchShortcut {
         scu.withSourceFile { (source, comp) =>
           import comp._
 
-          def isTopLevelClass(cdef: Tree) =
-            (cdef.isInstanceOf[ClassDef]
-              && cdef.symbol.owner.isPackageClass)
+          def isTopLevelClass(cdef: Tree) = (
+            cdef.isInstanceOf[ClassDef] && 
+            cdef.symbol.isClass         && 
+            cdef.symbol.owner.isPackageClass
+          )
 
           def isTestClass(cdef: Tree): Boolean =
             comp.askOption { () =>
@@ -218,10 +220,11 @@ object ScalaLaunchShortcut {
           import comp._
           import definitions._
 
-          def isTopLevelModule(cdef: Tree) =
-            (cdef.isInstanceOf[ModuleDef]
-              && cdef.symbol.isModule
-              && cdef.symbol.owner.isPackageClass)
+          def isTopLevelModule(cdef: Tree) = (
+             cdef.isInstanceOf[ModuleDef] && 
+             cdef.symbol.isModule         && 
+             cdef.symbol.owner.isPackageClass
+          )
 
           // The given symbol is a method with the right name and signature to be a runnable java program.
           // should be run inside `askOption`

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchableTester.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchableTester.scala
@@ -48,10 +48,10 @@ class ScalaLaunchableTester extends PropertyTester {
   }
 
   /**
-   * Determines if the Scala element contains main method(s).
+   * Determines if the Scala element is in a source that contains one (or more) runnable JUnit test class.
    * 
    * @param element the element to check for the method 
-   * @return true if a method is found in the element, false otherwise
+   * @return true if one or more JUnit test classes are found in the element, false otherwise
    */
   private def canLaunchAsJUnit(element: IJavaElement): Boolean = {
     try {


### PR DESCRIPTION
When checking if a runnable JUnit test class is available in the compilation unit containing the selected code element, it is sometime possible to get a Scala compiler exception: `No symbol does not have an owner`. This happens when trying to access the `owner` member of a `Symbol` that is of type `NoSymbol`.

I'm unfortunately not sure on the whys this can happen, but the net result is particularly bad. The pragmatic solution is to check that the `symbol` is a `ClassSymbol`, and simply bail out when it isn't.

No test is available because we honestly have no clue about how to reproduce this. About that, I was considering adding some logging to get some information on when this happens. It looked like a good idea to me, but I haven't done it because the fix for the problem is identical to what we do [here](https://github.com/scala-ide/scala-ide/blob/master/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchShortcut.scala#L221), and we don't care to log in that case. 
Anyone knows why?

If you don't, below is an alternative fix that would provide us some hint of when this happens:

``` scala
def isTopLevelClass(tree: Tree) = tree match {
  case cdef: ClassDef =>
    if(cdef.symbol.isClass) cdef.symbol.owner.isPackageClass
    else {
      logger.info {
        """Cannot check if Tree `" + cdef.toString + "` is a top level class because 
           |it doesn't have a symbol. This may be a bug in the Scala compiler.
        """.stripMargin
      }
      false
    }

  case _ => false
}
```

And yes, I would add a similar one  [here](https://github.com/scala-ide/scala-ide/blob/master/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchShortcut.scala#L221).

What's your take on this?
