### PR TITLE
Fixed the build for Juno.

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketAttachConnectorScala.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketAttachConnectorScala.scala
@@ -20,7 +20,7 @@ import org.eclipse.jdi.TimeoutException
  * Attach connector creating a Scala debug session.
  * Added to the platform through extension point.
  */
-class SocketAttachConnectorScala extends SocketConnectorScala {
+class SocketAttachConnectorScala extends VMConnectorAdapter with SocketConnectorScala {
   import SocketConnectorScala._
 
   // from scala.tools.eclipse.launching.SocketConnectorScala
@@ -42,7 +42,7 @@ class SocketAttachConnectorScala extends SocketConnectorScala {
 
   override def getName(): String = "Scala debugger (Socket Attach)"
 
-  override def connect(params: JMap[_, _], monitor: IProgressMonitor, launch: ILaunch) {
+  override def typedConnect(params: JMap[String, String], monitor: IProgressMonitor, launch: ILaunch) {
 
     val arguments = generateArguments(params)
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketConnectorScala.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketConnectorScala.scala
@@ -57,15 +57,15 @@ trait SocketConnectorScala extends IVMConnector {
     }
     args
   }
-  
+
   /**
    * Create an argument map containing the values provided in the params map.
    */
-  def generateArguments(params: JMap[_, _]): JMap[String, Argument] = {
+  def generateArguments(params: JMap[String, String]): JMap[String, Argument] = {
     import scala.collection.JavaConverters._
     // convert to a usable type
-    val p = params.asInstanceOf[JMap[String, AnyRef]].asScala
-    
+    val p = params.asScala
+
     val arguments= connector.defaultArguments()
 
     // set the values from the params to the the connector arguments
@@ -78,7 +78,7 @@ trait SocketConnectorScala extends IVMConnector {
             throw ScalaDebugPlugin.wrapInCoreException("Unable to initialize connection, argument '%s' is not available".format(key), null)
         }
     }
-    
+
     arguments
   }
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketListenConnectorScala.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/SocketListenConnectorScala.scala
@@ -25,7 +25,7 @@ import com.sun.jdi.connect.TransportTimeoutException
  * Listen connector creating a Scala debug session.
  * Added to the platform through extension point.
  */
-class SocketListenConnectorScala extends SocketConnectorScala {
+class SocketListenConnectorScala extends VMConnectorAdapter with SocketConnectorScala {
   import SocketConnectorScala._
 
   // from scala.tools.eclipse.launching.SocketConnectorScala
@@ -47,7 +47,7 @@ class SocketListenConnectorScala extends SocketConnectorScala {
 
   override def getName(): String = "Scala debugger (Socket Listen)"
 
-  override def connect(params: JMap[_, _], monitor: IProgressMonitor, launch: ILaunch) {
+  override def typedConnect(params: JMap[String, String], monitor: IProgressMonitor, launch: ILaunch) {
     val arguments = generateArguments(params)
 
     // the port number is needed for the process label. It should be available if we got that far

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/VMConnectorAdapter.java
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/launching/VMConnectorAdapter.java
@@ -1,0 +1,30 @@
+package scala.tools.eclipse.launching;
+
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.jdt.launching.*;
+
+/**
+ * Workaround for compatibility between Indigo and Juno.
+ *
+ * The `connect` method changed signature to take type arguments, and Scala
+ * won't allow overriding
+ *   connect(Map<String, String> args, ..)
+ * with
+ *   connect(args: Map[_, _], ..)
+ *
+ * But we can do this in Java, and keep one source code for the two
+ * platforms.
+ */
+public abstract class VMConnectorAdapter implements IVMConnector {
+
+  public void connect(Map arguments, IProgressMonitor monitor, ILaunch launch) throws CoreException {
+    typedConnect((Map<String, String>) arguments, monitor, launch);
+  }
+
+  /** Same as `connect`, but with proper type paramters. */
+  public abstract void typedConnect(Map<String, String> arguments, IProgressMonitor monitor, ILaunch launch);
+}


### PR DESCRIPTION
The build was broken because Juno changed an interface method from taking a raw type to using a proper type, like this:

connect(Map args, ..)

to

connect(Map<String, String> args, ..)

We used to implement this method by using an existential type, but overriding rules prevent it in the new case. So we resort to Java, where we bridge the method in question towards one that has the proper generic type signature in both Indigo and Juno.

Fixed #1001374.
