### PR TITLE
Show implicit arguments in the quick fix for implicit highlighting.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ImplicitHighlightingPresenter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ImplicitHighlightingPresenter.scala
@@ -178,7 +178,9 @@ object ImplicitHighlightingPresenter {
       // TODO find the implicit args value
       val argsStr = t.args match {
         case null => ""
-        case l => l.collect { case x if x.hasSymbol => x.symbol.name }.mkString("( ", ", ", " )")
+        case l => l.collect {
+          case x if x.symbol ne null => x.symbol.fullName
+        }.mkString("( ", ", ", " )")
       }
       val annotation = new ImplicitArgAnnotation("Implicit arguments found: " + txt + DisplayStringSeparator + txt + argsStr)
       val pos = mkPosition(t.pos, txt)


### PR DESCRIPTION
`hasSymbol` is a misleading name: `TypeApply` nodes return false, though they definitely have a symbol. Changed the condition to filter on actually having a symbol.

Fixed #1001280.
