### PR TITLE
Show implicit arguments in the quick fix for implicit highlighting.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantic/ImplicitsHighlightingTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantic/ImplicitsHighlightingTest.scala
@@ -55,7 +55,7 @@ class ImplicitsHighlightingTest {
     withCompilationUnitAndCompiler("implicit-highlighting/ImplicitArguments.scala") {(src, compiler) =>
            
       val expected = List (
-        "Implicit arguments found: takesImplArg => takesImplArg( s ) [124, 12]"
+        "Implicit arguments found: takesImplArg => takesImplArg( implicits.ImplicitArguments.s ) [124, 12]"
       )
       val actual = implicits(src, compiler)
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ImplicitHighlightingPresenter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/implicits/ImplicitHighlightingPresenter.scala
@@ -35,7 +35,6 @@ import org.eclipse.jface.text.Region
 import scala.tools.eclipse.hyperlink.text._
 
 
-
 /**
  * @author Jin Mingjian
  * @author David Bernard
@@ -178,7 +177,12 @@ object ImplicitHighlightingPresenter {
       // TODO find the implicit args value
       val argsStr = t.args match {
         case null => ""
-        case l => l.collect { case x if x.hasSymbol => x.symbol.name }.mkString("( ", ", ", " )")
+        case l => l.map { x =>
+          if ((x.symbol ne null) && (x.symbol ne compiler.NoSymbol))
+            x.symbol.fullName
+          else
+            "<error>"
+        }.mkString("( ", ", ", " )")
       }
       val annotation = new ImplicitArgAnnotation("Implicit arguments found: " + txt + DisplayStringSeparator + txt + argsStr)
       val pos = mkPosition(t.pos, txt)


### PR DESCRIPTION
`hasSymbol` is a misleading name: `TypeApply` nodes return false, though they definitely have a symbol. Changed the condition to filter on actually having a symbol.

Fixed #1001280.
