### PR TITLE
Tweak the tests to workaround defect.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/findreferences/FindReferencesTests.scala
@@ -15,7 +15,6 @@ import scala.tools.eclipse.testsetup.FileUtils
 import scala.tools.eclipse.testsetup.SDTTestUtils
 import scala.tools.eclipse.testsetup.SearchOps
 import scala.tools.eclipse.testsetup.TestProjectSetup
-
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.NullProgressMonitor
@@ -206,7 +205,7 @@ class FindReferencesTests extends FindReferencesTester with HasLogger {
 
   @Test
   def findReferencesInConstructorSuperCall() {
-    val expected = fieldVal("foo.Bar$.v") isReferencedBy clazzConstructor("foo.Foo")
+    val expected = fieldVal("foo.Bar$.vvvv") isReferencedBy clazzConstructor("foo.Foo")
     runTest("super", "foo/Bar.scala", expected)
   }
 
@@ -218,7 +217,7 @@ class FindReferencesTests extends FindReferencesTester with HasLogger {
 
   @Test
   def findReferencesInClassFields() {
-    val expected = fieldVal("Bar$.v") isReferencedBy fieldVal("Foo.v")
+    val expected = fieldVal("Bar$.vvvv") isReferencedBy fieldVal("Foo.vvvv")
     runTest("field-ref", "Bar.scala", expected)
   }
 

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/field-ref/src/Bar.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/field-ref/src/Bar.scala
@@ -1,3 +1,3 @@
 object Bar {
-  val v/*ref*/ = 2
+  val vvvv/*ref*/ = 2
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/field-ref/src/Foo.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/field-ref/src/Foo.scala
@@ -1,3 +1,3 @@
 class Foo {
-  val v = Bar.v
+  val vvvv = Bar.vvvv
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/super/src/foo/Bar.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/super/src/foo/Bar.scala
@@ -1,5 +1,5 @@
 package foo
 
 object Bar {
-  val v/*ref*/ = 2
+  val vvvv/*ref*/ = 2
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/super/src/foo/Foo.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/super/src/foo/Foo.scala
@@ -1,3 +1,3 @@
 package foo
 
-class Foo extends Top(Bar.v)
+class Foo extends Top(Bar.vvvv)

--- a/org.scala-ide.sdt.core.tests/test-workspace/find-references/super/src/foo/Top.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/find-references/super/src/foo/Top.scala
@@ -1,3 +1,3 @@
 package foo
 
-class Top(val v: Int)
+class Top(val vvvv: Int)


### PR DESCRIPTION
On Linux, additional inaccurate matches are returned in the 2 updated tests (see #1001392).
Tweaked the test data to avoid being in this case.

Fix #1001391
