### PR TITLE
Refactoring of ScaladocAutoEditStrategyTest

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/ui/ScaladocAutoEditStrategyTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/ui/ScaladocAutoEditStrategyTest.scala
@@ -1,240 +1,371 @@
 package scala.tools.eclipse.ui
 
-import org.eclipse.jdt.internal.core.util.SimpleDocument
-import org.junit.Test
-import AutoEditStrategyTests._
-import org.eclipse.jface.text.Document
 import scala.tools.eclipse.lexical.ScalaDocumentPartitioner
-import org.eclipse.jface.text.IDocument
+
 import org.eclipse.jdt.ui.text.IJavaPartitions
+import org.eclipse.jface.text.{ Document, IDocument }
+import org.junit.{ ComparisonFailure, Test }
+
+import AutoEditStrategyTests.TestCommand
 
 class ScaladocAutoEditStrategyTest {
 
-  val strategy = new ScaladocAutoIndentStrategy(IJavaPartitions.JAVA_PARTITIONING)
-  
+  /**
+   * Tests if the input string is equal to the expected output.
+   *
+   * For each input and output string, there must be set the cursor position
+   * which is denoted by a ^ sign and must occur once.
+   *
+   * Sometimes it can happen that the input or output must contain trailing
+   * white spaces. If this is the case then a $ sign must be set to the position
+   * after the expected number of white spaces.
+   */
+  def test(input: String, expectedOutput: String) {
+    require(input.count(_ == '^') == 1, "the cursor in the input isn't set correctly")
+    require(expectedOutput.count(_ == '^') == 1, "the cursor in the expected output isn't set correctly")
+
+    def createDocument(input: String): IDocument = {
+      val rawInput = input.filterNot(_ == '^')
+      val doc = new Document(rawInput)
+      val partitioner = new ScalaDocumentPartitioner
+
+      doc.setDocumentPartitioner(IJavaPartitions.JAVA_PARTITIONING, partitioner)
+      partitioner.connect(doc)
+      doc
+    }
+
+    def createTestCommand(input: String): TestCommand = {
+      val pos = input.indexOf('^')
+      new TestCommand(pos, 0, "\n", -1, false, true)
+    }
+
+    val doc = createDocument(input)
+    val cmd = createTestCommand(input)
+    val strategy = new ScaladocAutoIndentStrategy(IJavaPartitions.JAVA_PARTITIONING)
+
+    strategy.customizeDocumentCommand(doc, cmd)
+    doc.replace(cmd.offset, 0, cmd.text)
+
+    val offset = if (cmd.caretOffset > 0) cmd.caretOffset else cmd.offset + cmd.text.length()
+    doc.replace(offset, 0, "^")
+
+    val expected = expectedOutput.replaceAll("\\$", "")
+    val actual = doc.get()
+
+    if (expected != actual) {
+      throw new ComparisonFailure("", expected, actual)
+    }
+  }
+
   @Test
   def openDocComment_topLevel() {
     val input =
       """
-/**^
-class Foo
-"""
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n * \n */", cmd.offset + 4, false, true, cmd)
+      /**^
+      class Foo
+      """
+    val expectedOutput =
+      """
+      /**
+       * ^
+       */
+      class Foo
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def openDocComment_topLevel_with_nested() {
     val input =
       """
-/**^
-class Foo {
-   /** blah */
-   def foo() {}
-}
-"""
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n * \n */", cmd.offset + 4, false, true, cmd)
+      /**^
+      class Foo {
+        /** blah */
+        def foo() {}
+      }
+      """
+    val expectedOutput =
+      """
+      /**
+       * ^
+       */
+      class Foo {
+        /** blah */
+        def foo() {}
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def openDocComment_topLevel_with_stringLit() {
     val input =
       """
-/**^
-class Foo {
-   def foo() {
-        "/* */" // tricky, this trips the Java auto-edit :-D
-  }
-}
-"""
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n * \n */", cmd.offset + 4, false, true, cmd)
+      /**^
+      class Foo {
+         def foo() {
+              "/* */" // tricky, this trips the Java auto-edit :-D
+        }
+      }
+      """
+    val expectedOutput =
+      """
+      /**
+       * ^
+       */
+      class Foo {
+         def foo() {
+              "/* */" // tricky, this trips the Java auto-edit :-D
+        }
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def openDocComment_nested() {
     val input =
       """
-/** blah */
-class Foo {
-   /**^
-   def foo() {
-  }
-}
-"""
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n    * \n    */", cmd.offset + 7, false, true, cmd)
+      /** blah */
+      class Foo {
+        /**^
+        def foo() {
+        }
+      }
+      """
+    val expectedOutput =
+      """
+      /** blah */
+      class Foo {
+        /**
+         * ^
+         */
+        def foo() {
+        }
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def openDocComment_nested_with_other_docs() {
     val input =
       """
-/** blah */
-class Foo {
-   /**^
-   def foo() {
-  }
-  /** */
-  def bar
-}
-"""
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n    * \n    */", cmd.offset + 7, false, true, cmd)
+      /** blah */
+      class Foo {
+        /**^
+        def foo() {
+        }
+        /** */
+        def bar
+      }
+      """
+    val expectedOutput =
+      """
+      /** blah */
+      class Foo {
+        /**
+         * ^
+         */
+        def foo() {
+        }
+        /** */
+        def bar
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def closedDocComment_topLevel() {
     val input =
       """
-/** ^blah */
-class Foo {
-}
-"""
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n * ", -1, false, true, cmd)
+      /** ^blah */
+      class Foo {
+      }
+      """
+    val expectedOutput =
+      """
+      /** $
+       * ^blah */
+      class Foo {
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def closedDocComment_topLevel_nested() {
     val input =
       """
-/** blah */
-class Foo {
-   /**^*/
-   def foo() {
-  }
-  /** */
-  def bar
-}
-"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n    * ", -1, false, true, cmd)
+      /** blah */
+      class Foo {
+        /**^*/
+        def foo() {
+        }
+        /** */
+        def bar
+      }
+      """
+    val expectedOutput =
+      """
+      /** blah */
+      class Foo {
+        /**
+         * ^*/
+        def foo() {
+        }
+        /** */
+        def bar
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def openDocComment_at_beginning() {
     val input =
-      """/**^class Foo {
-   def foo() {
-  }
-  /** */
-  def bar
-}
-"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n * \n */", cmd.offset + 4, false, true, cmd)
+      """
+      /**^class Foo {
+        def foo() {
+        }
+        /** */
+        def bar
+      }
+      """
+    val expectedOutput =
+      """
+      /**
+       * ^
+       */class Foo {
+        def foo() {
+        }
+        /** */
+        def bar
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def openDocComment_at_end() {
     val input =
       """
-class Foo {
-}/**^"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n* ", -1, false, true, cmd)
+      class Foo {
+      }/**^
+      """
+    val expectedOutput =
+      """
+      class Foo {
+      }/**
+      * ^
+      */
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def closedDocComment_first_char_of_line() {
     val input =
       """
-/**
-^
-*/
-class Foo {
-}"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n* ", -1, false, true, cmd)
+      /**
+      ^
+      */
+      class Foo {
+      }
+      """
+    val expectedOutput =
+      """
+      /**
+      $
+      * ^
+      */
+      class Foo {
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def closedDocComment_line_break() {
     val input =
       """
-/** one^two
- */
-class Foo {
-}"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n * ", -1, false, true, cmd)
+      /** one^two
+       */
+      class Foo {
+      }
+      """
+    val expectedOutput =
+      """
+      /** one
+       * ^two
+       */
+      class Foo {
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def closedDocComment_line_break_nested() {
     val input =
       """
-class Foo {
-  /** one^two
-   */
-  def meth() {}
-      
-}"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n   * ", -1, false, true, cmd)
+      class Foo {
+        /** one^two
+         */
+        def meth() {}
+      }
+      """
+    val expectedOutput =
+      """
+      class Foo {
+        /** one
+         * ^two
+         */
+        def meth() {}
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def closedDocComment_nop_end() {
     val input =
       """
-class Foo {
-  /** one two *^/
-  def meth() {}
-      
-}"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n   * ", -1, false, true, cmd)
+      class Foo {
+        /** one two *^/
+        def meth() {}
+      }
+      """
+    val expectedOutput =
+      """
+      class Foo {
+        /** one two *
+         * ^/
+        def meth() {}
+      }
+      """
+    test(input, expectedOutput)
   }
 
   @Test
   def closedDocComment_nop_beginning() {
     val input =
       """
-class Foo {
-  /^** one two */
-  def meth() {}
-      
-}"""
-
-    val cmd = testCommand(input)
-    strategy.customizeDocumentCommand(testDocument(input), cmd)
-    checkCommand(cmd.offset, 0, "\n   * ", -1, false, true, cmd)
+      class Foo {
+        /^** one two */
+        def meth() {}
+      }
+      """
+    val expectedOutput =
+      """
+      class Foo {
+        /
+         * ^** one two */
+        def meth() {}
+      }
+      """
+    test(input, expectedOutput)
   }
 
-  def testDocument(input: String): IDocument = {
-    val rawInput = input.filterNot(_ == '^')
-    val doc = new Document(rawInput)
-    val partitioner = new ScalaDocumentPartitioner
-    doc.setDocumentPartitioner(IJavaPartitions.JAVA_PARTITIONING, partitioner)
-    partitioner.connect(doc)
-    doc
-  }
-
-  def testCommand(input: String): TestCommand = {
-    val pos = input.indexOf('^')
-    new TestCommand(pos, 0, "\n", -1, false, true)
-  }
 }


### PR DESCRIPTION
The previous test class was difficult to work with because input
and expected output must be handled manually. The new test class
can compare input and output directly and is also able to check
the correct cursor position.
