### PR TITLE
Add URL hyperlink detector

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
@@ -40,6 +40,7 @@ import scalariform.ScalaVersions
 import org.eclipse.jface.text.DefaultTextHover
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.eclipse.ui.ScaladocAutoIndentStrategy
+import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector
 
 class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceStore: IPreferenceStore, editor: ITextEditor)
    extends JavaSourceViewerConfiguration(JavaPlugin.getDefault.getJavaTextTools.getColorManager, store, editor, IJavaPartitions.JAVA_PARTITIONING) {
@@ -96,7 +97,7 @@ class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceSto
      val strategies = List(DeclarationHyperlinkDetector(), ImplicitHyperlinkDetector())
      val detector = new CompositeHyperlinkDetector(strategies)
      if (editor != null) detector.setContext(editor)
-     Array(detector)
+     Array(detector, new URLHyperlinkDetector())
    }
 
    def getCodeAssist: Option[ICodeAssist] = Option(editor) map { editor =>


### PR DESCRIPTION
The URL hyperlink detector shows hyperlinks for URLs in comments
as well as strings.

Because the detector is functionality already built into the
Eclipse API, no tests are created.

Fix #1001266
