### PR TITLE
``sbt.precompiled.version`` has to match ``scala.version``

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -10,7 +10,7 @@ ROOT_DIR=${PWD}
 
 if [ -z "$*" ]
 then
-  ARGS="clean install"
+  ARGS="-P scala-2.9.x clean install"
 else
   ARGS="$*"
 fi

--- a/org.scala-ide.sdt.core/pom.xml
+++ b/org.scala-ide.sdt.core/pom.xml
@@ -94,7 +94,7 @@
             <goals><goal>add-source</goal></goals>
             <configuration>
               <sources>
-                <source>src-${scala.major.minor.version}</source>
+                <source>src-${scala.era.major.version}</source>
               </sources>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -55,33 +55,37 @@
     <repo.eclipse>${repo.eclipse.indigo}</repo.eclipse>
     <repo.ajdt>${repo.ajdt.indigo}</repo.ajdt>
 
-    <!-- default values, can be overwritten by profiles -->
-    <scala.version>2.9.3-SNAPSHOT</scala.version>
-    <scala.major.minor.version>2.9</scala.major.minor.version>
-    <scala.library.version>${scala.version}</scala.library.version>
-    <sbt.compiled.version>2.9.2</sbt.compiled.version>
-    <version.suffix>2_09</version.suffix>
-    <version.tag>local</version.tag>
+     <!-- default values, can be overwritten by profiles -->
+     <scala.version>2.9.3-SNAPSHOT</scala.version>
+     <scala.era.major.version>2.9</scala.era.major.version>
+     <scala.library.version>${scala.version}</scala.library.version>
+     <sbt.compiled.version>${scala.version}</sbt.compiled.version>
+     <version.suffix>2_09</version.suffix>
+     <version.tag>local</version.tag>
 
     <!-- the repos containing the Scala dependencies -->
-    <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-29x</repo.scala-refactoring>
-    <repo.scalariform>${repo.scala-ide.root}/scalariform-29x</repo.scalariform>
-    <repo.typesafe>http://repo.typesafe.com/typesafe/ide-2.9</repo.typesafe>
+    <repo.scala-refactoring>Select a profile</repo.scala-refactoring>
+    <repo.scalariform>Select a profile</repo.scalariform>
+    <repo.typesafe>Select a profile</repo.typesafe>
+
   </properties>
 
   <profiles>
     <profile>
       <!--- the profile using the default values. Scala 2.9.x -->
       <id>scala-2.9.x</id>
+      <properties>
+        <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-29x</repo.scala-refactoring>
+        <repo.scalariform>${repo.scala-ide.root}/scalariform-29x</repo.scalariform>
+        <repo.typesafe>http://repo.typesafe.com/typesafe/ide-2.9</repo.typesafe>
+      </properties>
     </profile>
 
     <profile>
       <id>scala-2.10.x</id>
       <properties>
         <scala.version>2.10.0-SNAPSHOT</scala.version>
-        <scala.major.minor.version>2.10</scala.major.minor.version>
-        <scala.library.version>${scala.version}</scala.library.version>
-        <sbt.compiled.version>2.10</sbt.compiled.version>
+        <scala.era.major.version>2.10</scala.era.major.version>
         <version.suffix>2_10</version.suffix>
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-210x</repo.scala-refactoring>
@@ -94,9 +98,7 @@
       <id>scala-2.11.x</id>
       <properties>
         <scala.version>2.11.0-SNAPSHOT</scala.version>
-        <scala.major.minor.version>2.11</scala.major.minor.version>
-        <scala.library.version>${scala.version}</scala.library.version>
-        <sbt.compiled.version>2.11</sbt.compiled.version>
+        <scala.era.major.version>2.11</scala.era.major.version>
         <version.suffix>2_11</version.suffix>
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-211x</repo.scala-refactoring>


### PR DESCRIPTION
It is really important that when we build the IDE, the sbt artifacts are
compiled against the exact same Scala compiler that is shipped in the IDE. To
this end, I've updated the value of `sbt.precompiled.version` to always match
the `scala.version` one. This is needed because while the Scala library is
ensured to be forward binary compatible across minor releases, no such
guarantee is provided for the Scala compiler (and the Sbt compiler-interface,
which we use in the IDE, does need to be linked against the Scala compiler).

As part of this commit, I've also made another small change to the property
`scala.major.minor.version` and renamed it `scala.era.major.version`, as
this what this property actually contains.
