### PR TITLE
Correct auto indent behavior in comments

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/ui/CommentAutoEditStrategyTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/ui/CommentAutoEditStrategyTest.scala
@@ -3,12 +3,12 @@ package scala.tools.eclipse.ui
 import scala.tools.eclipse.lexical.ScalaDocumentPartitioner
 
 import org.eclipse.jdt.ui.text.IJavaPartitions
-import org.eclipse.jface.text.{ Document, IDocument }
-import org.junit.{ ComparisonFailure, Test }
+import org.eclipse.jface.text.{Document, IDocument}
+import org.junit.{ComparisonFailure, Test}
 
 import AutoEditStrategyTests.TestCommand
 
-class ScaladocAutoEditStrategyTest {
+class CommentAutoEditStrategyTest {
 
   /**
    * Tests if the input string is equal to the expected output.
@@ -41,7 +41,7 @@ class ScaladocAutoEditStrategyTest {
 
     val doc = createDocument(input)
     val cmd = createTestCommand(input)
-    val strategy = new ScaladocAutoIndentStrategy(IJavaPartitions.JAVA_PARTITIONING)
+    val strategy = new CommentAutoIndentStrategy(IJavaPartitions.JAVA_PARTITIONING)
 
     strategy.customizeDocumentCommand(doc, cmd)
     doc.replace(cmd.offset, 0, cmd.text)
@@ -67,6 +67,23 @@ class ScaladocAutoEditStrategyTest {
     val expectedOutput =
       """
       /**
+       * ^
+       */
+      class Foo
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def openMultilineComment_topLevel() {
+    val input =
+      """
+      /*^
+      class Foo
+      """
+    val expectedOutput =
+      """
+      /*
        * ^
        */
       class Foo
@@ -187,7 +204,25 @@ class ScaladocAutoEditStrategyTest {
     val expectedOutput =
       """
       /** $
-       * ^blah */
+       *  ^blah */
+      class Foo {
+      }
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def closedMultilineComment_topLevel() {
+    val input =
+      """
+      /*  ^blah */
+      class Foo {
+      }
+      """
+    val expectedOutput =
+      """
+      /*  $
+       *  ^blah */
       class Foo {
       }
       """
@@ -265,7 +300,7 @@ class ScaladocAutoEditStrategyTest {
   }
 
   @Test
-  def closedDocComment_first_char_of_line() {
+  def closedDocComment_no_asterisk_on_empty_line() {
     val input =
       """
       /**
@@ -278,7 +313,51 @@ class ScaladocAutoEditStrategyTest {
       """
       /**
       $
-      * ^
+      ^
+      */
+      class Foo {
+      }
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def closedMultilineComment_no_asterisk_on_empty_line() {
+    val input =
+      """
+      /*
+      ^
+      */
+      class Foo {
+      }
+      """
+    val expectedOutput =
+      """
+      /*
+      $
+      ^
+      */
+      class Foo {
+      }
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def closedDocComment_no_asterisk_on_line_not_starting_with_asterisk() {
+    val input =
+      """
+      /**
+      hello^
+      */
+      class Foo {
+      }
+      """
+    val expectedOutput =
+      """
+      /**
+      hello
+      ^
       */
       class Foo {
       }
@@ -298,7 +377,27 @@ class ScaladocAutoEditStrategyTest {
     val expectedOutput =
       """
       /** one
-       * ^two
+       *  ^two
+       */
+      class Foo {
+      }
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def closedMultilineComment_line_break() {
+    val input =
+      """
+      /*  one^two
+       */
+      class Foo {
+      }
+      """
+    val expectedOutput =
+      """
+      /*  one
+       *  ^two
        */
       class Foo {
       }
@@ -320,7 +419,7 @@ class ScaladocAutoEditStrategyTest {
       """
       class Foo {
         /** one
-         * ^two
+         *  ^two
          */
         def meth() {}
       }
@@ -341,7 +440,7 @@ class ScaladocAutoEditStrategyTest {
       """
       class Foo {
         /** one two *
-         * ^/
+         *  ^/
         def meth() {}
       }
       """
@@ -364,6 +463,72 @@ class ScaladocAutoEditStrategyTest {
          * ^** one two */
         def meth() {}
       }
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def openDocComment_keep_indentation() {
+    val input =
+      """
+      /**   hello^
+      """
+    val expectedOutput =
+      """
+      /**   hello
+       *    ^
+       */
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def openMultilineComment_keep_indentation() {
+    val input =
+      """
+      /*   hello^
+      """
+    val expectedOutput =
+      """
+      /*   hello
+       *   ^
+       */
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def docComment_keep_indentation() {
+    val input =
+      """
+      /**
+       *    hello^
+       */
+      """
+    val expectedOutput =
+      """
+      /**
+       *    hello
+       *    ^
+       */
+      """
+    test(input, expectedOutput)
+  }
+
+  @Test
+  def multilineComment_keep_indentation() {
+    val input =
+      """
+      /*
+       *    hello^
+       */
+      """
+    val expectedOutput =
+      """
+      /*
+       *    hello
+       *    ^
+       */
       """
     test(input, expectedOutput)
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
@@ -39,7 +39,7 @@ import scala.tools.eclipse.hyperlink.text.detector.{CompositeHyperlinkDetector, 
 import scalariform.ScalaVersions
 import org.eclipse.jface.text.DefaultTextHover
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
-import scala.tools.eclipse.ui.ScaladocAutoIndentStrategy
+import scala.tools.eclipse.ui.CommentAutoIndentStrategy
 import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector
 
 class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceStore: IPreferenceStore, editor: ITextEditor)
@@ -125,7 +125,7 @@ class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceSto
       val partitioning = getConfiguredDocumentPartitioning(sourceViewer)
       contentType match {
          case IJavaPartitions.JAVA_DOC | IJavaPartitions.JAVA_MULTI_LINE_COMMENT =>
-           Array(new ScaladocAutoIndentStrategy(partitioning))
+           Array(new CommentAutoIndentStrategy(partitioning))
          case IJavaPartitions.JAVA_STRING =>
             Array(new SmartSemicolonAutoEditStrategy(partitioning), new JavaStringAutoIndentStrategy(partitioning))
          case IJavaPartitions.JAVA_CHARACTER | IDocument.DEFAULT_CONTENT_TYPE =>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/CommentAutoIndentStrategy.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/CommentAutoIndentStrategy.scala
@@ -1,20 +1,19 @@
 package scala.tools.eclipse.ui
 
-import org.eclipse.jface.text.DefaultIndentLineAutoEditStrategy
-import org.eclipse.jface.text.DocumentCommand
-import org.eclipse.jface.text.IDocument
-import org.eclipse.jface.text.TextUtilities
-import scala.tools.eclipse.lexical.ScalaPartitions
-import org.eclipse.jdt.ui.text.IJavaPartitions
-import org.eclipse.jface.text.BadLocationException
 import scala.tools.eclipse.logging.HasLogger
 
-/** A Scaladoc auto-edit strategy that does the following:
+import org.eclipse.jdt.ui.text.IJavaPartitions
+import org.eclipse.jface.text.{DefaultIndentLineAutoEditStrategy, DocumentCommand, IDocument, TextUtilities}
+
+/** An auto-edit strategy for Scaladoc and multiline comments that does the following:
  *
  *  - adds '*' and left-aligns them when pressing enter
- *  - auto-closes an open ScalaDoc and places the cursor in between
+ *  - automatically indentates to the start position of the text in the previous line of code
+ *  - auto-closes an open Scaladoc or multiline comment and places the cursor in between
+ *  - allows to enlarge a comment block without adding a star to the following line
+ *    by pressing enter on an empty line
  */
-class ScaladocAutoIndentStrategy(partitioning: String) extends DefaultIndentLineAutoEditStrategy with HasLogger {
+class CommentAutoIndentStrategy(partitioning: String) extends DefaultIndentLineAutoEditStrategy with HasLogger {
 
   override def customizeDocumentCommand(doc: IDocument, cmd: DocumentCommand) {
     if (cmd.offset == -1 || doc.getLength() == 0) return // don't spend time on invalid docs
@@ -26,17 +25,37 @@ class ScaladocAutoIndentStrategy(partitioning: String) extends DefaultIndentLine
         val (indent, rest) = breakLine(doc, cmd.offset)
         val buf = new StringBuilder(cmd.text)
         buf.append(indent)
-        val docStart = rest.length > 0 && rest(0) == '/'
 
-        // align the star under the other star
-        if (docStart) buf.append(" * ") else buf.append("* ")
+        lazy val shouldAddAsterisk = shouldClose || rest(0) == '/' || rest(0) == '*'
 
-        if (shouldClose) {
-          // we want the caret before the closing comment
-          cmd.caretOffset = cmd.offset + buf.length
-          buf append ("\n" + indent)
-          buf append (if (docStart) " */" else "*/")
-          cmd.shiftsCaret = false
+        if (!rest.isEmpty() && shouldAddAsterisk) {
+          val isDocStart = rest(0) == '/'
+          val docStarSize = if (isDocStart) 1 else 0
+          val isScaladoc = rest.length > 2 && rest.charAt(2) == '*'
+
+          /* Returns the white space indentation count */
+          def commentTextIndentation(i: Int) =
+            rest.drop(i + docStarSize).takeWhile(c => c == ' ' || c == '\t').size
+
+          val textIndent = {
+            val indent =
+              if (doc.getChar(cmd.offset - 1) == '/') 1
+              else if (isScaladoc) commentTextIndentation(2) + 1
+              else commentTextIndentation(1)
+
+            if (indent == 0) 1 else indent
+          }
+
+          buf.append(if (isDocStart) " *" else "*")
+          buf.append(" " * textIndent)
+
+          if (shouldClose) {
+            // we want the caret before the closing comment
+            cmd.caretOffset = cmd.offset + buf.length
+            buf append ("\n"+indent)
+            buf append (if (isDocStart) " */" else "*/")
+            cmd.shiftsCaret = false
+          }
         }
         cmd.text = buf.toString
       }


### PR DESCRIPTION
The old behavior did not correctly indent text inside of comments
whereas the comments themselves are indented correctly. This commit
corrects the behavior by indent a new line to the same depth as the
previous line.

Another feature introduced is, that if the enter key is pressed while
the cursor is adjusted in an line not starting with a *, a completely
empty line is inserted instead of auto inserting a \* sign at the begin
of the related line.

Furthermore, ScaladocAutoEditStrategy is renamed to
CommentAutoEditStrategy because this component does its auto edits not
only to Scaladoc but also to multi-line comments.
