### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,3 @@
 * Fixed bug in PresentationCompiler.parseTree - :ticket:`1001326`
 * Ignore non-existent source classpath entries - :ticket:`1001394`
+* Correct auto indent behavior in comments - :ticket:`1001432`


### PR DESCRIPTION
I added the entry after the previous one. Just tell me, if you want to have it the other way.

Btw, how to refer to a commit from Assembla? A normal `#<commit-hash>` doesn't do it.
