### PR TITLE
Correct partitioning of octal sequences in character literals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,3 +6,4 @@
 * Add syntax highlighting for Scaladoc - :ticket:`1001172`
 * Disable Java quick fixes/assists in Scala sources :ticket:`1001434`
 * Disable Run As/Debug As Java in Scala sources :ticket:`1001178`
+* Correct partitioning of octal sequences in character literals - :ticket:`1001443`

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniserTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniserTest.scala
@@ -158,6 +158,26 @@ class ScalaPartitionTokeniserTest {
       ((JAVA_MULTI_LINE_COMMENT, 0, 11))
   }
 
+  @Test
+  def char_literal() {
+    "'a'" ==> ((JAVA_CHARACTER, 0, 2))
+  }
+
+  @Test
+  def char_literal_containing_escape_sequence() {
+    """'\n'""" ==> ((JAVA_CHARACTER, 0, 3))
+  }
+
+  @Test
+  def char_literal_containing_unicode_sequence() {
+    "'\\u0000'" ==> ((JAVA_CHARACTER, 0, 7))
+  }
+
+  @Test
+  def char_literal_containing_octal_sequence() {
+    """'\123'""" ==> ((JAVA_CHARACTER, 0, 5))
+  }
+
 }
 
 object ScalaPartitionTokeniserTest {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniser.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniser.scala
@@ -180,7 +180,7 @@ class ScalaPartitionTokeniser(text: String) extends TokenTests {
         else if (ch(6) == '\'') Some(6)
         else if (ch(7) == '\'') Some(7)
         else None
-      else if (ch(2) == '0')
+      else if (isOctalDigit(ch(2)))
         if (ch(3) == '\'') Some(3)
         else if (ch(4) == '\'') Some(4)
         else if (ch(5) == '\'') Some(5)
@@ -193,6 +193,9 @@ class ScalaPartitionTokeniser(text: String) extends TokenTests {
       Some(2)
     else
       None
+
+  private def isOctalDigit(c: Char): Boolean =
+    c >= '0' && c <= '7'
 
   @tailrec
   private def getStringLit(isInterpolation: Boolean): Unit =


### PR DESCRIPTION
The previous behavior was not correct because an octal sequence can
start not only with a '0' but with all signs between '0' and '7'.

Fix #1001443
