### PR TITLE
Disable useless and expensive Java goodies for Scala sources.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,3 +4,5 @@
 * Add syntax highlighting for numeric literals - :ticket:`1001442`
 * Add syntax highlighting for escape sequences - :ticket:`1001372`
 * Add syntax highlighting for Scaladoc - :ticket:`1001172`
+* Disable Java quick fixes/assists in Scala sources :ticket:`1001434`
+* Disable Run As/Debug As Java in Scala sources :ticket:`1001178`

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/launching/JavaLaunchableTesterAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/launching/JavaLaunchableTesterAspect.aj
@@ -5,39 +5,32 @@
 
 package scala.tools.eclipse.contribution.weaving.jdt.launching;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.launching.JavaLaunchableTester;
+
+import scala.tools.eclipse.contribution.weaving.jdt.IScalaElement;
 
 @SuppressWarnings("restriction")
 public privileged aspect JavaLaunchableTesterAspect {
-  pointcut hasMain(JavaLaunchableTester jlt, IJavaElement element) :
-    execution(boolean JavaLaunchableTester.hasMain(IJavaElement)) &&
-    target(jlt) &&
-    args(element);
-  
-  boolean around(JavaLaunchableTester jlt, IJavaElement element) :
-    hasMain(jlt, element) {
-    try {
-      IType type = jlt.getType(element);
-      if(type != null && type.exists()) {
-        if(jlt.hasMainMethod(type)) {
-          return true;
-        }
-        //failed to find in public type, check static inner types
-        IJavaElement[] children = type.getChildren();
-        for(int i = 0; i < children.length; i++) {
-          type = jlt.getType(children[i]);
-          if(type != null && jlt.hasMainInChildren(type)) {
-            return true;
-          }
-        }
-      }
-    }
-    catch (JavaModelException e) {}
-    catch (CoreException ce){}
-    return false;
+  pointcut launchTesters(IJavaElement element, String name) :
+    execution(boolean JavaLaunchableTester.hasSuperclass(IJavaElement, String)) && args(element, name);
+
+  pointcut hasMain(IJavaElement element) :
+    execution(boolean JavaLaunchableTester.hasMain(IJavaElement)) && args(element);
+
+  boolean around(IJavaElement element) :
+    hasMain(element) {
+    if (element instanceof IScalaElement) {
+      return false;
+    } else
+      return proceed(element);
+  }
+
+  boolean around(IJavaElement element, String name) :
+    launchTesters(element, name) {
+    if (element instanceof IScalaElement) {
+      return false;
+    } else
+      return proceed(element, name);
   }
 }

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/javaeditor/ScalaEditorPreferencesAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/javaeditor/ScalaEditorPreferencesAspect.aj
@@ -5,7 +5,14 @@
 
 package scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor;
 
-import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
+import org.eclipse.jdt.internal.ui.text.correction.QuickAssistProcessor;
+import org.eclipse.jdt.internal.ui.text.correction.AdvancedQuickAssistProcessor;
+import org.eclipse.jdt.internal.ui.text.correction.QuickFixProcessor;
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+
+import scala.tools.eclipse.contribution.weaving.jdt.IScalaCompilationUnit;
 
 @SuppressWarnings("restriction")
 public privileged aspect ScalaEditorPreferencesAspect {
@@ -17,5 +24,21 @@ public privileged aspect ScalaEditorPreferencesAspect {
     isSemanticHighlightingEnabled() && target(editor) {
     // Disable Java semantic highlighting for Scala source
     return false;
+  }
+
+  pointcut getAssists(IInvocationContext context, IProblemLocation[] locations):
+    execution(IJavaCompletionProposal[] QuickAssistProcessor.getAssists(IInvocationContext, IProblemLocation[])) && args(context, locations) ||
+    execution(IJavaCompletionProposal[] AdvancedQuickAssistProcessor.getAssists(IInvocationContext, IProblemLocation[])) && args(context, locations) ||
+    execution(IJavaCompletionProposal[] QuickFixProcessor.getCorrections(IInvocationContext, IProblemLocation[])) && args(context, locations);
+
+  /**
+   * Disable Java quick fixes/assists on Scala sources. They can be very slow, and totally useless.
+   */
+  IJavaCompletionProposal[] around(IInvocationContext context, IProblemLocation[] locations):
+    getAssists(context, locations) {
+      if (context.getCompilationUnit() instanceof IScalaCompilationUnit)
+        return null;
+      else
+        return proceed(context, locations);
   }
 }


### PR DESCRIPTION
- quick fixes and quick assists in Scala sources have no meaning, but may trigger pauses in the UI of more than 10 seconds
- Run As/Debug As testers may trigger hierarchy calculations, inducing 10s of seconds of delay in the UI thread, for instance when scrolling through a contextual menu. This disables 'Run As Java'

Fixed #1001434. Fixed #1001178.
