### PR TITLE
Fix #1000984

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/MethodTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/MethodTest.scala
@@ -161,4 +161,18 @@ class MethodTest extends AbstractSymbolClassifierTest {
       """,
       Map("CLS" -> Class))
   }
+
+  @Test(expected = Predef.classOf[AssertionError])
+  def while_keyword_is_not_treated_as_method() {
+    checkSymbolClassification("""
+      object X {
+        while (false) {}
+      }
+      """, """
+      object X {
+        $MET$ (false) {}
+      }
+      """,
+      Map("MET" -> Method))
+  }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SafeSymbol.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/SafeSymbol.scala
@@ -104,6 +104,9 @@ trait SafeSymbol extends CompilerAccess with PimpedTrees {
     case ExistentialTypeTree(tpt, whereClauses) =>
       (tpt :: whereClauses).flatMap(safeSymbol)
 
+    case _: LabelDef =>
+      Nil
+
     case tpe @ Select(qualifier, _) =>
       val tpeSym = if (hasSourceCodeRepresentation(tpe)) global.askOption(() => tpe.symbol -> tpe.namePosition).toList else Nil
       val qualiSym = if(hasSourceCodeRepresentation(qualifier)) safeSymbol(qualifier) else Nil


### PR DESCRIPTION
I was unable to provide a test case for the while keyword, the testsuite does not allow to check the absence of symbols. Instead I checked if a normal method/value is treated correctly.
