### PR TITLE
Properly initialize Scala editor (quick fix/interactive error reporting ...

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
@@ -48,6 +48,24 @@ class PresentationCompilerTest {
   }
 
   @Test
+  def freshFileReportsErrors() {
+    val contentsWithErrors = """
+package t1001094
+
+class FreshFile {
+  val x: ListBuffer[Int] = null
+}"""
+    val unit = open("t1001094/FreshFile.scala")
+    val errors = unit.currentProblems()
+    Assert.assertEquals("Unexpected errors", errors, Nil)
+
+    unit.getBuffer().setContents(contentsWithErrors)
+    SDTTestUtils.waitUntil(5000)(unit.currentProblems ne Nil)
+    val errors1 = unit.currentProblems()
+    Assert.assertNotSame("Unexpected clean source", errors1, Nil)
+  }
+
+  @Test
   def implicitConversionFromPackageObjectShouldBeInScope_t1000647() {
     //when
     open("t1000647/foo/package.scala")

--- a/org.scala-ide.sdt.core.tests/test-workspace/pc/src/t1001094/FreshFile.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/pc/src/t1001094/FreshFile.scala
@@ -1,0 +1,5 @@
+package t1001094
+
+class FreshFile {
+  
+}


### PR DESCRIPTION
...works even before a save).

Compilation units in the JDT are backed up by a `buffer`, holding the source that 
hasn't been saved yet. We use the buffer to get notification of character changes,
and in turn notify the presentation compiler. Without a proper buffer, errors (and
quick fixes) are not reported either.

Buffers are created lazily by the JDT, and we mimic the JDT code in 
`buildStructure`.

Fixed #1001094, Fixed #1001337.
