### PR TITLE
Correctly list test methods in the JUnit search dialog

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -1485,9 +1485,11 @@
  <extension
        point="org.eclipse.jdt.junit.internal_testKinds">
        <!-- This extension point is copied from org.eclipse.jdt.junit.core, including the troubling questions. -->
+       <!-- We are forced to use the same `id` as the Java JUnit4 test runner because of the runtime test in   -->
+       <!-- JUnitLaunchConfigurationTab.getMethodsForType                                                      -->
     <kind
           displayName="Scala JUnit 4"
-          id="org.scala-ide.sdt.core.junit"
+          id="org.eclipse.jdt.junit.loader.junit4"
           finderClass="scala.tools.eclipse.launching.JUnit4TestFinder"
           loaderPluginId="org.eclipse.jdt.junit4.runtime"
           loaderClass="org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader">

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaJUnitLaunchShortcut.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaJUnitLaunchShortcut.scala
@@ -32,5 +32,12 @@ class ScalaJUnitLaunchShortcut extends JUnitLaunchShortcut {
 }
 
 object ScalaJUnitLaunchShortcut {
-  final val SCALA_JUNIT_TEST_KIND = "org.scala-ide.sdt.core.junit"
+  /**
+   *  We're using the JUnit test kind ID because of an internal test in
+   *  JUnitLaunchConfigurationTab.getMethodsForType. That test kicks in
+   *  when the user presses the Search button for methods inside a class,
+   *  and based on the ID it filters methods by name (JUnit3-style) or by
+   *  annotation (JUnit 4 style).
+   */
+  final val SCALA_JUNIT_TEST_KIND = "org.eclipse.jdt.junit.loader.junit4"
 }


### PR DESCRIPTION
Fix the search button in JUnit test configuration tab. We need to use the same
`id` in the test runner extension as the JUnit4 runner, otherwise the button
will look for JUnit _3_ tests.

Since all the code is in private methods in UI classes, there is no test for this.
I tried it out and works well for Java and Scala classes, with the Java and
Scala test runners (so using their ID does not seem to impact anything other than
our own code).

Fixed #1001474.
