### PR TITLE
Rebuild Scala projects after a global compiler settings change.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -478,16 +478,33 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
   private def buildManagerInitialize: String =
     storage.getString(SettingConverterUtil.convertNameToProperty(properties.ScalaPluginSettings.buildManager.name))
 
+  /** Does this project use project-specific compiler settings? */
+  def usesProjectSettings: Boolean =
+    projectSpecificStorage.getBoolean(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE)
+
+  /** Return a the project-specific preference store. This does not take into account the
+   *  user-preference whether to use project-specific compiler settings or not.
+   *
+   *  @note This can't be a `val` or a `def`, because of the way `PropertyStore` is implemented.
+   *  @see  #1001241.
+   *  @see `storage` for a method that decides based on user preference
+   */
+  def projectSpecificStorage: IPreferenceStore = {
+    new PropertyStore(underlying, ScalaPlugin.prefStore, plugin.pluginId)
+  }
+
   /** Return the current project preference store.
    *
    *  The returned store won't track changes happening in the background, so it represents a
    *  snapshot of this project's settings.
    *
+   *  @note This can't be a `val` or a `def`, because of the way `PropertyStore` is implemented.
    *  @see the half-broken implementation of `PropertyStore`
+   *  @see  #1001241.
    */
   def storage: IPreferenceStore = {
     val workspaceStore = ScalaPlugin.prefStore
-    val projectStore = new PropertyStore(underlying, workspaceStore, plugin.pluginId)
+    val projectStore = projectSpecificStorage
     val useProjectSettings = projectStore.getBoolean(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE)
 
     if (useProjectSettings) projectStore else workspaceStore

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
@@ -215,8 +215,14 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
         //Make sure project is rebuilt
         javaProject.getProject().build(IncrementalProjectBuilder.CLEAN_BUILD, null)
       case other =>
-        None // We're a Preference page!
-      //TODO - Figure out who needs to rebuild
+        // rebuild all Scala projects that use global settings
+        val plugin = ScalaPlugin.plugin
+
+        for {
+          p <- (plugin.workspaceRoot.getProjects())
+          scalaProject <- plugin.asScalaProject(p)
+          if !scalaProject.usesProjectSettings
+        } scalaProject.underlying.build(IncrementalProjectBuilder.CLEAN_BUILD, null)
     }
   }
 


### PR DESCRIPTION
If the user changes compiler settings on the Scala Preferences page, all Scala
projects that 'inherit' these settings should be rebuild. The existing logic
was dealing only with the case where _project-specific_ settings were changed.

Fixed #1001460.

Note: there is no test since this action is triggered from the 'ok' handler of the preference page. I think the changes are quite well-localized, so that shouldn't be a problem.
