### PR TITLE
Make the class path validator regexp stricter.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/classpath/ClasspathTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/classpath/ClasspathTests.scala
@@ -131,6 +131,12 @@ class ClasspathTests {
     setRawClasspathAndCheckMarkers(baseRawClasspath :+ newLibraryEntry("specs2_%s.2-0.12.3.jar".format(ScalaPlugin.plugin.shortScalaVer)), 0, 0)
   }
 
+  /** Major binary-compatible library on the classpath, Eclipse style
+   */
+  @Test
+  def binaryCompatibleLibraryEclipseNaming() {
+    setRawClasspathAndCheckMarkers(baseRawClasspath :+ newLibraryEntry("org.scala-ide.sdt.aspects_2.1.0.nightly-2_10-201301251404-6e75290.jar".format(ScalaPlugin.plugin.shortScalaVer)), 0, 0)
+  }
   /** Multiple binary-compatible libraries on the classpath
    */
   @Test

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ClasspathManagement.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ClasspathManagement.scala
@@ -380,7 +380,7 @@ trait ClasspathManagement extends HasLogger { self: ScalaProject =>
     def roundUp(version: String) =
       if (version.count(_ == '.') < 2) version + ".0" else version
 
-    val crossCompiled = """.*_(2\.\d+(\..*)?)(-.*)?.jar""".r
+    val crossCompiled = """.*_(2\.\d+(\.\d*)?)(-.*)?.jar""".r
     val entries = scalaClasspath.userCp
     val errors = mutable.ListBuffer[(Int, String)]()
 


### PR DESCRIPTION
This protects against jars that might have a 2.x.y version number that looks like
a Scala version, but it's not. We check now that the third digit, if exists, is a
digit, not any character. (previously it would fail the aspects_2.1.0.nightly jar)

Would love to merge this ASAP, so next nightly works again.
