### PR TITLE
Correct regression error in ScalaCodeScanner

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
@@ -74,7 +74,7 @@ trait ScalaCodeTokenizer {
   /** Tokenizes a string given by its offset and length in a document. */
   def tokenize(document: IDocument, offset: Int, length: Int): IndexedSeq[Range] = {
     val source = document.get(offset, length)
-    val token = ScalaLexer.tokenise(source, forgiveErrors = true).toIndexedSeq.init
+    val token = ScalaLexer.createRawLexer(source, forgiveErrors = true).toIndexedSeq.init
 
     /**
      * Heuristic to distinguish the macro keyword from uses as an identifier. To be 100% accurate requires a full parse,


### PR DESCRIPTION
After refactoring the ScalaCodeScanner I discarded all white space
token because I thought it is an optimization (they must never
be colored). The offset error now occurres because of another
optimization that is done in a component built-in in Eclipse:
org.eclipse.jface.text.rules.DefaultDamagerRepairer. Whenever this
component detects style ranges of the same type that are consecutive,
only the first style range is applied and then expanded for all
following ranges. Because white space token are omitted it can be that
a color range is expanded although it is not allowed.

To correct the behavior white space token are not discarded anymore.

Fix #1001481
