### PR TITLE
Debugger code does not handle checked exceptions in many places

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugger.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugger.scala
@@ -39,6 +39,13 @@ object ScalaDebugger extends ISelectionListener {
     }
   }
 
+  /** Currently selected thread in the debugger UI view.
+    *  
+    * WARNING: 
+    * Mind that this code is by design subject to race-condition, clients accessing this member need to handle the case where the 
+    * value of `currentThread` is not the expected one. Practically, this means that accesses to `currentThread` should always happen 
+    * within a try..catch block. Failing to do so can cause the whole debug session to shutdown for no good reasons.
+    */
   @volatile var currentThread: ScalaThread = null
 
   def init() {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
@@ -138,6 +138,7 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
     }
   }
 
+  //FIXME: Should handle checked exception `AbsentInformationException`
   def getSourceName(): String = stackFrame.location.sourceName
   
   /**
@@ -156,6 +157,11 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
 
   def getMethodFullName(): String = getFullName(stackFrame.location.method)
 
+  /** Set the current stack frame to `newStackFrame`. The `ScalaStackFrame.variables` don't need 
+    *  to be recomputed because a variable (i.e., a `ScalaLocalVariable`) always uses the latest 
+    *  stack frame to compute its value, as it can be checked by looking at the implementation of 
+    *  `ScalaLocalVariable.getValue`
+    */
   def rebind(newStackFrame: StackFrame) {
     stackFrame = newStackFrame
   }


### PR DESCRIPTION
I've added a number of FIXMEs notes in the debugger codebase where checked
exceptions are not handled. This commit is partly related to the discussions
that happened in teh PR 219 (https://github.com/scala-ide/scala-ide/pull/219)

Re #1001487

review by @skyluc
