### PR TITLE
Bump version number to 3.0.0-SNAPSHOT.

### DIFF
--- a/org.scala-ide.build-toolchain/pom.xml
+++ b/org.scala-ide.build-toolchain/pom.xml
@@ -5,12 +5,13 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>org.scala-ide.build-toolchain</artifactId>
   <description>The Scala Toolchain for Scala Eclipse plugins</description>
   <packaging>pom</packaging>
+  <version>3.0.0-SNAPSHOT</version>
 
   <modules>
     <module>../org.scala-ide.scala.library</module>

--- a/org.scala-ide.sbt.full.library/pom.xml
+++ b/org.scala-ide.sbt.full.library/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.build-toolchain</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.build-toolchain/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sbt.full.library</artifactId>

--- a/org.scala-ide.scala.compiler/pom.xml
+++ b/org.scala-ide.scala.compiler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.build-toolchain</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.build-toolchain/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.scala.compiler</artifactId>

--- a/org.scala-ide.scala.library/pom.xml
+++ b/org.scala-ide.scala.library/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.build-toolchain</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.build-toolchain/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.scala.library</artifactId>

--- a/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala JDT Weaving
 Bundle-SymbolicName: org.scala-ide.sdt.aspects;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: scala-ide.org
 Bundle-Activator: scala.tools.eclipse.contribution.weaving.jdt.ScalaJDTWeavingPlugin
 Require-Bundle: 

--- a/org.scala-ide.sdt.aspects/pom.xml
+++ b/org.scala-ide.sdt.aspects/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.aspects</artifactId>

--- a/org.scala-ide.sdt.build/pom.xml
+++ b/org.scala-ide.sdt.build/pom.xml
@@ -5,10 +5,11 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.scala-ide.sdt.build</artifactId>
   <packaging>pom</packaging>
+  <version>3.0.0-SNAPSHOT</version>
 
   <!-- scm configuration is require to extract the github hash-->
   <scm>
@@ -227,5 +228,4 @@
       </plugins>
     </pluginManagement>
   </build>
-
 </project>

--- a/org.scala-ide.sdt.core.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Plugin (Test)
 Bundle-SymbolicName: org.scala-ide.sdt.core.tests
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: scala-ide.org
 Fragment-Host: org.scala-ide.sdt.core
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/org.scala-ide.sdt.core.tests/pom.xml
+++ b/org.scala-ide.sdt.core.tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.core.tests</artifactId>

--- a/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Plugin
 Bundle-SymbolicName: org.scala-ide.sdt.core;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: scala-ide.org
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/org.scala-ide.sdt.core/pom.xml
+++ b/org.scala-ide.sdt.core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.core</artifactId>

--- a/org.scala-ide.sdt.debug.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Plugin (Test)
 Bundle-SymbolicName: org.scala-ide.sdt.debug.tests
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: scala-ide.org
 Fragment-Host: org.scala-ide.sdt.debug
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/org.scala-ide.sdt.debug.tests/pom.xml
+++ b/org.scala-ide.sdt.debug.tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.debug.tests</artifactId>

--- a/org.scala-ide.sdt.debug/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Debug Plugin
 Bundle-SymbolicName: org.scala-ide.sdt.debug;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: scala-ide.org
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
@@ -45,8 +45,8 @@ Require-Bundle:
  org.scala-ide.sbt.full.library;bundle-version="[0.13,0.14)",
  scalariform,
  org.junit4;bundle-version="4.5.0",
- org.eclipse.ui.browser;bundle-version="3.3.0",
- org.scala-ide.sdt.core;bundle-version="[2.1.0, 2.2.0)",
+ org.eclipse.ui.browser,
+ org.scala-ide.sdt.core,
  org.scala-ide.equinox-weaving-launcher;bundle-version="[1.1.0,2.0.0)";resolution:=optional
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,

--- a/org.scala-ide.sdt.debug/pom.xml
+++ b/org.scala-ide.sdt.debug/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.debug</artifactId>

--- a/org.scala-ide.sdt.dev.feature/feature.xml
+++ b/org.scala-ide.sdt.dev.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.scala-ide.sdt.dev.feature"
       label="Scala IDE for Eclipse dev support"
-      version="2.1.0.qualifier"
+      version="3.0.0.qualifier"
       provider-name="scala-ide.org">
 
    <description url="http://scala-ide.org/">

--- a/org.scala-ide.sdt.dev.feature/pom.xml
+++ b/org.scala-ide.sdt.dev.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.dev.feature</artifactId>

--- a/org.scala-ide.sdt.feature/feature.xml
+++ b/org.scala-ide.sdt.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.scala-ide.sdt.feature"
       label="Scala IDE for Eclipse"
-      version="2.1.0.qualifier"
+      version="3.0.0.qualifier"
       provider-name="scala-ide.org"
       plugin="org.scala-ide.sdt.core">
 

--- a/org.scala-ide.sdt.feature/pom.xml
+++ b/org.scala-ide.sdt.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.feature</artifactId>

--- a/org.scala-ide.sdt.source.feature/feature.xml
+++ b/org.scala-ide.sdt.source.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
   id="org.scala-ide.sdt.source.feature"
   label="Scala IDE for Eclipse Source"
-  version="2.1.0.qualifier"
+  version="3.0.0.qualifier"
   provider-name="scala-ide.org">
 
   <description url="http://scala-ide.org/">

--- a/org.scala-ide.sdt.source.feature/pom.xml
+++ b/org.scala-ide.sdt.source.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.source.feature</artifactId>

--- a/org.scala-ide.sdt.spy/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.spy/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Plugin Spy
 Bundle-SymbolicName: org.scala-ide.sdt.spy;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Scala IDE
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
@@ -23,7 +23,7 @@ Require-Bundle:
  org.eclipse.ui.ide,
  org.scala-ide.scala.library,
  org.scala-ide.scala.compiler,
- org.scala-ide.sdt.core;bundle-version="[2.1.0, 2.2.0)"
+ org.scala-ide.sdt.core
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse;apply-aspects:=false,

--- a/org.scala-ide.sdt.spy/pom.xml
+++ b/org.scala-ide.sdt.spy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.spy</artifactId>

--- a/org.scala-ide.sdt.update-site/pom.xml
+++ b/org.scala-ide.sdt.update-site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.update-site</artifactId>

--- a/org.scala-ide.sdt.weaving.feature/feature.xml
+++ b/org.scala-ide.sdt.weaving.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.scala-ide.sdt.weaving.feature"
       label="JDT Weaving for Scala"
-      version="2.1.0.qualifier"
+      version="3.0.0.qualifier"
       provider-name="scala-ide.org">
 
    <description>

--- a/org.scala-ide.sdt.weaving.feature/pom.xml
+++ b/org.scala-ide.sdt.weaving.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.sdt.build</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../org.scala-ide.sdt.build/pom.xml</relativePath>
   </parent>
   <artifactId>org.scala-ide.sdt.weaving.feature</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </prerequisites>
   <groupId>org.scala-ide</groupId>
   <artifactId>org.scala-ide.build</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <description>Default config holder (value, profiles, versions, ...) for the build of Scala IDE for Eclipse</description>
   <packaging>pom</packaging>
 
@@ -411,6 +411,11 @@
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-source-plugin</artifactId>
+          <version>${tycho.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-versions-plugin</artifactId>
           <version>${tycho.plugin.version}</version>
         </plugin>
         <!-- aspectJ support -->


### PR DESCRIPTION
Once we bump the version, I can branch for release/3.0.x.

I removed some versioned dependencies between our own core plugins (sdt.debug
to sdt.core, sdt.spy to sdt.core), as I think they are not needed and are just
a pain to maintain.
