### PR TITLE
Add checks if the underlying project closed/not exists

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/sbtbuilder/SbtBuilderTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/sbtbuilder/SbtBuilderTest.scala
@@ -25,6 +25,12 @@ import scala.tools.eclipse.buildmanager.sbtintegration._
 
 object SbtBuilderTest extends TestProjectSetup("builder") with CustomAssertion
 object depProject extends TestProjectSetup("builder-sub")
+object closedProject extends TestProjectSetup("closed-project-test") {
+  
+  def closeProject() {
+    project.underlying.close(null)
+  }
+}
 
 class SbtBuilderTest {
 
@@ -156,6 +162,13 @@ class SbtBuilderTest {
     val expectedLib = plugin.workspaceRoot.findMember("/library/bin").getLocation
     Assert.assertEquals("Unexpected Scala lib", expectedLib, prjClient.scalaClasspath.scalaLib.get)
     deleteProjects(prjClient, prjLib)
+  }
+
+  @Test def checkClosedProject() { 
+    closedProject.closeProject()
+    Assert.assertEquals("exportedDependencies", Nil, closedProject.project.exportedDependencies)
+    Assert.assertEquals("sourceFolders", Nil, closedProject.project.sourceFolders)
+    Assert.assertEquals("sourceOutputFolders", Nil, closedProject.project.sourceOutputFolders)
   }
 
   /** Returns true if the expected regular expression matches the given error message. */

--- a/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>closed-project-test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/.settings/org.eclipse.jdt.core.prefs
+++ b/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+#Mon Sep 26 15:26:50 CEST 2011
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/src/resource.txt
+++ b/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/src/resource.txt
@@ -1,0 +1,2 @@
+This resource has to be copied to the output folder.
+

--- a/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/src/subpack/Foo.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/closed-project-test/src/subpack/Foo.scala
@@ -1,0 +1,3 @@
+package subpack
+
+class Foo


### PR DESCRIPTION
There are scenarios, where project depends on other, closed projects -
this happens with IvyDE, which adds even closed projects to the dependency
list (of course, in that case, the generated jars added as well), but
these closed projects cause build failures for ScalaIDE, because it
doesn't expects that the underlying IJavaProject could throw exceptions.
So the general fix is to add checks before calling the critical methods,
and a catch block with logging.
 This fixes #1001465
