### PR TITLE
Solves bug in CommentAutoIndentStrategy

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/ui/CommentAutoEditStrategyTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/ui/CommentAutoEditStrategyTest.scala
@@ -533,4 +533,21 @@ class CommentAutoEditStrategyTest {
     test(input, expectedOutput)
   }
 
+  @Test
+  def docComment_close_before_code_blocks() {
+    val input =
+      """
+      /**^
+      /** {{{ }}} */
+      """
+    val expectedOutput =
+      """
+      /**
+       * ^
+       */
+      /** {{{ }}} */
+      """
+    test(input, expectedOutput)
+  }
+
 }


### PR DESCRIPTION
Because of the new introduced Scaladoc code blocks the end of open
Scaladoc comments was not correctly detected anymore. Before, there was
looked if the Scaladoc comment has reached the end of the file, now it
is also looked if the end is before a Scaladoc code block.

Fix #1001463

Should be backportet to 3.0
