### PR TITLE
Use proper `ask` call inside `mapType`.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -148,24 +148,25 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
   /** Returns the simple name for the passed symbol (it expects the symbol to be a type).*/ 
   def mapSimpleType(s: Symbol): String = mapType(s, javaSimpleName(_))
 
-  private def mapType(symbolType: Symbol, symbolType2StringName: Symbol => String) : String = {
+  private def mapType(symbolType: Symbol, symbolType2StringName: Symbol => String) : String = askOption { () =>
     val normalizedSymbol = 
       if(symbolType == null || symbolType == NoSymbol || symbolType.isRefinementClass || symbolType.owner.isRefinementClass || 
          symbolType == definitions.AnyRefClass || symbolType == definitions.AnyClass) 
         definitions.ObjectClass
       else symbolType
-    normalizedSymbol match {
-      case definitions.UnitClass    => "void"
-      case definitions.BooleanClass => "boolean"
-      case definitions.ByteClass    => "byte"
-      case definitions.ShortClass   => "short"
-      case definitions.IntClass     => "int"
-      case definitions.LongClass    => "long"
-      case definitions.FloatClass   => "float"
-      case definitions.DoubleClass  => "double"
-      case n => symbolType2StringName(n)
-    }
-  }
+
+      normalizedSymbol match {
+        case definitions.UnitClass    => "void"
+        case definitions.BooleanClass => "boolean"
+        case definitions.ByteClass    => "byte"
+        case definitions.ShortClass   => "short"
+        case definitions.IntClass     => "int"
+        case definitions.LongClass    => "long"
+        case definitions.FloatClass   => "float"
+        case definitions.DoubleClass  => "double"
+        case n                        => symbolType2StringName(n)
+      }
+    } getOrElse("unknown")
 
   /** Map a Scala `Type` that '''does not take type parameters''' into its
    *  Java representation.


### PR DESCRIPTION
The nightly build uncovered a race condition in the indexer, that stepped on
a case where `definitions.ShortClass` was not yet loaded, triggering the
symbol loader.

Needs back port. Should fix flaky presentation compiler tests.
