### PR TITLE
Initialize symbols for primitive types on compiler startup.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -101,6 +101,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
         initializeCompilerSettings(settings, isPCSetting(settings))
         val pc = new ScalaPresentationCompiler(ScalaProject.this, settings)
         logger.debug("Presentation compiler classpath: " + pc.classPath)
+        pc.askOption(() => pc.initializeRequiredSymbols())
         Some(pc)
       } catch {
         case ex @ MissingRequirementError(required) =>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -15,7 +15,19 @@ import org.eclipse.jdt.core._
 import org.eclipse.jdt.internal.core.JavaModelManager
 import org.eclipse.core.runtime.Path
 
-trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with HasLogger { self : ScalaPresentationCompiler => 
+trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with HasLogger { self : ScalaPresentationCompiler =>
+
+  private[eclipse] def initializeRequiredSymbols() {
+    import definitions._
+    Set(UnitClass,
+      BooleanClass,
+      ByteClass,
+      ShortClass,
+      IntClass,
+      LongClass,
+      FloatClass,
+      DoubleClass).foreach(_.initialize)
+  }
 
   /** Return the Java Element corresponding to the given Scala Symbol, looking in the
    *  given project list
@@ -148,12 +160,13 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
   /** Returns the simple name for the passed symbol (it expects the symbol to be a type).*/ 
   def mapSimpleType(s: Symbol): String = mapType(s, javaSimpleName(_))
 
-  private def mapType(symbolType: Symbol, symbolType2StringName: Symbol => String) : String = {
-    val normalizedSymbol = 
-      if(symbolType == null || symbolType == NoSymbol || symbolType.isRefinementClass || symbolType.owner.isRefinementClass || 
-         symbolType == definitions.AnyRefClass || symbolType == definitions.AnyClass) 
+  private def mapType(symbolType: Symbol, symbolType2StringName: Symbol => String): String = {
+    val normalizedSymbol =
+      if (symbolType == null || symbolType == NoSymbol || symbolType.isRefinementClass || symbolType.owner.isRefinementClass ||
+        symbolType == definitions.AnyRefClass || symbolType == definitions.AnyClass)
         definitions.ObjectClass
       else symbolType
+
     normalizedSymbol match {
       case definitions.UnitClass    => "void"
       case definitions.BooleanClass => "boolean"
@@ -163,7 +176,7 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
       case definitions.LongClass    => "long"
       case definitions.FloatClass   => "float"
       case definitions.DoubleClass  => "double"
-      case n => symbolType2StringName(n)
+      case n                        => symbolType2StringName(n)
     }
   }
 


### PR DESCRIPTION
The nightly build uncovered a race condition in the indexer, that stepped on
a case where `definitions.ShortClass` was not yet loaded, triggering the
symbol loader.

A race condition may happen inside `mapType`, where a symbol is pattern-matched against every possible primitive type. If those primitive types (like `definition.UnitClass`, etc.) have not yet been loaded, the compiler will load them (the usual laziness). To protect against that, one needs an `ask` call, but since these primitive types should be loaded once, and no other part of the method touches symbols, we optimize by making sure they are loaded always, and skip the `ask` call.

Needs back port. Should fix flaky presentation compiler tests.
