### PR TITLE
[backport] Disabled flaky debugger ``RemoteConnectorTest`` tests class

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/launching/RemoteConnectorTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/launching/RemoteConnectorTest.scala
@@ -25,6 +25,7 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import scala.tools.eclipse.debug.EclipseDebugEvent
+import org.junit.Ignore
 
 object RemoteConnectorTest extends TestProjectSetup("debug", bundleName = "org.scala-ide.sdt.debug.tests") with ScalaDebugRunningTest {
   import ScalaDebugTestSession._
@@ -149,6 +150,7 @@ object RemoteConnectorTest extends TestProjectSetup("debug", bundleName = "org.s
 /**
  * Test using the Scala remote connectors to debug applications
  */
+@Ignore("Enable it once #1001464 is fixed")
 class RemoteConnectorTest {
 
   import RemoteConnectorTest._


### PR DESCRIPTION
Re #1001464
(cherry picked from commit b0087295001c01757a8a44c450be97d4c9c74fa5)
