### PR TITLE
Make stepping as fast as in the JDT debugger.

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
@@ -15,9 +15,7 @@ import com.sun.jdi.StackFrame
 object ScalaStackFrame {
   
   def apply(thread: ScalaThread, stackFrame: StackFrame): ScalaStackFrame = {
-    val scalaStackFrame= new ScalaStackFrame(thread, stackFrame)
-    scalaStackFrame.fireCreationEvent()
-    scalaStackFrame
+    new ScalaStackFrame(thread, stackFrame)
   }
 
   // regexp for JNI signature
@@ -122,7 +120,7 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
 
   // ---
 
-  val variables: Seq[ScalaVariable] = {
+  lazy val variables: Seq[ScalaVariable] = {
     import scala.collection.JavaConverters._
     val visibleVariables = try {
       stackFrame.visibleVariables.asScala.map(new ScalaLocalVariable(_, this))


### PR DESCRIPTION
Two performance improvements in the way we handle stack frames:
- make `variables` lazy. This way we don't retrieve variables values
  unless they are needed (most of the times, they are needed for only one
  frame in a full thread stack). Retrieving values requires a roundtrip
  to the debugged VM, hitting the network stack.
- don't fire DebugEvents for creation of stack frames. This is the
  time consuming part: each frame (can be hundreds) fires one CREATE
  event that is put in a queue and a job-dispatch is scheduled to run for
  _each_ frame in part. This floods the event queue and leads to
  lag times in the order of seconds (depending on the stack depth).

I checked (in the debugger) that the JDT debugger does not fire CREATE
events for stack frames, so I'm suggesting we do the same thing.
