### PR TITLE
Implement 'Search test methods' in the Scala JUnit4 test runner.

### DIFF
--- a/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Require-Bundle:
  org.eclipse.ui.ide,
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.jdt.debug.ui,
- org.aspectj.runtime
+ org.aspectj.runtime,
+ org.eclipse.jdt.junit.core
 Eclipse-SupplementBundle: 
  org.eclipse.core.resources,
  org.eclipse.debug.core,
@@ -31,7 +32,8 @@ Eclipse-SupplementBundle:
  org.eclipse.jdt.launching,
  org.eclipse.jdt.ui,
  org.eclipse.pde.ui,
- org.eclipse.jdt.groovy.core
+ org.eclipse.jdt.groovy.core,
+ org.eclipse.jdt.junit
 Bundle-ActivationPolicy: lazy
 Export-Package: 
  scala.tools.eclipse.contribution.weaving.jdt,
@@ -52,8 +54,10 @@ Export-Package:
  scala.tools.eclipse.contribution.weaving.jdt.ui.actions,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter,
- scala.tools.eclipse.contribution.weaving.pde.ui
+ scala.tools.eclipse.contribution.weaving.pde.ui,
+ scala.tools.eclipse.contribution.weaving.jdt.launching
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: org.eclipse.equinox.frameworkadmin,
  org.eclipse.equinox.internal.simpleconfigurator.manipulator,
- org.eclipse.equinox.simpleconfigurator.manipulator
+ org.eclipse.equinox.simpleconfigurator.manipulator,
+ org.eclipse.jdt.junit.launcher

--- a/org.scala-ide.sdt.aspects/META-INF/aop.xml
+++ b/org.scala-ide.sdt.aspects/META-INF/aop.xml
@@ -31,5 +31,6 @@
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.debug.SuppressBreakpointMarkerUpdaterAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.debug.JDIModelPresentationAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.pde.ui.PluginImportAspect"/>
+<aspect name="scala.tools.eclipse.contribution.weaving.jdt.launching.JUnitLaunchConfigurationTabAspect"/>
 </aspects>
 </aspectj>

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/launching/ISearchMethods.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/launching/ISearchMethods.java
@@ -1,0 +1,11 @@
+package scala.tools.eclipse.contribution.weaving.jdt.launching;
+
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+
+public interface ISearchMethods {
+  /** Return all @Test annotated methods in the given type. */
+  public Set<String> getTestMethods(IJavaProject project, IType type);
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/launching/JUnitLaunchConfigurationTabAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/launching/JUnitLaunchConfigurationTabAspect.aj
@@ -1,0 +1,25 @@
+package scala.tools.eclipse.contribution.weaving.jdt.launching;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.internal.junit.launcher.TestKind;
+import org.eclipse.jdt.junit.launcher.JUnitLaunchConfigurationTab;
+
+@SuppressWarnings("restriction")
+public privileged aspect JUnitLaunchConfigurationTabAspect {
+
+  pointcut getMethodsForType(IJavaProject javaProject, IType type, TestKind testKind): 
+    execution(private Set<String> JUnitLaunchConfigurationTab.getMethodsForType(IJavaProject, IType, TestKind)) && args(javaProject, type, testKind);
+
+  Set<String> around(IJavaProject javaProject, IType type, TestKind testKind) : getMethodsForType(javaProject, type, testKind) {
+    if ((testKind == null) || testKind.getId().startsWith("org.eclipse.jdt.junit.loader")) {
+      return proceed(javaProject, type, testKind);
+    } else if (testKind.getFinder() instanceof ISearchMethods) {
+      return ((ISearchMethods)testKind.getFinder()).getTestMethods(javaProject, type);
+    } else
+      return new HashSet<String>();
+  }
+}

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/launching/TestFinderTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/launching/TestFinderTest.scala
@@ -9,6 +9,7 @@ import org.eclipse.core.runtime.Path
 import collection.JavaConverters._
 import org.eclipse.core.resources.IResource
 import scala.collection.mutable
+import org.junit.ComparisonFailure
 
 object TestFinderTest extends TestProjectSetup("test-finder")
 
@@ -23,13 +24,14 @@ class TestFinderTest {
     val possibleMatches = finder.filteredTestResources(project, project.javaProject, new NullProgressMonitor)
     val expected = Set(getResource("/src/packa/TestA.scala"),
       getResource("/src/packa/FakeTest.scala"),
+      getResource("/src/packc/TestC.scala"),
       getResource("/src/jpacka/JTestA.java"),
       getResource("/src/jpacka/RunWithTest.java"),
       getResource("/src/packb/TestB.scala"),
       getResource("/src/jpackb/FakeJavaTest.java"),
       getResource("/src/jpackb/JTestB.java"),
       getResource("/src/TestInEmptyPackage.scala"))
-    Assert.assertEquals("wrong filtered files", expected, possibleMatches.toSet)
+    assertEqualsSets("wrong filtered files", expected, possibleMatches.toSet)
   }
 
   @Test
@@ -39,7 +41,7 @@ class TestFinderTest {
     val result = new mutable.HashSet[IType]
     val possibleMatches = finder.filteredTestResources(project, project.javaProject.findPackageFragment("/test-finder/src/packa"), new NullProgressMonitor)
     val expected = Set(getResource("/src/packa/TestA.scala"), getResource("/src/packa/FakeTest.scala"))
-    Assert.assertEquals("wrong filtered files", expected, possibleMatches.toSet)
+    assertEqualsSets("wrong filtered files", expected, possibleMatches.toSet)
   }
 
   @Test
@@ -50,7 +52,7 @@ class TestFinderTest {
     finder.findTestsInContainer(project.javaProject.findPackageFragment("/test-finder/src/packa"), result, new NullProgressMonitor)
 
     val expected = Set(getType("packa.TestA"), getType("packa.TestA1"))
-    Assert.assertEquals("wrong tests found", expected, result)
+    assertEqualsSets("wrong tests found", expected, result)
   }
 
   @Test
@@ -61,7 +63,7 @@ class TestFinderTest {
     finder.findTestsInContainer(project.javaProject.findPackageFragment("/test-finder/src/jpacka"), result, new NullProgressMonitor)
 
     val expected = Set(getType("jpacka.JTestA"), getType("jpacka.RunWithTest"))
-    Assert.assertEquals("wrong tests found", expected, result.asScala.toSet)
+    assertEqualsSets("wrong tests found", expected, result.asScala.toSet)
   }
 
   @Test
@@ -72,7 +74,7 @@ class TestFinderTest {
     finder.findTestsInContainer(project.javaProject.findPackageFragment("/test-finder/src/jpackb"), result, new NullProgressMonitor)
 
     val expected = Set(getType("jpackb.JTestB"))
-    Assert.assertEquals("wrong tests found", expected, result.asScala.toSet)
+    assertEqualsSets("wrong tests found", expected, result.asScala.toSet)
   }
 
   @Test
@@ -89,8 +91,11 @@ class TestFinderTest {
       getType("packa.TestA"),
       getType("packa.TestA1"),
       getType("packb.TestB"),
+      getType("packc.TestC"),
+      getType("packc.TestCInherited1"),
+      getType("packc.TestCInherited2"),
       getType("TestInEmptyPackage"))
-    Assert.assertEquals("wrong tests found", expected, result.asScala.toSet)
+    assertEqualsSets("wrong tests found", expected, result.asScala.toSet)
   }
 
   @Test
@@ -106,9 +111,12 @@ class TestFinderTest {
       getType("jpackb.JTestB"),
       getType("packa.TestA"),
       getType("packa.TestA1"),
+      getType("packc.TestC"),
+      getType("packc.TestCInherited1"),
+      getType("packc.TestCInherited2"),
       getType("TestInEmptyPackage"),
       getType("packb.TestB"))
-    Assert.assertEquals("wrong tests found", expected, result.asScala.toSet)
+    assertEqualsSets("wrong tests found", expected, result.asScala.toSet)
   }
 
   @Test
@@ -121,7 +129,7 @@ class TestFinderTest {
 
     // there are two types in the same source, we want only the one that we passed to the finder to be returned
     val expected = Set(element)
-    Assert.assertEquals("wrong tests found", expected, result.asScala.toSet)
+    assertEqualsSets("wrong tests found", expected, result.asScala.toSet)
   }
 
   @Test
@@ -133,7 +141,7 @@ class TestFinderTest {
     finder.findTestsInContainer(element, result, new NullProgressMonitor)
 
     val expected = Set(element)
-    Assert.assertEquals("wrong tests found", expected, result.asScala.toSet)
+    assertEqualsSets("wrong tests found", expected, result.asScala.toSet)
   }
 
   @Test
@@ -146,9 +154,53 @@ class TestFinderTest {
     finder.findTestsInContainer(element, result, new NullProgressMonitor)
 
     val expected = Set(testClass)
-    Assert.assertEquals("wrong tests found", expected, result.asScala.toSet)
+    assertEqualsSets("wrong tests found", expected, result.asScala.toSet)
   }
 
+  @Test
+  def search_test_methods_decls() {
+    val finder = new JUnit4TestFinder
+    val testClass = getType("packa.TestA1")
+    val result = finder.getTestMethods(project.javaProject, testClass)
+    val expected = Set("testMethod1", "testMethod2")
+    assertEqualsSets("wrong test methods", expected, result.asScala)
+  }
+
+  @Test
+  def search_test_methods_inherited_from_class() {
+    val finder = new JUnit4TestFinder
+    val testClass = getType("packc.TestC")
+    val result = finder.getTestMethods(project.javaProject, testClass)
+    val expected = Set("testMethod1", "testMethod2", "derivedTestMethod1")
+    assertEqualsSets("wrong test methods", expected, result.asScala)
+  }
+
+  @Test
+  def search_test_methods_inherited_from_trait() {
+    val finder = new JUnit4TestFinder
+    val testClass = getType("packc.TestCInherited1")
+    val result = finder.getTestMethods(project.javaProject, testClass)
+    val expected = Set("traitTestMethod1")
+    assertEqualsSets("wrong test methods", expected, result.asScala)
+  }
+
+  @Test
+  def search_test_methods_inherited_from_abstract_class() {
+    val finder = new JUnit4TestFinder
+    val testClass = getType("packc.TestCInherited2")
+    val result = finder.getTestMethods(project.javaProject, testClass)
+    val expected = Set("abstractClassTestMethod1")
+    assertEqualsSets("wrong test methods", expected, result.asScala)
+  }
+
+  @Test
+  def search_test_methods_in_empty_package() {
+    val finder = new JUnit4TestFinder
+    val testClass = getType("TestInEmptyPackage")
+    val result = finder.getTestMethods(project.javaProject, testClass)
+    val expected = Set("foo")
+    assertEqualsSets("wrong test methods", expected, result.asScala)
+  }
   private def getType(fullyQualifiedName: String): IType =
     project.javaProject.findType(fullyQualifiedName)
 
@@ -156,4 +208,8 @@ class TestFinderTest {
     project.underlying.findMember(absolutePath)
 
   implicit def stringsArePaths(str: String): Path = new Path(str)
+
+  def assertEqualsSets[T](msg: String, set1: collection.Set[T], set2: collection.Set[T]) = {
+    if (set1 != set2) throw new ComparisonFailure(msg, set1.toString, set2.toString)
+  }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/test-finder/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/test-finder/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/test-finder/src/packc/TestC.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/test-finder/src/packc/TestC.scala
@@ -1,0 +1,21 @@
+package packc
+
+import org.junit.Test
+
+class TestC extends packa.TestA1 {
+  @Test
+  def derivedTestMethod1() {}
+}
+
+trait T1 {
+  @Test
+  def traitTestMethod1() {}
+}
+
+abstract class ATest1 {
+  @Test
+  def abstractClassTestMethod1() {}
+}
+
+class TestCInherited1 extends T1 {}
+class TestCInherited2 extends ATest1 {}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/JUnit4TestClassesCollector.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/JUnit4TestClassesCollector.scala
@@ -15,7 +15,7 @@ import org.eclipse.jdt.core.IType
   * any "runnable" JUnit test classes. This assumption is of course enforced in the code,
   * have a look at the companion object.
   */
-private[launching] abstract class JUnit4TestClassesCollector {
+private[launching] abstract class JUnit4TestClassesCollector extends HasLogger {
   protected val global: ScalaPresentationCompiler
 
   import global._
@@ -32,8 +32,6 @@ private[launching] abstract class JUnit4TestClassesCollector {
 
   /** Traverse the passed `Tree` and collect all class definitions that can be executed by the JUnit4 runtime. */
   private class JUnit4TestClassesTraverser extends global.Traverser {
-    import JUnit4TestClassesTraverser._
-
     val hits: ListBuffer[ClassDef] = ListBuffer.empty
 
     override def traverse(tree: Tree): Unit = tree match {
@@ -72,19 +70,17 @@ private[launching] abstract class JUnit4TestClassesCollector {
     }
   }
 
-  private object JUnit4TestClassesTraverser extends HasLogger {
-    private lazy val TestAnnotationOpt = getClassSafe("org.junit.Test")
-    private lazy val RunWithAnnotationOpt = getClassSafe("org.junit.runner.RunWith")
+  lazy val TestAnnotationOpt = getClassSafe("org.junit.Test")
+  lazy val RunWithAnnotationOpt = getClassSafe("org.junit.runner.RunWith")
 
-    /** Don't crash if the class is not on the classpath. */
-    private def getClassSafe(fullName: String): Option[Symbol] = {
-      try {
-        Option(definitions.getClass(newTypeName(fullName)))
-      } catch {
-        case _: MissingRequirementError =>
-          logger.info("Type `" + fullName + "` is not available in the project's classpath.")
-          None
-      }
+  /** Don't crash if the class is not on the classpath. */
+  def getClassSafe(fullName: String): Option[Symbol] = {
+    try {
+      Option(definitions.getClass(newTypeName(fullName)))
+    } catch {
+      case _: MissingRequirementError =>
+        logger.info("Type `" + fullName + "` is not available in the project's classpath.")
+        None
     }
   }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/JUnit4TestFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/JUnit4TestFinder.scala
@@ -1,6 +1,7 @@
 package scala.tools.eclipse.launching
 
 import collection.mutable
+import collection.immutable
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.core.runtime.IProgressMonitor
 import java.util.{ Set => JSet }
@@ -31,6 +32,7 @@ import org.eclipse.jdt.core.IMember
 import org.eclipse.jdt.core.IPackageFragmentRoot
 import scala.tools.eclipse.logging.HasLogger
 import org.eclipse.jdt.core.IParent
+import scala.tools.eclipse.contribution.weaving.jdt.launching.ISearchMethods
 
 /** A JUnit4 test finder that works for Java and Scala.
  *
@@ -50,7 +52,7 @@ import org.eclipse.jdt.core.IParent
  *  - classes that *don't* define any @Test members, but inherit them, are not found in Scala sources
  *     - this can be worked around by adding `@Test` anywhere in the file, for instance as a comment
  */
-class JUnit4TestFinder extends ITestFinder with HasLogger {
+class JUnit4TestFinder extends ITestFinder with ISearchMethods with HasLogger {
   import JUnit4TestFinder._
 
   override def findTestsInContainer(element: IJavaElement, result: JSet[_], pm: IProgressMonitor): Unit =
@@ -77,6 +79,34 @@ class JUnit4TestFinder extends ITestFinder with HasLogger {
     case _ =>
       logger.info("Unknown element type when looking for tests: %s:%s".format(element.getClass(), element.toString))
       ()
+  }
+
+  override def getTestMethods(javaProject: IJavaProject, tpe: IType): java.util.Set[String] = {
+    import collection.JavaConverters._
+
+    val emptySet = immutable.Set[String]()
+
+    val res = ScalaPlugin.plugin.asScalaProject(javaProject.getProject()) map { scalaProject =>
+      scalaProject.withPresentationCompiler { comp =>
+        import comp._
+        object helper extends JUnit4TestClassesCollector { val global: comp.type = comp }
+
+        def hasTestAnnotation(sym: Symbol) = {
+          sym.initialize
+          helper.TestAnnotationOpt.exists(sym.hasAnnotation)
+        }
+        val fqn = newTypeName(tpe.getFullyQualifiedName())
+
+        askOption { () =>
+          // classes in the empty package are not found in the root mirror
+          val sym = if (fqn.lastPos('.') > -1) definitions.getClass(fqn) else definitions.EmptyPackageClass.info.member(fqn)
+          sym.annotations
+          sym.info.members.filter(hasTestAnnotation).map(_.originalName.toString).toSet
+        } getOrElse (emptySet)
+      }(emptySet)
+    } getOrElse (emptySet)
+
+    res.asJava
   }
 
   /** This method finds tests in any container, but may be imprecise if `element` is smaller than a source file.


### PR DESCRIPTION
Hook into the JUnit test configuration tab and implement the
Search Methods button functionality. We use aspects to intercept
the right call, and route it to our `ITestKind` implementation.

Fixed #1001474
