### PR TITLE
Uses sbinary '-pretending-SNAPSHOT' version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <!-- fixed versions -->
     <sbt.version>0.13.0-SNAPSHOT</sbt.version>
-    <sbinary.version>0.4.1-SNAPSHOT</sbinary.version>
+    <sbinary.version>0.4.1-pretending-SNAPSHOT</sbinary.version>
     <jline.version>0.9.94</jline.version>
     <ivy.version>2.2.0</ivy.version>
     <miglayout.version>3.7.4</miglayout.version>
@@ -88,7 +88,7 @@
     <profile>
       <id>scala-2.10.x</id>
       <properties>
-        <scala.version>2.10.0-SNAPSHOT</scala.version>
+        <scala.version>2.10.0</scala.version>
         <scala.era.major.version>2.10</scala.era.major.version>
         <version.suffix>2_10</version.suffix>
 


### PR DESCRIPTION
The builds of sbinary and sbt have been changed to use the `-pretending-SNAPSHOT`, but the scala-ide build was still using `-SNAPSHOT`.
