### PR TITLE
Revert "Merge pull request #269 from mads379/parsetree-1001326"

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
@@ -13,7 +13,6 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import scala.tools.eclipse.hyperlink.HyperlinkTester
 import scala.tools.eclipse.testsetup.CustomAssertion
-import scala.tools.eclipse.testsetup.TestProjectSetup
 
 object PresentationCompilerTest extends testsetup.TestProjectSetup("pc") with CustomAssertion with HyperlinkTester
 
@@ -147,72 +146,4 @@ class FreshFile {
     // verify
     assertNoErrors(unitB)
   }
-  
-  
-  @Test
-  def uniqueParseTree_t1001326() {
-
-    val cu = scalaCompilationUnit("t1001326/ParsedTree.scala")
-    val newTree = project.withSourceFile(cu) { (sf, compiler) =>
-      val parseTree1 = compiler.parseTree(sf)
-      val parseTree2 = compiler.parseTree(sf)
-      parseTree1 != parseTree2
-    } (false)
-
-    Assert.assertTrue("Asking twice for a parseTree on the same source should always return a new tree", newTree)
-  }
-
-  @Test
-  def unattributedParseTree_t1001326() {
-    val cu = scalaCompilationUnit("t1001326/ParsedTree.scala")
-    val noSymbols = project.withSourceFile(cu) { (sf, c) =>
-      noSymbolsOrTypes(new CompilerAndTree { 
-        val compiler = c
-        val tree = compiler.parseTree(sf)
-      })
-    } (false)
-    Assert.assertTrue("A parseTree should never contain any symbols or types", noSymbols)
-  }
-
-  @Test
-  def neverModifyParseTree_t1001326() {
-    val path = "t1001326/ParsedTree.scala"
-    val cu = scalaCompilationUnit(path)
-
-    val notChanged = project.withSourceFile(cu) { (sf, c) =>
-      val compilerAndTree = new CompilerAndTree { 
-        val compiler = c
-        val tree = compiler.parseTree(sf)
-      }
-      open(path)
-      noSymbolsOrTypes(compilerAndTree)
-    } (false)
-
-    Assert.assertTrue("Once you have obtained a parseTree it should never change", notChanged)
-
-  }
-
-  // We don't have dependent method types in Scala 2.9.x so this is a work-around.
-  private trait CompilerAndTree {
-    val compiler: ScalaPresentationCompiler
-    val tree: compiler.Tree
-  }
-
-  /**
-   * Traverses a tree and makes sure that there are no types or symbols present in the tree with
-   * the exception of the symbol for the package 'scala'. This is because that symbol will be
-   * present in some of the nodes that the compiler generates.
-   */
-  private def noSymbolsOrTypes(compilerandTree: CompilerAndTree): Boolean = {
-    import compilerandTree.compiler._
-    val existsSymbolsOrTypes = compilerandTree.tree.exists { t =>
-      t.symbol != null &&
-      t.symbol != NoSymbol &&
-      t.symbol != definitions.ScalaPackage && // ignore the symbol for the scala package for now
-      t.tpe != null &&
-      t.tpe != NoType
-    }
-    !existsSymbolsOrTypes
-  }
-
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/pc/src/t1001326/ParsedTree.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/pc/src/t1001326/ParsedTree.scala
@@ -1,5 +1,0 @@
-class MyParsedTree {
-
-  def foo(s: String) = s + s
-
-}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -31,7 +31,6 @@ import scala.tools.eclipse.completion.CompletionProposal
 import org.eclipse.jdt.core.IMethod
 import scala.tools.nsc.io.VirtualFile
 import scala.tools.nsc.interactive.MissingResponse
-import scala.tools.nsc.ast.parser.Parsers
 
 class ScalaPresentationCompiler(project: ScalaProject, settings: Settings)
   extends Global(settings, new ScalaPresentationCompiler.PresentationReporter, project.underlying.getName)
@@ -112,10 +111,6 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings)
       throw ScalaPresentationCompiler.InvalidThread("Tried to execute `askLoadedType` while inside `ask`")
     askLoadedTyped(sourceFile, response)
     response.get
-  }
-
-  override def parseTree(source: SourceFile): Tree = {
-    new syntaxAnalyzer.UnitParser(new CompilationUnit(source)).parse()
   }
 
   def withParseTree[T](sourceFile: SourceFile)(op: Tree => T): T = {


### PR DESCRIPTION
The parse-tree changes have been merged in Scala [pull 1982](https://github.com/scala/scala/pull/1982),
so there is no need for it anymore. Moreover, the presentation compiler must _not_ be interrupted
while parsing on a foreign thread, and that can't be ensured in this commit (but is correctly ensured
in the Scala changeset). Since this branch is used with 2.9.3, there is a potential for race conditions.

This reverts commit 712e6bf5eb983a18aac03294c0656519d53ac634, reversing
changes made to 4f7b391cf1a64c6d906263afc2ebd0928bf4cb4d.
