### PR TITLE
[backport] Clean projects in a background job when project settings' change

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/ProjectsCleanJob.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/ProjectsCleanJob.scala
@@ -1,0 +1,51 @@
+package scala.tools.eclipse.buildmanager
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.resources.WorkspaceJob
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.core.runtime.Status
+import org.eclipse.core.runtime.SubProgressMonitor
+import org.eclipse.ui.progress.IProgressConstants2
+
+/** Job for asynchronously cleaning the passed `projects`.*/
+class ProjectsCleanJob private (projects: Seq[IProject]) {
+
+  private class DoCleanJob(projects: Seq[IProject]) extends WorkspaceJob("Cleaning project" + (if (projects.length > 1) "s" else "")) {
+    override def belongsTo(family: AnyRef): Boolean = ResourcesPlugin.FAMILY_MANUAL_BUILD.equals(family)
+    override def runInWorkspace(monitor: IProgressMonitor): IStatus = {
+      doClean(monitor)
+      Status.OK_STATUS
+    }
+
+    private def doClean(monitor: IProgressMonitor): Unit = {
+      try {
+        monitor.beginTask(getName(), projects.length)
+        for {
+          project <- projects
+          if project != null
+        } project.build(IncrementalProjectBuilder.CLEAN_BUILD, new SubProgressMonitor(monitor, 1))
+      }
+      finally monitor.done()
+    }
+  }
+
+  private def cleanJob: WorkspaceJob = {
+    val cleanJob = new DoCleanJob(projects)
+    cleanJob.setRule(ResourcesPlugin.getWorkspace().getRuleFactory().buildRule())
+    cleanJob.setUser(true)
+    cleanJob.setProperty(IProgressConstants2.SHOW_IN_TASKBAR_ICON_PROPERTY, true)
+    cleanJob
+  }
+
+  /** Schedule this job to run. */
+  def schedule(): Unit = {
+    if (projects.nonEmpty) cleanJob.schedule()
+  }
+}
+
+object ProjectsCleanJob {
+  def apply(projects: Seq[IProject]): ProjectsCleanJob = new ProjectsCleanJob(projects)
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
@@ -26,6 +26,7 @@ import scala.tools.nsc.CompilerCommand
 import org.eclipse.jface.fieldassist._
 import org.eclipse.jface.bindings.keys.KeyStroke
 import scala.tools.eclipse.logging.HasLogger
+import scala.tools.eclipse.buildmanager.ProjectsCleanJob
 
 trait ScalaPluginPreferencePage extends HasLogger {
   self: PreferencePage with EclipseSettings =>
@@ -209,13 +210,13 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
 
   /** Check who needs to rebuild with new compiler flags */
   private def buildIfNecessary() = {
-    getElement() match {
+    val projects: Seq[IProject] = getElement() match {
       case project: IProject =>
         //Make sure project is rebuilt
-        project.build(IncrementalProjectBuilder.CLEAN_BUILD, null)
+        Seq(project)
       case javaProject: IJavaProject =>
         //Make sure project is rebuilt
-        javaProject.getProject().build(IncrementalProjectBuilder.CLEAN_BUILD, null)
+        Seq(javaProject.getProject())
       case other =>
         // rebuild all Scala projects that use global settings
         val plugin = ScalaPlugin.plugin
@@ -224,8 +225,10 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
           p <- (plugin.workspaceRoot.getProjects())
           scalaProject <- plugin.asScalaProject(p)
           if !scalaProject.usesProjectSettings
-        } scalaProject.underlying.build(IncrementalProjectBuilder.CLEAN_BUILD, null)
+        } yield scalaProject.underlying
     }
+
+    ProjectsCleanJob(projects).schedule()
   }
 
   // Eclipse PropertyPage API


### PR DESCRIPTION
Cleaning the projects in the UI Thread was causing UI freeze. The
fix is really simple: clean the projects in a background job.

Note: The implemented solution is inspired by the Eclipse
      `CleanDialog` component.

Fixes #1001527
(cherry picked from commit aec8edd4136ff82d9a81860b4f7002f5f4e4f6c4)
