### PR TITLE
More robust against VM exceptions.

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaThreadTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/ScalaThreadTest.scala
@@ -93,7 +93,7 @@ class ScalaThreadTest {
 
     val thread = createThread(jdiThread)
 
-    assertEquals("Bad thread name on VMDisconnectedException", "<disconnected>", thread.getName)
+    assertEquals("Bad thread name on VMDisconnectedException", "Error retrieving name", thread.getName)
   }
 
   @Test
@@ -106,7 +106,7 @@ class ScalaThreadTest {
 
     val thread = createThread(jdiThread)
 
-    assertEquals("Bad thread name", "<garbage collected>", thread.getName)
+    assertEquals("Bad thread name", "Error retrieving name", thread.getName)
   }
 
   /**

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/BaseDebuggerActor.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/BaseDebuggerActor.scala
@@ -132,7 +132,7 @@ trait BaseDebuggerActor extends Actor with HasLogger {
     // exception do not provide any meaningful information, hence we simply swallow it.
     case vme: VMDisconnectedException => ()
     case e: Exception =>
-      logger.debug("Shutting down " + this + " because of", e)
+      eclipseLog.error("Shutting down " + this + " because of", e)
       val reason = UncaughtException(this, Some("Unhandled exception while actor %s was still running.".format(this)), Some(sender), Thread.currentThread(), e)
       exit(reason)
   }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/JDIUtil.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/JDIUtil.scala
@@ -1,6 +1,9 @@
 package scala.tools.eclipse.debug
 
 import com.sun.jdi.{ Method, AbsentInformationException, ReferenceType, Location }
+import com.sun.jdi.VMDisconnectedException
+import com.sun.jdi.ObjectCollectedException
+import com.sun.jdi.VMOutOfMemoryException
 
 object JDIUtil {
 
@@ -34,4 +37,19 @@ object JDIUtil {
         })
   }
 
+  import scala.util.control.Exception
+  import Exception.Catch
+
+  /** Catch the usual VM exceptions and return a default value.
+   *
+   *  It catches VMDisconnectedException, ObjectCollectedException, VMOutOfMemoryException
+   *
+   *  @note This method only catches non-checked exceptions. Combine with other
+   *        catchers using the `or` combinator.
+   */
+  def safeVmCalls[A](defaultValue: A): Catch[A] =
+    Exception.failAsValue(
+      classOf[VMDisconnectedException],
+      classOf[ObjectCollectedException],
+      classOf[VMOutOfMemoryException])(defaultValue)
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
@@ -2,15 +2,15 @@ package scala.tools.eclipse.debug.model
 
 import scala.collection.JavaConverters.asScalaBufferConverter
 import scala.reflect.NameTransformer
-
 import org.eclipse.debug.core.model.IRegisterGroup
 import org.eclipse.debug.core.model.IStackFrame
 import org.eclipse.debug.core.model.IThread
 import org.eclipse.debug.core.model.IVariable
-
 import com.sun.jdi.AbsentInformationException
 import com.sun.jdi.Method
 import com.sun.jdi.StackFrame
+import com.sun.jdi.InvalidStackFrameException
+import com.sun.jdi.NativeMethodException
 
 object ScalaStackFrame {
   
@@ -92,8 +92,8 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
 
   override def getCharEnd(): Int = -1
   override def getCharStart(): Int = -1
-  override def getLineNumber(): Int = stackFrame.location.lineNumber // TODO: cache data ?
-  override def getName(): String = stackFrame.location.declaringType.name // TODO: cache data ?
+  override def getLineNumber(): Int = safeStackFrameCalls(-1) { stackFrame.location.lineNumber }// TODO: cache data ?
+  override def getName(): String = safeStackFrameCalls("Error retrieving name") { stackFrame.location.declaringType.name } // TODO: cache data ?
   override def getRegisterGroups(): Array[IRegisterGroup] = ???
   override def getThread(): IThread = thread
   override def getVariables(): Array[IVariable] = variables.toArray // TODO: need real logic
@@ -120,7 +120,11 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
 
   // ---
 
-  lazy val variables: Seq[ScalaVariable] = {
+  import scala.tools.eclipse.debug.JDIUtil._
+  import scala.util.control.Exception
+  import Exception.Catch
+
+  lazy val variables: Seq[ScalaVariable] = safeStackFrameCalls(Nil) {
     import scala.collection.JavaConverters._
     val visibleVariables = try {
       stackFrame.visibleVariables.asScala.map(new ScalaLocalVariable(_, this))
@@ -136,8 +140,8 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
     }
   }
 
-  //FIXME: Should handle checked exception `AbsentInformationException`
-  def getSourceName(): String = stackFrame.location.sourceName
+  def getSourceName(): String =
+    safeStackFrameCalls("Source name not available")(stackFrame.location.sourceName)
   
   /**
    * Return the source path based on source name and the package.
@@ -153,7 +157,8 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
     }
   }
 
-  def getMethodFullName(): String = getFullName(stackFrame.location.method)
+  def getMethodFullName(): String = 
+    safeStackFrameCalls("Error retrieving full name") { getFullName(stackFrame.location.method) }
 
   /** Set the current stack frame to `newStackFrame`. The `ScalaStackFrame.variables` don't need 
     *  to be recomputed because a variable (i.e., a `ScalaLocalVariable`) always uses the latest 
@@ -164,4 +169,11 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
     stackFrame = newStackFrame
   }
 
+  /** Wrap calls to the underlying VM stack frame to handle exceptions gracefully. */
+  private def safeStackFrameCalls[A](defaultValue: A): Catch[A] =
+    (safeVmCalls(defaultValue)
+      or Exception.failAsValue(
+        classOf[InvalidStackFrameException],
+        classOf[AbsentInformationException],
+        classOf[NativeMethodException])(defaultValue))
 }


### PR DESCRIPTION
- clearly report an actor shutting down because of an uncaught exception
  using the Eclipse Error log
- gracefully handle the common VM exceptions.

This is not exhaustive (a handful of FIXME notes are still in the codebase),
but it is a step in the right direction and fixes a number of issues I've
been seeing lately. Now I can actually debug our own codebase!

Fixed #1001328, Refs #1001487.
