### PR TITLE
Adds multi line error messages

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
@@ -41,6 +41,9 @@ import org.eclipse.jface.text.DefaultTextHover
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.eclipse.ui.CommentAutoIndentStrategy
 import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector
+import org.eclipse.jdt.internal.ui.text.HTMLAnnotationHover
+import org.eclipse.jface.text.source.Annotation
+import org.eclipse.jface.internal.text.html.HTMLPrinter
 
 class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceStore: IPreferenceStore, editor: ITextEditor)
    extends JavaSourceViewerConfiguration(JavaPlugin.getDefault.getJavaTextTools.getColorManager, store, editor, IJavaPartitions.JAVA_PARTITIONING) {
@@ -75,6 +78,23 @@ class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceSto
       ScalaPartitions.XML_PCDATA -> xmlPCDATAScanner,
       ScalaPartitions.XML_PI -> xmlPIScanner
     )
+  }
+
+  override def getAnnotationHover(sourceViewer: ISourceViewer) = {
+    new HTMLAnnotationHover(false) {
+      override def isIncluded(annotation: Annotation) = {
+        isShowInVerticalRuler(annotation)
+      }
+
+      override def formatSingleMessage(message: String) = {
+        import HTMLPrinter._
+        val buffer = new StringBuffer(message.length())
+        addPageProlog(buffer)
+        addParagraph(buffer, "<pre><code>"+message+"</code></pre>")
+        addPageEpilog(buffer)
+        buffer.toString()
+      }
+    }
   }
 
   override def getPresentationReconciler(sourceViewer: ISourceViewer): ScalaPresentationReconciler = {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/resources/MarkerFactory.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/resources/MarkerFactory.scala
@@ -62,12 +62,7 @@ abstract class MarkerFactory(markerType: String) {
     val maxMarkerLen = 21000
     val trimmedMsg = msg.take(maxMarkerLen)
 
-    val attrValue = trimmedMsg.map {
-      case '\n' | '\r' => ' '
-      case c => c
-    }
-
-    marker.setAttribute(IMarker.MESSAGE, attrValue)
+    marker.setAttribute(IMarker.MESSAGE, trimmedMsg)
     marker
   }
 


### PR DESCRIPTION
The new behavior is more or less the behavior that is inherited from
JDT. The only difference is that error messages aren't shrank to
single lines anymore but are surrounded with a HTML-pre-code block. This
allows to display them in the Annotation Hover as well as in the
Problems View on multiple lines.

Fixes #1001534

---

The problems view can handle messages spanning multiple lines without any problems when they are nested in a HTML-pre-code block. Do you know of further components or are problems view and annotation hover the only components affected by this change?
