### PR TITLE
Lazy retrieval of Java parameter names in completions.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
@@ -181,7 +181,7 @@ class CompletionTests {
     withCompletions("ticket_1000772/CompletionsWithName.scala") { (idx, position, completions) =>
       assertEquals("Only one completion expected at (%d, %d)".format(position.line, position.column), 1, completions.size)
       assertEquals("Expected the following names: %s".format(OracleNames),
-        OracleNames, completions(0).explicitParamNames)
+        OracleNames, completions(0).getParamNames())
     }
   }
 
@@ -228,7 +228,7 @@ class CompletionTests {
         assertEquals("There is only one completion location", 0, index)
         assertTrue("The completion should return java.util", completions.exists(
           _ match {
-            case CompletionProposal(MemberKind.Package, _, "util", _, _, _, _, _, _, _, _, _) =>
+            case CompletionProposal(MemberKind.Package, _, "util", _, _, _, _, _, _, _, _) =>
               true
             case _ =>
               false

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/CompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/CompletionProposal.scala
@@ -18,20 +18,32 @@ object HasArgs extends Enumeration {
  *  This class is independent of both the Scala compiler (does not
  *  know about Symbols and Types), and the UI elements used to
  *  display it to the user.
+ *
+ *  @note Parameter names are retrieved lazily, since the operation is potentially long-running.
+ *  @see  ticket #1001560
  */
 case class CompletionProposal(kind: MemberKind.Value,
   startPos: Int,             // position where the 'completion' string should be inserted
   completion: String,        // the string to be inserted in the document
   display: String,           // the display string in the completion list
-  tooltip: String,           // tooltip info showed after a completion has been selected
   displayDetail: String,     // additional details to be display in the completion list (like package for a class)
   relevance: Int,
-  hasArgs: HasArgs.Value,
   isJava: Boolean,
-  explicitParamNames: List[List[String]], // parameter names (excluding any implicit parameter sections)
+  getParamNames: () => List[List[String]], // parameter names (excluding any implicit parameter sections)
+  paramTypes: List[List[String]],          // parameter types matching parameter names (excluding implicit parameter sections)
   fullyQualifiedName: String, // for Class, Trait, Type, Objects: the fully qualified name
   needImport: Boolean        // for Class, Trait, Type, Objects: import statement has to be added
-)
+) {
+
+  /** Return the tooltip displayed once a completion has been activated. */
+  def tooltip: String = {
+    val contextInfo = for {
+      (names, tpes) <- getParamNames().zip(paramTypes)
+    } yield for { (name, tpe) <- names.zip(tpes) } yield "%s: %s".format(name, tpe)
+
+    contextInfo.map(_.mkString("(", ", ", ")")).mkString("")
+  }
+}
 
 /** The kind of a completion proposal. */
 object MemberKind extends Enumeration {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaCompletions.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/ScalaCompletions.scala
@@ -115,11 +115,10 @@ class ScalaCompletions extends HasLogger {
               start,
               simpleName,
               simpleName,
-              "",
               packageName,
               50,
-              HasArgs.NoArgs,
               true,
+              () => List(),
               List(),
               fullyQualifiedName,
               true))

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -59,7 +59,7 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
       val fullClassName = mapType(sym)
       val results = projects.map(p => Option(p.findType(fullClassName)))
       results.find(_.isDefined).flatten.headOption
-    } else getJavaElement(sym.owner) match {
+    } else getJavaElement(sym.owner, projects: _*) match {
         case Some(ownerClass: IType) =>
           def isGetterOrSetter: Boolean = sym.isGetter || sym.isSetter
           def isConcreteGetterOrSetter: Boolean = isGetterOrSetter && !sym.isDeferred


### PR DESCRIPTION
When a completion is selected we need to show the parameter names as placeholders.
If the method comes from Java, we need to retrieve the Java element, a potentially
long-running operation that can trigger the structure builder. Instead of retrieving
all parameter names eagerly, for each completion proposal, we delay it to the
moment a completion is selected and inserted in the editor.

Fixed #1001560, #1001497.
