### PR TITLE
Comply to the debugger interfaces by wrapping JDI runtime exceptions

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugComputeDetailTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugComputeDetailTest.scala
@@ -8,7 +8,6 @@ import org.junit.After
 import org.junit.Test
 import org.junit.Assert._
 import scala.tools.eclipse.debug.model.ScalaDebugModelPresentation
-import scala.tools.eclipse.debug.model.ScalaLogicalStructureProvider
 import scala.tools.eclipse.debug.model.ScalaCollectionLogicalStructureType
 import scala.tools.eclipse.debug.model.ScalaArrayReference
 import org.junit.internal.matchers.StringContains
@@ -116,7 +115,7 @@ class ScalaDebugComputeDetailTest {
 
     assertThat("Wrong type for the logical structure", logicalStructure.getValueString(), StringContains.containsString("Array[Object](3)"))
     
-    val elements= logicalStructure.asInstanceOf[ScalaArrayReference].getVariables
+    val elements = logicalStructure.asInstanceOf[ScalaArrayReference].getVariables()
     assertThat("Wrong value for first element", elements(0).getValue().getValueString(), StringContains.containsString("Integer 4"))
     assertThat("Wrong value for second element", elements(1).getValue().getValueString(), StringContains.containsString("Integer 5"))
     assertThat("Wrong value for third element", elements(2).getValue().getValueString(), StringContains.containsString("Integer 6"))

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
@@ -294,7 +294,7 @@ class ScalaDebugTestSession(launchConfiguration: ILaunchConfiguration) extends H
   def getLocalVariable(name: String): ScalaValue = {
     assertEquals("Bad state before getLocalVariable", SUSPENDED, state)
     
-    currentStackFrame.variables.find(_.getName == name).get.getValue.asInstanceOf[ScalaValue]
+    currentStackFrame.getVariables.find(_.getName == name).get.getValue.asInstanceOf[ScalaValue]
   }
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/BreakpointSupport.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/BreakpointSupport.scala
@@ -33,16 +33,20 @@ private[debug] object BreakpointSupport {
    */
   final val ATTR_VM_REQUESTS_ENABLED = "org.scala-ide.sdt.debug.breakpoint.vm_enabled"
 
-  /** Create the breakpoint support actor. */
+  /** Create the breakpoint support actor.
+   *  
+   *  @note `BreakpointSupportActor` instances are created only by the `ScalaDebugBreakpointManagerActor`, hence 
+   *        any uncaught exception that may occur during initialization (i.e., in `BreakpointSupportActor.apply`) 
+   *        will be caught by the `ScalaDebugBreakpointManagerActor` default exceptions' handler.
+   */
   def apply(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget): Actor = {
     BreakpointSupportActor(breakpoint, debugTarget)
   }
 }
 
-private[debug] object BreakpointSupportActor {
+private object BreakpointSupportActor {
   // specific events
   case class Changed(delta: IMarkerDelta)
-
 
   def apply(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget): Actor = {
     val typeName= breakpoint.typeName

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugCache.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugCache.scala
@@ -35,7 +35,7 @@ object ScalaDebugCache {
     val debugCache = new ScalaDebugCache(debugTarget) {
       val actor = new ScalaDebugCacheActor(this, debugTarget, scalaDebugTargetActor)
     }
-    debugCache.actor.start
+    debugCache.actor.start()
     debugCache
   }
 
@@ -148,9 +148,11 @@ abstract class ScalaDebugCache(val debugTarget: ScalaDebugTarget) extends HasLog
   /** Returns the anon function for the given type, if it exists.
    */
   private def findAnonFunction(refType: ReferenceType): Option[Method] = {
-    // TODO: check super type at some point
+    val allMethods = refType.methods
+
     import scala.collection.JavaConverters._
-    val methods = refType.methods.asScala.filter(method => !method.isBridge && method.name.startsWith("apply"))
+    // TODO: check super type at some point
+    val methods = allMethods.asScala.filter(method => !method.isBridge && method.name.startsWith("apply"))
 
     methods.size match {
       case 1 =>

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugElement.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugElement.scala
@@ -4,14 +4,19 @@ import scala.tools.eclipse.debug.ScalaDebugPlugin
 import scala.tools.eclipse.debug.ScalaDebugger
 import scala.tools.eclipse.debug.ScalaDebugger.modelProvider
 import scala.tools.eclipse.logging.HasLogger
-
 import org.eclipse.debug.core.model.{ITerminate, DebugElement}
-
 import com.sun.jdi.ClassType
 import com.sun.jdi.Field
 import com.sun.jdi.Method
 import com.sun.jdi.ReferenceType
 import com.sun.jdi.Value
+import org.eclipse.debug.core.DebugException
+import org.eclipse.jdi.TimeoutException
+import com.sun.jdi.VMDisconnectedException
+import org.eclipse.core.runtime.Status
+import org.eclipse.core.runtime.IStatus
+import scala.util.control.Exception
+import scala.util.control.Exception.Catch
 
 /**
  * Base class for debug elements in the Scala debug model
@@ -44,23 +49,47 @@ abstract class ScalaDebugElement(debugTarget: ScalaDebugTarget) extends DebugEle
 
   // ----
 
+  def wrapJDIException[T](msg: String): Catch[T] = 
+    Exception.handling(classOf[RuntimeException]) by (targetRequestFailed(msg, _))
+
+  /**
+    * Throws a new debug exception with a status code of `TARGET_REQUEST_FAILED`
+    * with the given underlying exception. If the underlying exception is not a JDI
+    * exception, the original exception is thrown.
+    * 
+    * @param message Failure message
+    * @param e underlying exception that has occurred
+    * @throws DebugException The exception with a status code of `TARGET_REQUEST_FAILED`
+    */
+  private def targetRequestFailed(message: String, t: Throwable): Nothing = {
+    if (t == null || t.getClass().getName().startsWith("com.sun.jdi") || t.isInstanceOf[TimeoutException])
+      throw new DebugException(new Status(IStatus.ERROR, ScalaDebugPlugin.id, DebugException.TARGET_REQUEST_FAILED, message, t))
+    else
+      throw t
+  }
 }
 
 trait HasFieldValue {
   self: ScalaDebugElement =>
 
-  protected[model] def referenceType(): ReferenceType
+  final protected[model] def referenceType(): ReferenceType =
+    wrapJDIException("Exception while retrieving reference type") { getReferenceType() }
 
-  /** Return the JDI value for the given field.
-   */
-  protected[model] def jdiFieldValue(field: Field): Value
+  /** Return the JDI value for the given field. */
+  final protected[model] def jdiFieldValue(field: Field): Value =
+    wrapJDIException("Exception while retrieving JDI field value") { getJdiFieldValue(field) }
+  
+  protected def getReferenceType(): ReferenceType
+  protected def getJdiFieldValue(field: Field): Value
 
   /** Return the value of the field with the given name.
    *
    *  @throws IllegalArgumentException if the no field with the given name exists.
+   *  @throws DebugException
    */
-  def fieldValue(fieldName: String): ScalaValue = {
+  def fieldValue(fieldName: String): ScalaValue = wrapJDIException("Exception while retrieving field " + fieldName + " in reference type") {
     val field = referenceType().fieldByName(fieldName)
+      
     if (field == null) {
       throw new IllegalArgumentException("Field '%s' doesn't exist for '%s'".format(fieldName, referenceType().name()))
     }
@@ -80,28 +109,36 @@ trait HasMethodInvocation {
   /** Invoke the method with given name, using the given arguments.
    *
    *  @throws IllegalArgumentException if no method with given name exists, or more than one.
+   *  @throws DebugException
    */
   def invokeMethod(methodName: String, thread: ScalaThread, args: ScalaValue*): ScalaValue = {
-    val methods = classType().methodsByName(methodName)
-    methods.size match {
-      case 0 =>
-        throw new IllegalArgumentException("Method '%s(..)' doesn't exist for '%s'".format(methodName, classType.name()))
-      case 1 =>
-        ScalaValue(jdiInvokeMethod(methods.get(0), thread, args.map(_.underlying): _*), getDebugTarget)
-      case _ =>
-        throw new IllegalArgumentException("More than on method '%s(..)' for '%s'".format(methodName, classType.name()))
+    wrapJDIException("Exception while retrieving method " + methodName + " in reference type") {
+      val methods = classType().methodsByName(methodName)
+
+      methods.size match {
+        case 0 =>
+          throw new IllegalArgumentException("Method '%s(..)' doesn't exist for '%s'".format(methodName, classType.name()))
+        case 1 =>
+          ScalaValue(jdiInvokeMethod(methods.get(0), thread, args.map(_.underlying): _*), getDebugTarget)
+        case _ =>
+          throw new IllegalArgumentException("More than on method '%s(..)' for '%s'".format(methodName, classType.name()))
+      }
     }
   }
 
   /** Invoke the method with given name and signature, using the given arguments.
    *
    *  @throws IllegalArgumentException if no method with given name and signature exists.
+   *  @throws DebugException
    */
   def invokeMethod(methodName: String, methodSignature: String, thread: ScalaThread, args: ScalaValue*): ScalaValue = {
-    val method = classType().concreteMethodByName(methodName, methodSignature)
-    if (method == null) {
-      throw new IllegalArgumentException("Method '%s%s' doesn't exist for '%s'".format(methodName, methodSignature, classType().name()))
+    wrapJDIException("Exception while retrieving method " + methodName + " in reference type") {
+      val method = classType().concreteMethodByName(methodName, methodSignature)
+
+      if (method == null) {
+        throw new IllegalArgumentException("Method '%s%s' doesn't exist for '%s'".format(methodName, methodSignature, classType().name()))
+      }
+      ScalaValue(jdiInvokeMethod(method, thread, args.map(_.underlying): _*), getDebugTarget)
     }
-    ScalaValue(jdiInvokeMethod(method, thread, args.map(_.underlying): _*), getDebugTarget)
   }
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
@@ -1,7 +1,6 @@
 package scala.tools.eclipse.debug.model
 
 import scala.tools.eclipse.debug.ScalaDebugger
-
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Status
@@ -11,6 +10,7 @@ import org.eclipse.debug.internal.ui.views.variables.IndexedVariablePartition
 import org.eclipse.debug.ui.{ IValueDetailListener, IDebugUIConstants, IDebugModelPresentation, DebugUITools }
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility
 import org.eclipse.ui.IEditorInput
+import org.eclipse.jface.viewers.ILabelProviderListener
 
 /**
  * Utility methods for the ScalaDebugModelPresentation class
@@ -74,10 +74,10 @@ class ScalaDebugModelPresentation extends IDebugModelPresentation {
 
   // Members declared in org.eclipse.jface.viewers.IBaseLabelProvider
 
-  override def addListener(x$1: org.eclipse.jface.viewers.ILabelProviderListener): Unit = ???
+  override def addListener(listener: ILabelProviderListener): Unit = ???
   override def dispose(): Unit = {} // TODO: need real logic
-  override def isLabelProperty(x$1: Any, x$2: String): Boolean = ???
-  override def removeListener(x$1: org.eclipse.jface.viewers.ILabelProviderListener): Unit = ???
+  override def isLabelProperty(element: Any, property: String): Boolean = ???
+  override def removeListener(listener: ILabelProviderListener): Unit = ???
 
   // Members declared in org.eclipse.debug.ui.IDebugModelPresentation
 
@@ -88,7 +88,7 @@ class ScalaDebugModelPresentation extends IDebugModelPresentation {
         listener.detailComputed(value, ScalaDebugModelPresentation.computeDetail(value))
         Status.OK_STATUS
       }
-    }.schedule
+    }.schedule()
   }
 
   override def getImage(element: Any): org.eclipse.swt.graphics.Image = {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaLogicalStructureProvider.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaLogicalStructureProvider.scala
@@ -10,29 +10,7 @@ import org.eclipse.debug.core.model.IValue
 
 import com.sun.jdi.ClassType
 
-object ScalaLogicalStructureProvider {
-  
-  def isScalaCollection(objectReference: ScalaObjectReference): Boolean = {
-    objectReference.underlying.referenceType match {
-      case classType: ClassType =>
-        implements(classType, "scala.collection.TraversableOnce")
-      case _ => // TODO: ScalaObjectReference should always reference objects of class type, never of array type. Can we just cast?
-        false
-    }
-  }
-  
-  /**
-   * Checks 'implements' with Java meaning
-   */
-  def implements(classType: ClassType, interfaceName: String): Boolean = {
-    import scala.collection.JavaConverters._
-    classType.allInterfaces.asScala.exists(_.name == interfaceName)
-  }
-  
-}
-
-class ScalaLogicalStructureProvider extends ILogicalStructureProvider {
-  import ScalaLogicalStructureProvider._
+class ScalaLogicalStructureProviders extends ILogicalStructureProvider {
 
   override def getLogicalStructureTypes(value: IValue) : Array[ILogicalStructureType] = {
     value match {
@@ -46,7 +24,25 @@ class ScalaLogicalStructureProvider extends ILogicalStructureProvider {
         Array() // TODO: return fixed empty Array
     }
   }
+
+  private def isScalaCollection(objectReference: ScalaObjectReference): Boolean = {
+    objectReference.wrapJDIException("Exception while checking if passed object reference is a scala collection type") {
+      objectReference.referenceType match {
+        case classType: ClassType =>
+          implements(classType, "scala.collection.TraversableOnce")
+        case _ => // TODO: ScalaObjectReference should always reference objects of class type, never of array type. Can we just cast?
+          false
+      }
+    }
+  }
   
+  /**
+   * Checks 'implements' with Java meaning
+   */
+  private def implements(classType: ClassType, interfaceName: String): Boolean = {
+    import scala.collection.JavaConverters._
+    classType.allInterfaces.asScala.exists(_.name == interfaceName)
+  }
 }
 
 object ScalaCollectionLogicalStructureType extends ILogicalStructureType with HasLogger {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaStackFrame.scala
@@ -50,18 +50,18 @@ object ScalaStackFrame {
   
   // TODO: need unit tests
   def getArgumentSimpleNames(methodSignature: String): List[String] = {
-    val argumentsInMethodSignature(argString)= methodSignature
+    val argumentsInMethodSignature(argString) = methodSignature
     
     def parseArguments(args: String) : List[String] = {
       if (args.isEmpty) {
         Nil
       } else {
-        args.head match {
+        args.charAt(0) match {
           case 'L' =>
-            val typeSignatureLength= args.indexOf(';') + 1
+            val typeSignatureLength = args.indexOf(';') + 1
             getSimpleName(args.substring(0, typeSignatureLength)) +: parseArguments(args.substring(typeSignatureLength))
           case '[' =>
-            val parsedArguments= parseArguments(args.tail)
+            val parsedArguments = parseArguments(args.tail)
             "Array[%s]".format(parsedArguments.head) +: parsedArguments.tail
           case c =>
             getSimpleName(c.toString) +: parseArguments(args.tail)
@@ -70,13 +70,6 @@ object ScalaStackFrame {
     }
     
     parseArguments(argString)
-  }
-
-  def getFullName(method: Method): String = {
-    "%s.%s(%s)".format(
-      getSimpleName(method.declaringType.signature),
-      NameTransformer.decode(method.name),
-      getArgumentSimpleNames(method.signature).mkString(", "))
   }
 }
 
@@ -92,8 +85,16 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
 
   override def getCharEnd(): Int = -1
   override def getCharStart(): Int = -1
-  override def getLineNumber(): Int = safeStackFrameCalls(-1) { stackFrame.location.lineNumber }// TODO: cache data ?
-  override def getName(): String = safeStackFrameCalls("Error retrieving name") { stackFrame.location.declaringType.name } // TODO: cache data ?
+  override def getLineNumber(): Int = {
+    (safeStackFrameCalls(-1) or wrapJDIException("Exception while retrieving stack frame's line number")) {
+      stackFrame.location.lineNumber // TODO: cache data ?
+    }
+  }
+  override def getName(): String = {
+    (safeStackFrameCalls("Error retrieving name") or wrapJDIException("Exception while retrieving stack frame's name")) {
+      stackFrame.location.declaringType.name // TODO: cache data ?
+    }
+  }
   override def getRegisterGroups(): Array[IRegisterGroup] = ???
   override def getThread(): IThread = thread
   override def getVariables(): Array[IVariable] = variables.toArray // TODO: need real logic
@@ -115,7 +116,7 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
   override def canResume(): Boolean = true
   override def canSuspend(): Boolean = false
   override def isSuspended(): Boolean = true
-  override def resume(): Unit = thread.resume
+  override def resume(): Unit = thread.resume()
   override def suspend(): Unit = ???
 
   // ---
@@ -124,41 +125,55 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
   import scala.util.control.Exception
   import Exception.Catch
 
-  lazy val variables: Seq[ScalaVariable] = safeStackFrameCalls(Nil) {
-    import scala.collection.JavaConverters._
-    val visibleVariables = try {
-      stackFrame.visibleVariables.asScala.map(new ScalaLocalVariable(_, this))
-    } catch {
-      case e: AbsentInformationException => Seq()
-    }
-    val currentMethod = stackFrame.location.method
-    if (currentMethod.isNative || currentMethod.isStatic) {
-      // 'this' is not available for native and static methods
-      visibleVariables
-    } else {
-      new ScalaThisVariable(stackFrame.thisObject, this) +: visibleVariables
+  private lazy val variables: Seq[ScalaVariable] = {
+    (safeStackFrameCalls(Nil) or wrapJDIException("Exception while retrieving stack frame's visible variables")) {
+      import scala.collection.JavaConverters._
+      val visibleVariables = {
+        (Exception.handling(classOf[AbsentInformationException]) by (_ => Seq.empty)) {
+          stackFrame.visibleVariables.asScala.map(new ScalaLocalVariable(_, this))
+        }
+      }
+
+      val currentMethod = stackFrame.location.method
+      if (currentMethod.isNative || currentMethod.isStatic) {
+        // 'this' is not available for native and static methods
+        visibleVariables
+      } else {
+        new ScalaThisVariable(stackFrame.thisObject, this) +: visibleVariables
+      }
     }
   }
 
-  def getSourceName(): String =
+  private def getSourceName(): String =
     safeStackFrameCalls("Source name not available")(stackFrame.location.sourceName)
   
   /**
    * Return the source path based on source name and the package.
    * Segments are separated by '/'.
+   * 
+   * @throws DebugException
    */
   def getSourcePath(): String = {
-    // we shoudn't use location#sourcePath, as it is platform dependent
-    stackFrame.location.declaringType.name.split('.').init match {
-      case Array() =>
-        getSourceName
-      case packageSegments =>
-        packageSegments.mkString("", "/", "/") + getSourceName
+    wrapJDIException("Exception while retrieving source path") {
+      // we shoudn't use location#sourcePath, as it is platform dependent
+      stackFrame.location.declaringType.name.split('.').init match {
+        case Array() =>
+          getSourceName
+        case packageSegments =>
+          packageSegments.mkString("", "/", "/") + getSourceName
+      }
     }
   }
 
-  def getMethodFullName(): String = 
+  def getMethodFullName(): String = {
+    def getFullName(method: Method): String = {
+      "%s.%s(%s)".format(
+        getSimpleName(method.declaringType.signature),
+        NameTransformer.decode(method.name),
+        getArgumentSimpleNames(method.signature).mkString(", "))
+    }
     safeStackFrameCalls("Error retrieving full name") { getFullName(stackFrame.location.method) }
+  }
 
   /** Set the current stack frame to `newStackFrame`. The `ScalaStackFrame.variables` don't need 
     *  to be recomputed because a variable (i.e., a `ScalaLocalVariable`) always uses the latest 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaThread.scala
@@ -17,6 +17,8 @@ import scala.tools.eclipse.debug.BaseDebuggerActor
 import com.sun.jdi.ClassType
 import scala.tools.eclipse.debug.JDIUtil._
 import com.sun.jdi.VMCannotBeModifiedException
+import org.eclipse.debug.core.model.IStackFrame
+import com.sun.jdi.IncompatibleThreadStateException
 
 class ThreadNotSuspendedException extends Exception
 
@@ -45,9 +47,15 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   override def canStepReturn: Boolean = suspended // TODO: need real logic
   override def isStepping: Boolean = ???
 
-  override def stepInto(): Unit = ScalaStepInto(stackFrames.head).step()
-  override def stepOver(): Unit = ScalaStepOver(stackFrames.head).step()
-  override def stepReturn(): Unit = ScalaStepReturn(stackFrames.head).step()
+  override def stepInto(): Unit = {
+    wrapJDIException("Exception while performing `step into`") { ScalaStepInto(stackFrames.head).step() }
+  }
+  override def stepOver(): Unit = {
+    wrapJDIException("Exception while performing `step over`") { ScalaStepOver(stackFrames.head).step() }
+  }
+  override def stepReturn(): Unit = {
+    wrapJDIException("Exception while performing `step return`") { ScalaStepReturn(stackFrames.head).step() }
+  }
 
   // Members declared in org.eclipse.debug.core.model.ISuspendResume
 
@@ -56,9 +64,11 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   override def isSuspended: Boolean = suspended // TODO: need real logic
 
   override def resume(): Unit = resumeFromScala(DebugEvent.CLIENT_REQUEST)
-  override def suspend(): Unit = safeThreadCalls(()) {
-    threadRef.suspend()
-    suspendedFromScala(DebugEvent.CLIENT_REQUEST)
+  override def suspend(): Unit = {
+    (safeThreadCalls(()) or wrapJDIException("Exception while retrieving suspending stack frame")) {
+      threadRef.suspend()
+      suspendedFromScala(DebugEvent.CLIENT_REQUEST)
+    }
   }
 
   // Members declared in org.eclipse.debug.core.model.IThread
@@ -66,15 +76,15 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   override def getBreakpoints: Array[IBreakpoint] = Array.empty // TODO: need real logic
 
   override def getName: String = {
-    name = safeThreadCalls("Error retrieving name") {
-      threadRef.name
+    (safeThreadCalls("Error retrieving name") or wrapJDIException("Exception while retrieving stack frame's name")){ 
+      name = threadRef.name
+      name
     }
-    name
   }
 
   override def getPriority: Int = ???
-  override def getStackFrames: Array[org.eclipse.debug.core.model.IStackFrame] = stackFrames.toArray
-  override def getTopStackFrame: org.eclipse.debug.core.model.IStackFrame = stackFrames.headOption.getOrElse(null)
+  override def getStackFrames: Array[IStackFrame] = stackFrames.toArray
+  override def getTopStackFrame: IStackFrame = stackFrames.headOption.getOrElse(null)
   override def hasStackFrames: Boolean = !stackFrames.isEmpty
 
   // ----
@@ -90,7 +100,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
    * THE VALUE IS MODIFIED ONLY BY THE COMPANION ACTOR, USING METHODS DEFINED LOWER.
    */
   @volatile
-  private var stackFrames= List[ScalaStackFrame]()
+  private var stackFrames: List[ScalaStackFrame] = Nil
 
   // keep the last known name around, for when the vm is not available anymore
   @volatile
@@ -98,8 +108,8 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   
   protected[debug] val companionActor: BaseDebuggerActor
 
-  val isSystemThread: Boolean = safeThreadCalls(false) {
-    Option(threadRef.threadGroup).exists(_.name == "system")
+  val isSystemThread: Boolean = {
+    safeThreadCalls(false) { Option(threadRef.threadGroup).exists(_.name == "system") }
   }
 
   def suspendedFromScala(eventDetail: Int): Unit = companionActor ! SuspendedFromScala(eventDetail)
@@ -144,7 +154,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
    */
   def dispose() {
     running = false
-    stackFrames= Nil
+    stackFrames = Nil
     companionActor ! TerminatedFromScala
   }
   
@@ -157,11 +167,13 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
    * Set the this object internal states to suspended.
    * FOR THE COMPANION ACTOR ONLY.
    */
-  private[model] def suspend(eventDetail: Int) = safeThreadCalls(()) {
-    // FIXME: `threadRef.frames` should handle checked exception `IncompatibleThreadStateException`
-    stackFrames= threadRef.frames.asScala.map(ScalaStackFrame(this, _)).toList
-    suspended = true
-    fireSuspendEvent(eventDetail)
+  private[model] def suspend(eventDetail: Int) = {
+    (safeThreadCalls(()) or wrapJDIException("Exception while suspending thread")) {
+      // FIXME: `threadRef.frames` should handle checked exception `IncompatibleThreadStateException`
+      stackFrames = threadRef.frames.asScala.map(ScalaStackFrame(this, _)).toList
+      suspended = true
+      fireSuspendEvent(eventDetail)
+    }
   }
 
   /**
@@ -170,7 +182,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
    */
   private[model] def resume(eventDetail: Int) {
     suspended = false
-    stackFrames= Nil
+    stackFrames = Nil
     fireResumeEvent(eventDetail)
   }
 
@@ -179,7 +191,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
    * TO BE USED ONLY IF THE NUMBER OF FRAMES MATCHES
    * FOR THE COMPANION ACTOR ONLY.
    */
-  private[model] def rebindScalaStackFrames(): Unit = safeThreadCalls(()) {
+  private[model] def rebindScalaStackFrames(): Unit = (safeThreadCalls(()) or wrapJDIException("Exception while rebinding stack frames")) {
     // FIXME: Should check that `threadRef.frames == stackFrames` before zipping
     threadRef.frames.asScala.zip(stackFrames).foreach {
       case (jdiStackFrame, scalaStackFrame) => scalaStackFrame.rebind(jdiStackFrame)
@@ -193,7 +205,7 @@ abstract class ScalaThread private (target: ScalaDebugTarget, private[model] val
   private def safeThreadCalls[A](defaultValue: A): Catch[A] =
     (safeVmCalls(defaultValue)
       or Exception.failAsValue(
-        classOf[IllegalThreadStateException],
+        classOf[IncompatibleThreadStateException],
         classOf[VMCannotBeModifiedException])(defaultValue))
 }
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaType.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaType.scala
@@ -13,9 +13,9 @@ class ScalaReferenceType(underlying: ReferenceType, debugTarget: ScalaDebugTarge
 
   // Members declared in scala.tools.eclipse.debug.model.HasFieldValue
   
-  protected[model] override def referenceType = underlying
+  protected override def getReferenceType(): ReferenceType = underlying
   
-  protected[model] override def jdiFieldValue(field: Field) = underlying.getValue(field)
+  protected override def getJdiFieldValue(field: Field): Value = underlying.getValue(field)
   
 }
 
@@ -25,9 +25,9 @@ class ScalaClassType(underlying: ClassType, debugTarget: ScalaDebugTarget) exten
   
   // Members declared in scala.tools.eclipse.debug.model.HasMethodInvocation
   
-  protected[model] def classType() = underlying
+  protected[model] def classType(): ClassType = underlying
   
-  protected[model] def jdiInvokeMethod(method: Method, thread: ScalaThread, args: Value*) = thread.invokeStaticMethod(underlying, method, args:_*)
+  protected[model] def jdiInvokeMethod(method: Method, thread: ScalaThread, args: Value*): Value = thread.invokeStaticMethod(underlying, method, args:_*)
   
 }
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaValue.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaValue.scala
@@ -9,6 +9,8 @@ import com.sun.jdi.ClassType
 import com.sun.jdi.PrimitiveValue
 import com.sun.jdi.Field
 import com.sun.jdi.Method
+import scala.tools.eclipse.debug.JDIUtil
+import com.sun.jdi.ReferenceType
 
 object ScalaValue {
 
@@ -74,18 +76,32 @@ abstract class ScalaValue(val underlying: Value, target: ScalaDebugTarget) exten
 
   override def isAllocated(): Boolean = true // TODO: should always be true with a JVM, to check. ObjectReference#isCollected ?
 
-  // new Members
+  final override def getReferenceTypeName(): String =
+    wrapJDIException("Exception while retrieving reference type name") { doGetReferenceTypeName() }
 
+  final override def getValueString(): String =
+    wrapJDIException("Exception while retrieving value string") { doGetValueString() }
+
+  final override def getVariables(): Array[IVariable] =
+    wrapJDIException("Exception while retrieving variables") { doGetVariables() }
+  
+  final override def hasVariables(): Boolean = 
+    wrapJDIException("Exception while checking if debug element has variables") { doHasVariables() }
+
+  protected def doGetReferenceTypeName(): String
+  protected def doGetValueString(): String
+  protected def doGetVariables(): Array[IVariable]
+  protected def doHasVariables(): Boolean
 }
 
 class ScalaArrayReference(override val underlying: ArrayReference, target: ScalaDebugTarget) extends ScalaValue(underlying, target) with IIndexedValue {
 
   // Members declared in org.eclipse.debug.core.model.IValue
 
-  override def getReferenceTypeName(): String = "scala.Array"
-  override def getValueString(): String = "%s(%d) (id=%d)".format(ScalaStackFrame.getSimpleName(underlying.referenceType.signature), underlying.length, underlying.uniqueID)
-  override def getVariables(): Array[IVariable] = getVariables(0, underlying.length)
-  override def hasVariables(): Boolean = underlying.length > 0
+  protected override def doGetReferenceTypeName(): String = "scala.Array"
+  protected override def doGetValueString(): String = "%s(%d) (id=%d)".format(ScalaStackFrame.getSimpleName(underlying.referenceType.signature), getSize, underlying.uniqueID)
+  protected override def doGetVariables(): Array[IVariable] = getVariables(0, getSize)
+  protected override def doHasVariables(): Boolean = getSize > 0 
   
   // Members declared in org.eclipse.debug.core.model.IIndexedValue
   
@@ -93,7 +109,8 @@ class ScalaArrayReference(override val underlying: ArrayReference, target: Scala
   
   override def getVariables(offset: Int, length: Int) : Array[IVariable] = (offset until offset + length).map(new ScalaArrayElementVariable(_, this)).toArray
   
-  override def getSize(): Int = underlying.length	
+  override def getSize(): Int = 
+    wrapJDIException("Exception while retrieving size") { underlying.length }
 
   override def getInitialOffset(): Int = 0
 
@@ -103,17 +120,17 @@ class ScalaPrimitiveValue(typeName: String, value: String, override val underlyi
 
   // Members declared in org.eclipse.debug.core.model.IValue
 
-  override def getReferenceTypeName(): String = typeName
-  override def getValueString(): String = value
-  override def getVariables(): Array[org.eclipse.debug.core.model.IVariable] = Array()
-  override def hasVariables(): Boolean = false
+  protected override def doGetReferenceTypeName(): String = typeName
+  protected override def doGetValueString(): String = value
+  protected override def doGetVariables(): Array[IVariable] = Array()
+  protected override def doHasVariables(): Boolean = false
 
 }
 
 class ScalaStringReference(override val underlying: StringReference, target: ScalaDebugTarget) extends ScalaObjectReference(underlying, target) {
 
-  override def getReferenceTypeName() = "java.lang.String"
-  override def getValueString(): String = """"%s" (id=%d)""".format(underlying.value, underlying.uniqueID)
+  protected override def doGetReferenceTypeName() = "java.lang.String"
+  protected override def doGetValueString(): String = """"%s" (id=%d)""".format(underlying.value, underlying.uniqueID)
 
 }
 
@@ -122,36 +139,37 @@ class ScalaObjectReference(override val underlying: ObjectReference, target: Sca
 
   // Members declared in org.eclipse.debug.core.model.IValue
 
-  override def getReferenceTypeName(): String = underlying.referenceType.name
+  protected override def doGetReferenceTypeName(): String = underlying.referenceType.name
 
-  override def getValueString(): String = {
+  protected override def doGetValueString(): String = {
     // TODO: move to string builder?
-    if (BOXED_PRIMITIVE_TYPES.contains(underlying.referenceType.signature)) {
-      "%s %s (id=%d)".format(ScalaStackFrame.getSimpleName(underlying.referenceType.signature), getBoxedPrimitiveValue(), underlying.uniqueID)
-    } else if (BOXED_CHAR_TYPE == underlying.referenceType.signature) {
-      "%s '%s' (id=%d)".format(ScalaStackFrame.getSimpleName(underlying.referenceType.signature), getBoxedPrimitiveValue(), underlying.uniqueID)
+    val refTypeSignature = getReferenceType.signature
+    if (BOXED_PRIMITIVE_TYPES.contains(refTypeSignature)) {
+      "%s %s (id=%d)".format(ScalaStackFrame.getSimpleName(refTypeSignature), getBoxedPrimitiveValue(), underlying.uniqueID)
+    } else if (BOXED_CHAR_TYPE == refTypeSignature) {
+      "%s '%s' (id=%d)".format(ScalaStackFrame.getSimpleName(refTypeSignature), getBoxedPrimitiveValue(), underlying.uniqueID)
     } else {
-      "%s (id=%d)".format(ScalaStackFrame.getSimpleName(underlying.referenceType.signature), underlying.uniqueID)
+      "%s (id=%d)".format(ScalaStackFrame.getSimpleName(refTypeSignature), underlying.uniqueID)
     }
   }
 
-  override def getVariables(): Array[org.eclipse.debug.core.model.IVariable] = {
+  protected override def doGetVariables(): Array[IVariable] = {
     import scala.collection.JavaConverters._
-    underlying.referenceType.allFields.asScala.map(new ScalaFieldVariable(_, this)).sortBy(_.getName).toArray
+    referenceType.allFields.asScala.map(new ScalaFieldVariable(_, this)).sortBy(_.getName).toArray
   }
-  override def hasVariables(): Boolean = !underlying.referenceType.allFields.isEmpty
+  protected override def doHasVariables(): Boolean = !referenceType.allFields.isEmpty
 
   // Members declared in scala.tools.eclipse.debug.model.HasFieldValue
   
-  protected[model] override def referenceType = underlying.referenceType()
+  protected override def getReferenceType: ReferenceType = underlying.referenceType()
   
-  protected[model] override def jdiFieldValue(field: Field) = underlying.getValue(field)
+  protected override def getJdiFieldValue(field: Field): Value = underlying.getValue(field)
   
   // Members declared in scala.tools.eclipse.debug.model.HasMethodInvocation
   
-  protected[model] override def classType = underlying.referenceType.asInstanceOf[ClassType]
+  protected[model] override def classType: ClassType = referenceType.asInstanceOf[ClassType]
   
-  protected[model] def jdiInvokeMethod(method: Method, thread: ScalaThread, args: Value*) = thread.invokeMethod(underlying, method, args:_*)
+  protected[model] def jdiInvokeMethod(method: Method, thread: ScalaThread, args: Value*): Value = thread.invokeMethod(underlying, method, args:_*)
 
   // -----
 
@@ -160,17 +178,16 @@ class ScalaObjectReference(override val underlying: ObjectReference, target: Sca
    */
   private def getBoxedPrimitiveValue(): String = {
     ScalaDebugModelPresentation.computeDetail(fieldValue("value"))
-  }
-  
+  } 
 }
 
 class ScalaNullValue(target: ScalaDebugTarget) extends ScalaValue(null, target) {
 
   // Members declared in org.eclipse.debug.core.model.IValue
 
-  override def getReferenceTypeName(): String = "null"
-  override def getValueString(): String = "null"
-  override def getVariables(): Array[org.eclipse.debug.core.model.IVariable] = Array() // TODO: cached empty array?
-  override def hasVariables(): Boolean = false
+  protected override def doGetReferenceTypeName(): String = "null"
+  protected override def doGetValueString(): String = "null"
+  protected override def doGetVariables(): Array[IVariable] = Array() // TODO: cached empty array?
+  protected override def doHasVariables(): Boolean = false
 
 }

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaVariable.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaVariable.scala
@@ -17,36 +17,49 @@ abstract class ScalaVariable(target: ScalaDebugTarget) extends ScalaDebugElement
 
   // Members declared in org.eclipse.debug.core.model.IVariable
 
+  final override def getValue(): IValue = 
+    wrapJDIException("Exception while retrieving variable's value") { doGetValue() }
+
+  final override def getName(): String = 
+    wrapJDIException("Exception while retrieving variable's name") { doGetName() }
+
+  final override def getReferenceTypeName(): String =
+    wrapJDIException("Exception while retrieving variable's reference type name") { doGetReferenceTypeName() }
+
   override def hasValueChanged: Boolean = false // TODO: need real logic
+  
+  protected def doGetValue(): IValue
+  protected def doGetName(): String
+  protected def doGetReferenceTypeName(): String
 }
 
 class ScalaThisVariable(underlying: ObjectReference, stackFrame: ScalaStackFrame) extends ScalaVariable(stackFrame.getDebugTarget) {
   
   // Members declared in org.eclipse.debug.core.model.IVariable
 
-  override def getName: String = "this"
-  override def getReferenceTypeName: String = underlying.referenceType.name
-  override def getValue: IValue = new ScalaObjectReference(underlying, getDebugTarget)
+  override protected def doGetName: String = "this"
+  override protected def doGetReferenceTypeName: String = underlying.referenceType.name
+  override protected def doGetValue: IValue = new ScalaObjectReference(underlying, getDebugTarget)
 }
 
 class ScalaLocalVariable(underlying: LocalVariable, stackFrame: ScalaStackFrame) extends ScalaVariable(stackFrame.getDebugTarget) {
 
   // Members declared in org.eclipse.debug.core.model.IVariable
 
-  override def getName(): String = underlying.name
-  override def getReferenceTypeName(): String = underlying.typeName
+  override protected def doGetName(): String = underlying.name
+  override protected def doGetReferenceTypeName(): String = underlying.typeName
   
   // fetching the value for local variables cannot be delayed because the underlying stackframe element may become invalid at any time
-  override val getValue: IValue = ScalaValue(stackFrame.stackFrame.getValue(underlying), getDebugTarget)
+  override protected def doGetValue: IValue = ScalaValue(stackFrame.stackFrame.getValue(underlying), getDebugTarget)
 }
 
 class ScalaArrayElementVariable(index: Int, arrayReference: ScalaArrayReference) extends ScalaVariable(arrayReference. getDebugTarget) {
 
   // Members declared in org.eclipse.debug.core.model.IVariable
 
-  override def getName(): String = "(%s)".format(index)
-  override def getReferenceTypeName(): String = arrayReference.underlying.referenceType.asInstanceOf[ArrayType].componentTypeName
-  override def getValue(): org.eclipse.debug.core.model.IValue = ScalaValue(arrayReference.underlying.getValue(index), getDebugTarget)
+  override protected def doGetName(): String = "(%s)".format(index)
+  override protected def doGetReferenceTypeName(): String = arrayReference.underlying.referenceType.asInstanceOf[ArrayType].componentTypeName
+  override protected def doGetValue(): IValue = ScalaValue(arrayReference.underlying.getValue(index), getDebugTarget)
 
 }
 
@@ -54,7 +67,7 @@ class ScalaFieldVariable(field: Field, objectReference: ScalaObjectReference) ex
 
   // Members declared in org.eclipse.debug.core.model.IVariable
 
-  override def getName(): String = field.name
-  override def getReferenceTypeName(): String = field.typeName
-  override def getValue(): org.eclipse.debug.core.model.IValue = ScalaValue(objectReference.underlying.getValue(field), getDebugTarget)
+  override protected def doGetName(): String = field.name
+  override protected def doGetReferenceTypeName(): String = field.typeName
+  override protected def doGetValue(): IValue = ScalaValue(objectReference.underlying.getValue(field), getDebugTarget)
 }


### PR DESCRIPTION
Several of the debugger interfaces we implement expect a `DebugException` to
be thrown when the called method fails to execute. Failure can occur, for
instance, when a debugger session is terminated by the user. Failing to wrap
the JDI runtime exception in a `DebugException` can prevent the debugger to
correctly work and the user is sometime forced to restart Eclipse.

`DebugException` is a platform exception that is specially treated by
Eclipse.

If you wonder why do we have calls to `safeStackFrameCalls` in, for instance,
`ScalaStackFrame.getLineNumber`, the answer is: I don't think we need it. However,
since we are in RCs cycle for the 3.0 release, I want to minimize the changes in
this commit to avoid regressions.

Fix #1001531
