### PR TITLE
Expanding variable in debugger resulted in NPE

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaLogicalStructureProvider.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaLogicalStructureProvider.scala
@@ -10,7 +10,7 @@ import org.eclipse.debug.core.model.IValue
 
 import com.sun.jdi.ClassType
 
-class ScalaLogicalStructureProviders extends ILogicalStructureProvider {
+class ScalaLogicalStructureProvider extends ILogicalStructureProvider {
 
   override def getLogicalStructureTypes(value: IValue) : Array[ILogicalStructureType] = {
     value match {


### PR DESCRIPTION
The regression was introduced by SHA: be83fc8f7c40c71269d5e7315594896e6b85ab69.

The reason for the regression is that the name of the class
`ScalaLogicalStructureProvider` was inadvertently changed to
`ScalaLogicalStructureProviders` (note the final **s**). Since that class was
linked to the _org.eclipse.debug.core.logicalStructureProviders_ extension
point, as soon as the debugger code needed to load that class an exception is
reported.

What we should do to avoid this sort of errors in the future is setting the PDE
compiler flag for "References to non-existing classes" to _Error_. Furthermore,
it would be good if this check could be enforced in our Tycho build (I've asked
in the tycho-user ML,
[here](http://dev.eclipse.org/mhonarc/lists/tycho-user/msg04110.html) is the
link to the discussion).

Fix #1001586

Backport to _release/3.0.x_
