### PR TITLE
Disabled ``implicitConversionFromPackageObjectShouldBeInScope`` PC test

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
@@ -69,6 +69,7 @@ class FreshFile {
     Assert.assertNotSame("Unexpected clean source", errors1, Nil)
   }
 
+  @Ignore("Enable this once we understand why it spuriously fail #1001588")
   @Test
   def implicitConversionFromPackageObjectShouldBeInScope_t1000647() {
     //when


### PR DESCRIPTION
Disabling the test `implicitConversionFromPackageObjectShouldBeInScope` from
PresentationCompilerTest because it often fails on our Jenkins machine (and
that's just plain annoying), e.g.,
https://jenkins.scala-ide.org:8496/jenkins/job/parameterized-scala-ide/168/console.
This test has been flaky for at least a month now.

Re #1001588
