### PR TITLE
Don't add arguments templates for parameterless method's completion

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposal.scala
@@ -136,9 +136,9 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
      
       None
     }
-        
+
     selectionProvider match {
-      case viewer: ITextViewer if explicitParamNames.nonEmpty =>
+      case viewer: ITextViewer if explicitParamNames.flatten.nonEmpty =>
         addArgumentTemplates(d, viewer)
       case _ => () 
     }


### PR DESCRIPTION
When asking for completion on a parameterless method we were trying to install
arguments' templates. This operation in not allowed on parameterless methods,
and it caused a `java.lang.IllegalStateException: must specify at least one
linked position` during completion.

`explicitParamNames` is a `List[List[String]]` (because of currying), hence
a parameterless method is represented as `List(List())`. The arguments'
templates where added only if `explicitParamNames` is not empty, however a
`List(List())` contains exactly one element (the empty list), hence it's
never empty!  The fix is really simple, we just need to flatten the
`explicitParamNames` before checking for emptiness.

Fixes #1001591

backport to _release/3.0.x_

review by @dragos
