### PR TITLE
[backport] Workaround for NPE in debugger variable view when using Eclipse Juno

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
@@ -16,6 +16,7 @@ import scala.tools.eclipse.logging.HasLogger
 import org.eclipse.debug.core.ILaunchConfiguration
 import scala.tools.eclipse.debug.breakpoints.BreakpointSupport
 import scala.tools.eclipse.debug.model.ScalaValue
+import org.eclipse.jface.viewers.StructuredSelection
 
 object EclipseDebugEvent {
   def unapply(event: DebugEvent): Option[(Int, AnyRef)] = Some((event.getKind, event.getSource()))
@@ -80,7 +81,8 @@ class ScalaDebugTestSession(launchConfiguration: ILaunchConfiguration) extends H
   def setSuspended(stackFrame: ScalaStackFrame) {
     this.synchronized {
       currentStackFrame = stackFrame
-      ScalaDebugger.currentThread = stackFrame.thread
+      val selection = new StructuredSelection(stackFrame)
+      ScalaDebugger.selectionChanged(null, selection)
       state = SUSPENDED
       logger.info("SUSPENDED at: %s:%d".format(stackFrame.getMethodFullName, stackFrame.getLineNumber))
       this.notify

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugger.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/ScalaDebugger.scala
@@ -1,16 +1,16 @@
 package scala.tools.eclipse.debug
 
 import scala.tools.eclipse.ScalaPlugin
-
 import org.eclipse.debug.core.model.IDebugModelProvider
 import org.eclipse.jface.viewers.IStructuredSelection
 import org.eclipse.ui.ISelectionListener
 import org.eclipse.ui.PlatformUI
-
 import model.ScalaStackFrame
 import model.ScalaThread
+import scala.tools.eclipse.debug.model.ScalaObjectReference
+import scala.tools.eclipse.logging.HasLogger
 
-object ScalaDebugger extends ISelectionListener {
+object ScalaDebugger extends ISelectionListener with HasLogger {
 
   val classIDebugModelProvider = classOf[IDebugModelProvider]
 
@@ -46,7 +46,28 @@ object ScalaDebugger extends ISelectionListener {
     * value of `currentThread` is not the expected one. Practically, this means that accesses to `currentThread` should always happen 
     * within a try..catch block. Failing to do so can cause the whole debug session to shutdown for no good reasons.
     */
-  @volatile var currentThread: ScalaThread = null
+  @volatile private var currentThread: ScalaThread = null
+  
+  def currentThreadOrFindFirstSuspendedThread(objRef: ScalaObjectReference): ScalaThread = {
+    if(currentThread == null) {
+     logger.info("`currentThread` is null. Now looking for first suspended thread...")
+     val threads = objRef.getDebugTarget.getThreads
+     val suspendedThreads = threads collect { case t: ScalaThread if t.isSuspended => t}
+     if(suspendedThreads.isEmpty) {
+       logger.error("Could not find a suspended thread. This is a bug, please file a bug report at " + ScalaPlugin.IssueTracker)
+       null
+     }
+     else {
+       if(suspendedThreads.length > 1) logger.info {
+         "There is more than one suspended thread. Using the first in the list. If you experience any issue during the " +
+         "current debug session, please file a bug report at " + ScalaPlugin.IssueTracker + " and make sure to mention this " + 
+         "message in the ticket's description."
+       }
+       suspendedThreads(0)
+     }
+    }
+    else currentThread
+  }
 
   def init() {
     if (!ScalaPlugin.plugin.headlessMode) {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
@@ -52,7 +52,7 @@ object ScalaDebugModelPresentation {
    */
   private def computeDetail(objectReference: ScalaObjectReference): String = {
     try {
-      objectReference.invokeMethod("toString", "()Ljava/lang/String;", ScalaDebugger.currentThread) match {
+      objectReference.invokeMethod("toString", "()Ljava/lang/String;", ScalaDebugger.currentThreadOrFindFirstSuspendedThread(objectReference)) match {
         case s: ScalaStringReference =>
           s.underlying.value
         case n: ScalaNullValue =>


### PR DESCRIPTION
Unfortunately, the way we keep track of the currently selected thread in the
Scala debugger isn't robust enough. Currently, we rely on a _selectionChanged_
event to be sent when the Debug Perspective is opened. This worked fine with
Eclipse Indigo, but it's no longer working with Eclipse Juno.

The workaround is to look for the first suspended thread if
`ScalaDebugger.currentThread` is null. This is far from being a proper fix,
but it doesn't look like we have many alternatives. The Java debugger
implementation seem to be using a DebugContextProvider/Manager/Event/Listener
to know the thread associated to each variable. But using the debug context
classes would require some import work, so it would be preferable to delay this
for after the 3.0.0 final release.

The workaround was suggested by @skyluc, and he believes the only issue this
could lead to is visibility issues due to invoking a method call on the wrong
thread (in case more than one is suspended), and hence the executing thread may
see some stale values. Not an issue to be taken lightly.

Fix #1001585

backport to _release/3.0.x_
(cherry picked from commit 2de89febce7f9fb36820838b83f9ebd05fb0409d)
