### PR TITLE
Correctly search for threads, and don't use `Option.get`

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugTarget.scala
@@ -393,7 +393,7 @@ private class ScalaDebugTargetActor private (threadStartRequest: ThreadStartRequ
       reply(false)
     case ThreadSuspended(thread, eventDetail) =>
       // forward the event to the right thread
-      debugTarget.getScalaThreads.find(_.threadRef eq thread).get.suspendedFromScala(eventDetail)
+      debugTarget.getScalaThreads.find(_.threadRef == thread).foreach(_.suspendedFromScala(eventDetail))
   }
 
   private def vmStarted() {


### PR DESCRIPTION
JDI objects implement `equals`, we should not rely on reference equality.

This is the last instance of `Option.get` in the debugger.

Fixed #1001599.

Should be backported.
