### PR TITLE
Small improvement in ``CompletionTests`` test runner

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
@@ -70,7 +70,9 @@ class CompletionTests {
         val completions: List[ICompletionProposal] = completion.computeCompletionProposals(context, monitor).map(_.asInstanceOf[ICompletionProposal]).toList
         */
 
-        body(i, position, completion.findCompletions(wordRegion)(pos + 1, unit)(src, compiler))
+        val completions = completion.findCompletions(wordRegion)(pos + 1, unit)(src, compiler)
+        val sortedCompletions = completions.sortWith((x,y) => x.relevance >= y.relevance)
+        body(i, position, sortedCompletions)
       }
     }()
   }
@@ -248,7 +250,6 @@ class CompletionTests {
           assertEquals("Relevance", "__stringLikeClass", proposals.head.completion)
         case 1 =>
           assertEquals("Relevance", "List", proposals.head.completion)
-          assertEquals("Relevance", "List", proposals(1).completion)
         case _ =>
           assert(false, "Unhandled completion position")
       }

--- a/org.scala-ide.sdt.core.tests/test-workspace/completion/src/relevance/RelevanceCompletions.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/completion/src/relevance/RelevanceCompletions.scala
@@ -3,10 +3,10 @@ package relevance
 class RelevanceCompletions{
   def meth1() {
     val __stringLikeClass = "some text"
-    __str/*!*/
+    __str /*!*/
   }
   def meth2() {
     val listLike = "some text"
-    Lis/*!*/
+    Lis /*!*/
   }
 }


### PR DESCRIPTION
If the test does not contain at least one occurrence of the expected marker,
fail the test.
