### PR TITLE
Correct syntax coloring for //* in multi line comments

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniserTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniserTest.scala
@@ -178,6 +178,16 @@ class ScalaPartitionTokeniserTest {
     """'\123'""" ==> ((JAVA_CHARACTER, 0, 5))
   }
 
+  @Test
+  def single_line_comment_in_multi_line_comment() {
+    """/*//*/ val x = 0""" ==> ((JAVA_MULTI_LINE_COMMENT, 0, 5), (DEFAULT_CONTENT_TYPE, 6, 15))
+  }
+
+  @Test
+  def single_line_comment_in_nested_multi_line_comment() {
+    """/*/*//*/ val s = 0 */*/*/ val p = 0""" ==> ((JAVA_MULTI_LINE_COMMENT, 0, 24), (DEFAULT_CONTENT_TYPE, 25, 34))
+  }
+
 }
 
 object ScalaPartitionTokeniserTest {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniser.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaPartitionTokeniser.scala
@@ -310,7 +310,7 @@ class ScalaPartitionTokeniser(text: String) extends TokenTests {
         accept(2)
         if (nesting > 1)
           getMultiLineComment(nesting - 1)
-      case '/' if (ch(1) == '*') =>
+      case '/' if ch(1) == '*' && (ch(-1) != '/' || nesting != 1) =>
         accept(2)
         getMultiLineComment(nesting + 1)
       case '{' if ch(1) == '{' && ch(2) == '{' && contentTypeOpt.exists(_ == JAVA_DOC) =>


### PR DESCRIPTION
Whenever two consecutive slashes occur before a star inside of a multi
line comment the rule is that such a comment is not terminated. This
means /_//_/ is a valid comment. On the other hand /_/_//_/_/ is not a
valid comment because whenever the //\* occurs inside of a nested
comment then it is counted as a starting point of another nested
comment.

This behavior looks weird but it reflects the way how the compiler
works.

Fixes #1000790
