### PR TITLE
Avoid workspace-wide locks when building.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaBuilder.scala
@@ -15,11 +15,16 @@ import scala.tools.eclipse.javaelements.JDTUtils
 import scala.tools.eclipse.util.{ FileUtils, ReflectionUtils }
 import scala.tools.eclipse.logging.HasLogger
 import scala.tools.nsc.interactive.RefinedBuildManager
+import org.eclipse.core.runtime.jobs.ISchedulingRule
 
 class ScalaBuilder extends IncrementalProjectBuilder with HasLogger {
   def plugin = ScalaPlugin.plugin
 
   private val scalaJavaBuilder = new GeneralScalaJavaBuilder
+
+  /** Lock only the current project during build. */
+  override def getRule(kind: Int, args: java.util.Map[String,String]): ISchedulingRule =
+    getProject()
   
   override def clean(monitor : IProgressMonitor) {
     super.clean(monitor)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -15,7 +15,6 @@ import scala.tools.eclipse.logging.HasLogger
 import scala.tools.eclipse.properties.{CompilerSettings, IDESettings, PropertyStore}
 import scala.tools.eclipse.ui.PartAdapter
 import scala.tools.eclipse.util.{Cached, EclipseResource, Trim, Utils}
-import scala.tools.eclipse.util.EclipseUtils.workspaceRunnableIn
 import scala.tools.eclipse.util.SWTUtils.asyncExec
 import scala.tools.nsc.{Settings, MissingRequirementError}
 import scala.tools.nsc.util.BatchSourceFile
@@ -177,36 +176,30 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
   
   /** Does this project have the Scala nature? */
   def hasScalaNature: Boolean = plugin.isScalaProject(underlying)
-  
-  private def settingsError(severity: Int, msg: String, monitor: IProgressMonitor): Unit =
-    workspaceRunnableIn(underlying.getWorkspace, monitor) { m =>
-      val mrk = underlying.createMarker(plugin.settingProblemMarkerId)
-      mrk.setAttribute(IMarker.SEVERITY, severity)
-      mrk.setAttribute(IMarker.MESSAGE, msg)
-    }
+
+  private def settingsError(severity: Int, msg: String, monitor: IProgressMonitor): Unit = {
+    val mrk = underlying.createMarker(plugin.settingProblemMarkerId)
+    mrk.setAttribute(IMarker.SEVERITY, severity)
+    mrk.setAttribute(IMarker.MESSAGE, msg)
+  }
 
   /** Deletes the build problem marker associated to {{{this}}} Scala project. */
-  private def clearBuildProblemMarker(): Unit = 
-    workspaceRunnableIn(underlying.getWorkspace) { m =>
-      if (isUnderlyingValid) {
-        underlying.deleteMarkers(plugin.problemMarkerId, true, IResource.DEPTH_ZERO)
-      }
-    }    
+  private def clearBuildProblemMarker(): Unit =
+    if (isUnderlyingValid) {
+      underlying.deleteMarkers(plugin.problemMarkerId, true, IResource.DEPTH_ZERO)
+    }
+
  
   /** Deletes all build problem markers for all resources in {{{this}}} Scala project. */
   private def clearAllBuildProblemMarkers(): Unit = {
-    workspaceRunnableIn(underlying.getWorkspace) { m =>
-      if (isUnderlyingValid) {
-        underlying.deleteMarkers(plugin.problemMarkerId, true, IResource.DEPTH_INFINITE)
-      }
+    if (isUnderlyingValid) {
+      underlying.deleteMarkers(plugin.problemMarkerId, true, IResource.DEPTH_INFINITE)
     }
   }
 
   private def clearSettingsErrors(): Unit =
-    workspaceRunnableIn(underlying.getWorkspace) { m =>
-      if (isUnderlyingValid) {
-        underlying.deleteMarkers(plugin.settingProblemMarkerId, true, IResource.DEPTH_ZERO)
-      }
+    if (isUnderlyingValid) {
+      underlying.deleteMarkers(plugin.settingProblemMarkerId, true, IResource.DEPTH_ZERO)
     }
 
   

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/resources/MarkerFactory.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/resources/MarkerFactory.scala
@@ -1,7 +1,5 @@
 package scala.tools.eclipse.resources
 
-import scala.tools.eclipse.util.EclipseUtils.workspaceRunnableIn
-
 import org.eclipse.core.resources.IMarker
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.runtime.IProgressMonitor

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/FileUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/FileUtils.scala
@@ -49,14 +49,14 @@ object FileUtils {
   
   def clearBuildErrors(file : IFile, monitor : IProgressMonitor) =
     try {
-      workspaceRunnableIn(file.getWorkspace, monitor)( m => file.deleteMarkers(plugin.problemMarkerId, true, IResource.DEPTH_INFINITE))
+      file.deleteMarkers(plugin.problemMarkerId, true, IResource.DEPTH_INFINITE)
     } catch {
       case _ : ResourceException =>
     }
   
   def clearTasks(file : IFile, monitor : IProgressMonitor) =
     try {
-      workspaceRunnableIn(file.getWorkspace, monitor) { m => file.deleteMarkers(plugin.taskMarkerId, true, IResource.DEPTH_INFINITE) }
+      file.deleteMarkers(plugin.taskMarkerId, true, IResource.DEPTH_INFINITE)
     } catch {
       case _ : ResourceException =>
     }
@@ -67,27 +67,26 @@ object FileUtils {
   def hasBuildErrors(file : IResource) : Boolean =
     file.findMarkers(plugin.problemMarkerId, true, IResource.DEPTH_INFINITE).exists(_.getAttribute(IMarker.SEVERITY) == IMarker.SEVERITY_ERROR)
 
-  def task(file: IFile, tag: String, msg: String, priority: String, offset: Int, length: Int, line: Int, monitor: IProgressMonitor) =
-    workspaceRunnableIn(file.getWorkspace, monitor) { m =>
-      val mrk = file.createMarker(plugin.taskMarkerId)
-      val values = new Array[AnyRef](taskMarkerAttributeNames.length)
+  def task(file: IFile, tag: String, msg: String, priority: String, offset: Int, length: Int, line: Int, monitor: IProgressMonitor) = {
+    val mrk = file.createMarker(plugin.taskMarkerId)
+    val values = new Array[AnyRef](taskMarkerAttributeNames.length)
 
-      val prioNum = priority match {
-        case JavaCore.COMPILER_TASK_PRIORITY_HIGH => IMarker.PRIORITY_HIGH
-        case JavaCore.COMPILER_TASK_PRIORITY_LOW  => IMarker.PRIORITY_LOW
-        case _                                    => IMarker.PRIORITY_NORMAL
-      }
-
-      values(0) = tag + " " + msg
-      values(1) = Integer.valueOf(prioNum)
-      values(2) = Integer.valueOf(IProblem.Task)
-      values(3) = Integer.valueOf(offset)
-      values(4) = Integer.valueOf(offset + length + 1)
-      values(5) = Integer.valueOf(line)
-      values(6) = java.lang.Boolean.valueOf(false)
-      values(7) = JavaBuilder.SOURCE_ID
-      mrk.setAttributes(taskMarkerAttributeNames, values);
+    val prioNum = priority match {
+      case JavaCore.COMPILER_TASK_PRIORITY_HIGH => IMarker.PRIORITY_HIGH
+      case JavaCore.COMPILER_TASK_PRIORITY_LOW  => IMarker.PRIORITY_LOW
+      case _                                    => IMarker.PRIORITY_NORMAL
     }
+
+    values(0) = tag + " " + msg
+    values(1) = Integer.valueOf(prioNum)
+    values(2) = Integer.valueOf(IProblem.Task)
+    values(3) = Integer.valueOf(offset)
+    values(4) = Integer.valueOf(offset + length + 1)
+    values(5) = Integer.valueOf(line)
+    values(6) = java.lang.Boolean.valueOf(false)
+    values(7) = JavaBuilder.SOURCE_ID
+    mrk.setAttributes(taskMarkerAttributeNames, values);
+  }
 
   private val taskMarkerAttributeNames = Array(
     IMarker.MESSAGE,


### PR DESCRIPTION
There is no reason to lock the workspace when building a project. Markers already
lock the required resources, and the build should just lock the current project.

Fixed #1001631.

(should be backported)
