### PR TITLE
Do not lock the whole workspace when running the ``ProjectsCleanJob``

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/ProjectsCleanJob.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/ProjectsCleanJob.scala
@@ -8,6 +8,8 @@ import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Status
 import org.eclipse.core.runtime.SubProgressMonitor
+import org.eclipse.core.runtime.jobs.ISchedulingRule
+import org.eclipse.core.runtime.jobs.MultiRule
 import org.eclipse.ui.progress.IProgressConstants2
 
 /** Job for asynchronously cleaning the passed `projects`.*/
@@ -34,7 +36,7 @@ class ProjectsCleanJob private (projects: Seq[IProject]) {
 
   private def cleanJob: WorkspaceJob = {
     val cleanJob = new DoCleanJob(projects)
-    cleanJob.setRule(ResourcesPlugin.getWorkspace().getRuleFactory().buildRule())
+    cleanJob.setRule(MultiRule.combine(projects.toArray[ISchedulingRule]))
     cleanJob.setUser(true)
     cleanJob.setProperty(IProgressConstants2.SHOW_IN_TASKBAR_ICON_PROPERTY, true)
     cleanJob


### PR DESCRIPTION
I noticed that the default implementation of
`ResourcesPlugin.getWorkspace().getRuleFactory().buildRule()` returns a
scheduling rule that **locks the whole workspace**. That seems unnecessary,
hence I've changed the implementation of the `ProjectsCleanJob` to only lock
the projects that are about to be cleaned.
