### PR TITLE
Add a quick fix to create a new class

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickfix/CreateClassTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickfix/CreateClassTests.scala
@@ -1,0 +1,12 @@
+package scala.tools.eclipse.quickfix
+
+import org.junit.Test
+
+class CreateClassTests {
+  import QuickFixesTests._
+
+  @Test
+  def createClassQuickFixes {
+    withQuickFixes("createclass/UsesMissingClass.scala")("Create class 'ThisClassDoesNotExist'")
+  }
+}

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickfix/QuickFixesTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickfix/QuickFixesTests.scala
@@ -1,180 +1,106 @@
 package scala.tools.eclipse.quickfix
 
-import scala.tools.eclipse.testsetup.SDTTestUtils
+import java.util.ArrayList
+
+import scala.collection.JavaConversions.asScalaBuffer
+import scala.collection.mutable.Buffer
+import scala.tools.eclipse.javaelements.ScalaCompilationUnit
 import scala.tools.eclipse.testsetup.TestProjectSetup
-import scala.tools.eclipse.ScalaWordFinder
-import org.eclipse.core.resources.IMarker
-import org.eclipse.core.resources.IncrementalProjectBuilder
-import org.eclipse.core.runtime.NullProgressMonitor
+import scala.tools.nsc.interactive.Response
+
+import org.eclipse.core.runtime.CoreException
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.jdt.core.compiler.IProblem
+import org.eclipse.jdt.internal.ui.text.correction.AssistContext
+import org.eclipse.jdt.internal.ui.text.correction.JavaCorrectionProcessor
+import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation
+import org.eclipse.jdt.ui.JavaUI
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
+import org.eclipse.jdt.ui.text.java.IProblemLocation
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
-import org.junit.Test
-import scala.tools.eclipse.hyperlink.text.detector.ScalaDeclarationHyperlinkComputer
-import java.util.ArrayList
-import org.eclipse.core.runtime.IStatus
-import org.eclipse.core.runtime.CoreException
-import org.eclipse.jdt.internal.ui.text.correction.JavaCorrectionProcessor
-import scala.tools.eclipse.javaelements.ScalaCompilationUnit
-import scala.tools.nsc.interactive.Response
-import org.eclipse.jdt.core.dom.CompilationUnit
-import org.eclipse.jdt.internal.ui.text.correction.AssistContext
-import org.eclipse.jdt.core.ICompilationUnit
-import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation
-import org.eclipse.jdt.ui.text.java.IProblemLocation
-import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
-import org.eclipse.jdt.core.compiler.IProblem
-import scala.collection.mutable.Buffer
-import org.eclipse.jdt.ui.JavaUI
-
 
 object QuickFixesTests extends TestProjectSetup("quickfix") {
-  
-  def assertStatusOk(status: IStatus) {
-		if (!status.isOK()) {
-			if (status.getException() == null) {  // find a status with an exception
-				val children = status.getChildren();
-				for (child <- children) {
-					if (child.getException() != null) {
-						throw new CoreException(child);
-					}
-				}
-			}
-		}
-	}
-  
-  def assertNumberOfProblems(nProblems: Int, problems: Array[IProblem] ) {
-    // check if numbers match but we want reasonable error message
-		if (problems.length != nProblems) {
-			val buf= new StringBuffer("Wrong number of problems, is: ")
-			buf.append(problems.length).append(", expected: ").append(nProblems).append('\n')
-			for (problem <- problems) {
-				buf.append(problem).append(" at ")
-				buf.append('[').append(problem.getSourceStart()).append(" ,").append(problem.getSourceEnd()).append(']')
-				buf.append('\n')
-			}
-			
-			assertEquals(buf.toString, nProblems, problems.length)
-		}
-	}
-  
-}
 
-class QuickFixesTests {
-  import QuickFixesTests._
+  def assertStatusOk(status: IStatus) {
+    if (!status.isOK()) {
+      if (status.getException() == null) { // find a status with an exception
+        val children = status.getChildren();
+        for (child <- children) {
+          if (child.getException() != null) {
+            throw new CoreException(child);
+          }
+        }
+      }
+    }
+  }
+
+  def assertNumberOfProblems(nProblems: Int, problems: Array[IProblem]) {
+    // check if numbers match but we want reasonable error message
+    if (problems.length != nProblems) {
+      val buf = new StringBuffer("Wrong number of problems, is: ")
+      buf.append(problems.length).append(", expected: ").append(nProblems).append('\n')
+      for (problem <- problems) {
+        buf.append(problem).append(" at ")
+        buf.append('[').append(problem.getSourceStart()).append(" ,").append(problem.getSourceEnd()).append(']')
+        buf.append('\n')
+      }
+
+      assertEquals(buf.toString, nProblems, problems.length)
+    }
+  }
   
-  private def withQuickFixes(pathToSource: String)(expectedQuickFixesList: List[List[String]]) {  
+  def withQuickFixes(pathToSource: String)(expectedQuickFixes: String*) {
+    withManyQuickFixesPerLine(pathToSource)(expectedQuickFixes.map(List(_)).toList)
+  }
+
+  def withManyQuickFixesPerLine(pathToSource: String)(expectedQuickFixesList: List[List[String]]) {
     // get our compilation unit
     val unit = compilationUnit(pathToSource).asInstanceOf[ScalaCompilationUnit]
-    
+
     // first, 'open' the file by telling the compiler to load it
     project.withSourceFile(unit) { (src, compiler) =>
-      
+
       // do a compiler reload before checking for problems
       val dummy = new Response[Unit]
       compiler.askReload(List(src), dummy)
-      dummy.get   
-      
+      dummy.get
+
       val problems = compiler.problemsOf(unit)
       assertTrue("No problems found.", problems.size > 0)
       assertNumberOfProblems(expectedQuickFixesList.size, problems.toArray)
-    
-    	val editor = JavaUI.openInEditor(unit.getCompilationUnit)
-    	Thread.sleep(5000)
-    	
+
+      val editor = JavaUI.openInEditor(unit.getCompilationUnit)
+
       // check each problem quickfix
-      for ( (problem, expectedQuickFixes) <- problems zip expectedQuickFixesList) {
-	      // here we will accumulate proposals
-		    var proposals: ArrayList[IJavaCompletionProposal] = new ArrayList()
-      
-		    // get all corrections for the problem
-	      val offset = problem.getSourceStart
-				val length = problem.getSourceEnd + 1 - offset
-				val context= new AssistContext(unit.getCompilationUnit, offset, length)
-	      
-	      val problemLocation: IProblemLocation = new ProblemLocation(problem);	      
-				val status = JavaCorrectionProcessor.collectCorrections(context, Array( problemLocation ), proposals)
-								
-				// assert that status is okay
-				assertStatusOk(status)
-				
-				// get collection of offered quickfix message
-				import scala.collection.JavaConversions._        
-				val corrections: List[String] = (proposals : Buffer[IJavaCompletionProposal]).toList.map( _.getDisplayString )
-				
-				// check all expected quick fixes
-				//assertEquals(expectedQuickFixes.size, corrections.size)
-				// NOTE due to a bug, Scala IDE returns a lot of quick fixes so we skip number comparison
-				for ( quickFix <- expectedQuickFixes  ) {
-				  assertTrue("Quick fix " + quickFix + " was not offered. Offered were: " + corrections.mkString(", "),
-			      corrections contains quickFix )				 
-				}
+      for ((problem, expectedQuickFixes) <- problems zip expectedQuickFixesList) {
+        // here we will accumulate proposals
+        var proposals: ArrayList[IJavaCompletionProposal] = new ArrayList()
+
+        // get all corrections for the problem
+        val offset = problem.getSourceStart
+        val length = problem.getSourceEnd + 1 - offset
+        val context = new AssistContext(unit.getCompilationUnit, offset, length)
+
+        val problemLocation: IProblemLocation = new ProblemLocation(problem)
+        val status = JavaCorrectionProcessor.collectCorrections(context, Array(problemLocation), proposals)
+
+        // assert that status is okay
+        assertStatusOk(status)
+
+        // get collection of offered quickfix message
+        import scala.collection.JavaConversions._
+        val corrections: List[String] = (proposals: Buffer[IJavaCompletionProposal]).toList.map(_.getDisplayString)
+
+        // check all expected quick fixes
+        //assertEquals(expectedQuickFixes.size, corrections.size)
+        // NOTE due to a bug, Scala IDE returns a lot of quick fixes so we skip number comparison
+        for (quickFix <- expectedQuickFixes) {
+          assertTrue("Quick fix " + quickFix + " was not offered. Offered were: " + corrections.mkString(", "),
+            corrections contains quickFix)
+        }
       }
-    } ( )
+    }()
 
   }
-  
-  val stringPattern = "Transform expression: %s => %s"
-  
-  @Test
-  def basicTypeMismatchQuickFixes { 
-    withQuickFixes("typemismatch/Basic.scala")(
-      List(
-        List(
-          stringPattern.format("List[List[Int]]()","List[List[Int]]().flatten"),
-          stringPattern.format("List[List[Int]]()","List[List[Int]]().head"),
-          stringPattern.format("List[List[Int]]()","List[List[Int]]().last")
-        ),
-        List(
-          stringPattern.format("listOfInt_val","listOfInt_val.flatten"),
-          stringPattern.format("listOfInt_val","listOfInt_val.head"),
-          stringPattern.format("listOfInt_val","listOfInt_val.last")
-        ),
-        List(
-          stringPattern.format("intVal","Some(intVal)"),
-          stringPattern.format("intVal","Option(intVal)")
-        ),
-        List(
-          stringPattern.format("List[Int]()","List[Int]().toArray")
-        ),
-        List(
-          stringPattern.format("arrayOfInt_val","arrayOfInt_val.toArray")
-        )
-//        ,
-//        List(
-//          stringPattern.format("5","Some(5)"),
-//          stringPattern.format("5","Option(5)")
-//        ),
-//        List(
-//          stringPattern.format("5 * 3 + 2","Some(5 * 3 + 2)"),
-//          stringPattern.format("5 * 3 + 2","Option(5 * 3 + 2)")
-//        ),
-//        List(
-//          stringPattern.format("5 * 3 + intVal","Some(5 * 3 + intVal)"),
-//          stringPattern.format("5 * 3 + intVal","Option(5 * 3 + intVal)")
-//        ),
-//        List(
-//          stringPattern.format("true","Some(true)"),
-//          stringPattern.format("true","Option(true)")
-//        ),
-//        List(
-//          stringPattern.format("(intVal % 4 == 2)","Some((intVal % 4 == 2))"),
-//          stringPattern.format("(intVal % 4 == 2)","Option((intVal % 4 == 2))")
-//        ),
-//        List(
-//          stringPattern.format("'5'","Some('5')"),
-//          stringPattern.format("'5'","Option('5')")
-//        ),
-//        List(
-//          stringPattern.format("\"asd\"","Some(\"asd\")"),
-//          stringPattern.format("\"asd\"","Option(\"asd\")")
-//        ),
-//        List(
-//          stringPattern.format("5.3f","Some(5.3f)"),
-//          stringPattern.format("5.3f","Option(5.3f)")
-//        )
-      )
-    )
-  }
-  
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickfix/TypeMismatchTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickfix/TypeMismatchTests.scala
@@ -1,0 +1,63 @@
+package scala.tools.eclipse.quickfix
+
+import org.junit.Test
+
+class TypeMismatchTests {
+  import QuickFixesTests._
+
+  val stringPattern = "Transform expression: %s => %s"
+
+  @Test
+  def basicTypeMismatchQuickFixes {
+    withManyQuickFixesPerLine("typemismatch/Basic.scala")(
+      List(
+        List(
+          stringPattern.format("List[List[Int]]()", "List[List[Int]]().flatten"),
+          stringPattern.format("List[List[Int]]()", "List[List[Int]]().head"),
+          stringPattern.format("List[List[Int]]()", "List[List[Int]]().last")),
+        List(
+          stringPattern.format("listOfInt_val", "listOfInt_val.flatten"),
+          stringPattern.format("listOfInt_val", "listOfInt_val.head"),
+          stringPattern.format("listOfInt_val", "listOfInt_val.last")),
+        List(
+          stringPattern.format("intVal", "Some(intVal)"),
+          stringPattern.format("intVal", "Option(intVal)")),
+        List(
+          stringPattern.format("List[Int]()", "List[Int]().toArray")),
+        List(
+          stringPattern.format("arrayOfInt_val", "arrayOfInt_val.toArray")) //        ,
+//        List(
+//          stringPattern.format("5","Some(5)"),
+//          stringPattern.format("5","Option(5)")
+//        ),
+//        List(
+//          stringPattern.format("5 * 3 + 2","Some(5 * 3 + 2)"),
+//          stringPattern.format("5 * 3 + 2","Option(5 * 3 + 2)")
+//        ),
+//        List(
+//          stringPattern.format("5 * 3 + intVal","Some(5 * 3 + intVal)"),
+//          stringPattern.format("5 * 3 + intVal","Option(5 * 3 + intVal)")
+//        ),
+//        List(
+//          stringPattern.format("true","Some(true)"),
+//          stringPattern.format("true","Option(true)")
+//        ),
+//        List(
+//          stringPattern.format("(intVal % 4 == 2)","Some((intVal % 4 == 2))"),
+//          stringPattern.format("(intVal % 4 == 2)","Option((intVal % 4 == 2))")
+//        ),
+//        List(
+//          stringPattern.format("'5'","Some('5')"),
+//          stringPattern.format("'5'","Option('5')")
+//        ),
+//        List(
+//          stringPattern.format("\"asd\"","Some(\"asd\")"),
+//          stringPattern.format("\"asd\"","Option(\"asd\")")
+//        ),
+//        List(
+//          stringPattern.format("5.3f","Some(5.3f)"),
+//          stringPattern.format("5.3f","Option(5.3f)")
+//        )
+          ))
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/quickfix/src/createclass/UsesMissingClass.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/quickfix/src/createclass/UsesMissingClass.scala
@@ -1,0 +1,5 @@
+package createclass
+
+object UsesMissingClass {
+  new ThisClassDoesNotExist()
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaImages.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaImages.scala
@@ -35,6 +35,8 @@ object ScalaImages  {
   
   val REFRESH_REPL_TOOLBAR = create("icons/full/etool16/refresh_interpreter.gif")
   
+  val NEW_CLASS = create("icons/full/etool16/newclass_wiz.gif")
+  
   private def create(localPath : String) = {
     try {
       val pluginInstallURL : URL = ScalaPlugin.plugin.getBundle.getEntry("/")

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/BasicCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/BasicCompletionProposal.scala
@@ -1,0 +1,16 @@
+package scala.tools.eclipse.quickfix
+
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.text.contentassist.IContextInformation
+import org.eclipse.swt.graphics.Image
+import org.eclipse.swt.graphics.Point
+
+abstract class BasicCompletionProposal(relevance: Int, displayString: String, image: Image = null) extends IJavaCompletionProposal {
+  override def getRelevance = relevance
+  override def getDisplayString(): String = displayString
+  override def getSelection(document: IDocument): Point = null
+  override def getAdditionalProposalInfo(): String = null
+  override def getImage(): Image = image
+  override def getContextInformation: IContextInformation = null
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/CreateClassProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/CreateClassProposal.scala
@@ -1,0 +1,36 @@
+package scala.tools.eclipse.quickfix
+
+import scala.tools.eclipse.ScalaImages
+import scala.tools.eclipse.wizards.NewClassWizard
+import scala.tools.eclipse.wizards.NewClassWizardPage
+
+import org.eclipse.jdt.core.ICompilationUnit
+import org.eclipse.jdt.internal.ui.JavaPlugin
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.viewers.StructuredSelection
+import org.eclipse.jface.window.Window
+import org.eclipse.jface.wizard.WizardDialog
+
+case class CreateClassProposal(className: String, compilationUnit: ICompilationUnit)
+  extends BasicCompletionProposal(
+    relevance = 90, //relevance should be less than ImportCompletionProposal since import quick fix should be first
+    displayString = s"Create class '$className'",
+    image = ScalaImages.NEW_CLASS.createImage()) {
+
+  override def apply(document: IDocument): Unit = {
+    val page = new NewClassWizardPage
+    val wizard = new NewClassWizard(page)
+    wizard.init(JavaPlugin.getDefault().getWorkbench(), new StructuredSelection(compilationUnit))
+    val dialog = new WizardDialog(JavaPlugin.getActiveWorkbenchShell(), wizard)
+    dialog.create()
+    page.setTypeName(className, /*canBeModified = */ false) //must go after dialog.create since create calls page.createControl which calls createTypeNameControls which actually makes the text field
+
+    if (dialog.open() == Window.OK && wizard.getCreatedElement != null) {
+      val existingClassPackage = compilationUnit.getPackageDeclarations().head.getElementName //there should always be a package declaration
+      val newClassPackage = page.getPackageText()
+      if (existingClassPackage != newClassPackage && !page.isDefaultPackage) { //can't import things from the default package, SLS 9.2
+        ImportCompletionProposal(page.getFullyQualifiedName).apply(document)
+      }
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandingProposalBase.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandingProposalBase.scala
@@ -12,11 +12,8 @@ import org.eclipse.jface.text.Position
 import scala.util.matching.Regex
 import scala.tools.eclipse.semantichighlighting.implicits.ImplicitHighlightingPresenter
 
-class ExpandingProposalBase(msg: String, displayString: String, pos: Position) extends IJavaCompletionProposal {
-  /**
-   * Fixed relevance at 100 for now, this is the maximum value according to IJavaCompletionProposal.
-   */
-  override def getRelevance = 100
+class ExpandingProposalBase(msg: String, displayString: String, pos: Position) 
+  extends BasicCompletionProposal(relevance = 100, displayString = displayString + msg) {
 
   /**
    * Inserts the proposed completion into the given document.
@@ -30,9 +27,4 @@ class ExpandingProposalBase(msg: String, displayString: String, pos: Position) e
     document.replace(pos.getOffset(), pos.getLength(), replacement);
   }
 
-  def getSelection(document: IDocument): Point = null
-  def getAdditionalProposalInfo(): String = null
-  def getDisplayString(): String = displayString + msg
-  def getImage(): Image = null
-  def getContextInformation: IContextInformation = null
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ProposalRefactoringActionAdapter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ProposalRefactoringActionAdapter.scala
@@ -16,7 +16,7 @@ abstract class ProposalRefactoringActionAdapter(
     action: ActionAdapter, 
     displayString: String,
     relevance: Int = 100) 
-	extends IJavaCompletionProposal {
+	extends BasicCompletionProposal(relevance, displayString) {
   
   override def apply(document: IDocument): Unit = {
     // document is not used because the refactoring actions use the current editor
@@ -24,13 +24,6 @@ abstract class ProposalRefactoringActionAdapter(
     action.run(null)
   }
   
-  override def getRelevance = relevance
-  override def getDisplayString(): String = displayString
-  override def getSelection(document: IDocument): Point = null
-  override def getAdditionalProposalInfo(): String = null
-  override def getImage(): Image = null
-  override def getContextInformation: IContextInformation = null
-
   def isValidProposal : Boolean = {
     val ra = action match {
       case refactoringAction: RefactoringAction => refactoringAction

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/AbstractNewElementWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/AbstractNewElementWizard.scala
@@ -11,8 +11,6 @@ import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.internal.ui.wizards.NewElementWizard
 
-import org.eclipse.jface.viewers.IStructuredSelection
-
 abstract class AbstractNewElementWizard(protected val wizardPage: AbstractNewElementWizardPage)
   extends NewElementWizard {
 	

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/core.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/core.scala
@@ -93,8 +93,10 @@ trait MuteLowerCaseTypeNameWarning extends AbstractNewElementWizardPage {
   }
 }
 
-class NewClassWizard
-  extends AbstractNewElementWizard(new NewClassWizardPage())
+class NewClassWizard(page: NewClassWizardPage)
+  extends AbstractNewElementWizard(page) {
+  def this() = this(new NewClassWizardPage())
+}
 
 class NewTraitWizard
   extends AbstractNewElementWizard(new NewTraitWizardPage())


### PR DESCRIPTION
This quick fix is available for any error that would have caused us to attempt an import completion quick fix.

Get rid of some duplication in the current quick fixes which define a set of 6 methods (getRelevance, getDisplayString, etc) with the trait BasicCompletionProposal.

I have also added an option to the AbstractNewElementWizardPage to put the created file in a folder that differs from the package, which is allowed in scala but not in java. The main motivation for this is so that using the new class quick fix will put the created class in the same directory as the class you were attempting to use the missing class from. This only applies when your code is in a folder that doesn't match the package, otherwise we default to the java convention of using a folder path that matches the package name.
It would be a little bit nicer to have the folder displayed as "com/some/thing" rather than "com.some.thing", but it turns out to be a lot of work: you would have to create a new CompletionProcessor to replace JavaPackageCompletionProcessor, make the UI for it to replace what comes with NewTypeWizard.choosePackage, set up the key binding so that autocompletion kicks in on '/' rather than '.', and the easy part of replacing '/' (or File.separatorChar) with '.' and coercing it in to an IPackageFragment when we need it.

Fixed source formatting of QuickFixesTests, and moved the actual test to a separate file. With the exception of renaming withQuickFixes to withManyQuickFixesPerLine, none of that code was changed, only the formatting.

Fix #1000809, Re #1000898
