### PR TITLE
Restore compatibility with IDE plugins.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ScalaSyntaxClass.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ScalaSyntaxClass.scala
@@ -92,3 +92,12 @@ case class ScalaSyntaxClass(displayName: String, baseName: String, canBeDisabled
   }
 
 }
+
+object ScalaSyntaxClass {
+  def unapply(a: AnyRef): Option[(String, String, Boolean)] = a match {
+    case syntaxClass: ScalaSyntaxClass =>
+      Some((syntaxClass.displayName, syntaxClass.baseName, syntaxClass.canBeDisabled))
+    case _ =>
+      None
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/SyntaxColouringTreeContentAndLabelProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/SyntaxColouringTreeContentAndLabelProvider.scala
@@ -21,6 +21,6 @@ object SyntaxColouringTreeContentAndLabelProvider extends LabelProvider with ITr
 
   override def getText(element: AnyRef) = element match {
     case Category(name, _) => name
-    case ScalaSyntaxClass(displayName, _, _, _) => displayName
+    case ScalaSyntaxClass(displayName, _, _) => displayName
   }
 }


### PR DESCRIPTION
The new field in `ScalaSyntaxClass` broke source and binary compatibility with
both play2 and worksheet. This breaks my flow, as I want to be using the latest
master builds while working on play2.
