### PR TITLE
Only consider opened projects when computing a project's direct dependen...

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -202,9 +202,9 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
     }
 
   
-  /** The direct dependencies of this project. It only returns existing projects. */
+  /** The direct dependencies of this project. It only returns opened projects. */
   def directDependencies: Seq[IProject] = 
-    underlying.getReferencedProjects.filter(_.exists)
+    underlying.getReferencedProjects.filter(_.isOpen)
 
   /** All direct and indirect dependencies of this project.
    * 


### PR DESCRIPTION
When computing a project's direct dependencies, filter out non opened
projects (if a project is open it implies it exists, which is why there is no
need to check for `project.exists`).

Fix #1001714
