### PR TITLE
Removes non-plugin reference to junit

### DIFF
--- a/org.scala-ide.sdt.core.tests/.classpath
+++ b/org.scala-ide.sdt.core.tests/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="target/lib/mockito-all-1.9.5.jar"/>

--- a/org.scala-ide.sdt.core.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.core.tests/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ClassPath: .,
  target/lib/mockito-all-1.9.5.jar
 Require-Bundle: org.scala-ide.scala.library,
- org.eclipse.equinox.weaving.aspectj
+ org.eclipse.equinox.weaving.aspectj,
+ org.junit4
 Export-Package: 
  scala.tools.eclipse.testsetup

--- a/org.scala-ide.sdt.core.tests/pom.xml
+++ b/org.scala-ide.sdt.core.tests/pom.xml
@@ -11,10 +11,6 @@
   
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
     </dependency>

--- a/org.scala-ide.sdt.core/.classpath
+++ b/org.scala-ide.sdt.core/.classpath
@@ -4,7 +4,6 @@
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="target/lib/log4j-1.2.17.jar"/>

--- a/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
@@ -44,7 +44,6 @@ Require-Bundle:
  org.scala-refactoring.library,
  org.scala-ide.sbt.full.library;bundle-version="[0.13,0.14)",
  scalariform,
- org.junit4;bundle-version="4.5.0",
  org.eclipse.ui.browser;bundle-version="3.3.0"
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,

--- a/org.scala-ide.sdt.debug.tests/.classpath
+++ b/org.scala-ide.sdt.debug.tests/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="target/lib/mockito-all-1.9.5.jar"/>

--- a/org.scala-ide.sdt.debug.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.debug.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Fragment-Host: org.scala-ide.sdt.debug
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.scala-ide.scala.library,
  org.eclipse.equinox.weaving.aspectj,
- org.scala-ide.sdt.core
+ org.scala-ide.sdt.core,
+ org.junit4
 Import-Package: scala.tools.eclipse.testsetup
 Bundle-ClassPath: .,
  target/lib/mockito-all-1.9.5.jar

--- a/org.scala-ide.sdt.debug.tests/pom.xml
+++ b/org.scala-ide.sdt.debug.tests/pom.xml
@@ -33,10 +33,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <ivy.version>2.2.0</ivy.version>
     <miglayout.version>3.7.4</miglayout.version>
     <log4j.version>1.2.17</log4j.version>
-    <junit.version>4.10</junit.version>
     <mockito.version>1.9.5</mockito.version>
 
     <!-- plugin versions -->
@@ -346,11 +345,6 @@
         <version>${log4j.version}</version>
       </dependency>
       <!-- test support -->
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>


### PR DESCRIPTION
It is provided as a bundle in the test plugins, it doesn't need to be added anywhere else.

review @huitseeker.
