### PR TITLE
Remove "private" compiler options from the settings dialog.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
@@ -24,10 +24,6 @@ object IDESettings {
              Xexperimental, future, XlogImplicits,
              noassertions, nouescape, plugin, disable,
              require, pluginsDir, Xwarnfatal)),
-      Box("Private",
-        List(Ynogenericsig, noimports,
-             selfInAnnots, Yrecursion, refinementMethodDispatch,
-             Ywarndeadcode)),
       Box("Presentation Compiler",
         List(YpresentationDebug, YpresentationVerbose, YpresentationLog, YpresentationReplay, YpresentationDelay)))
   }


### PR DESCRIPTION
I don't think anyone ever used these settings from the IDE,
and they can be accessed using the "additional params" edit
(with completion and validation). Moreover, we had an arbitrary
subset of the tens of `-Y` parameters.

These parameters are subject to change, and the 2.11 build
fails because one of them was removed. This fixes the nightly
build for 2.11, in the wake of 2.11.0-M3.
