### PR TITLE
Scala IDE now builds again against Scala 2.11.0-SNAPSHOT

### DIFF
--- a/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/src/A.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/src/A.scala
@@ -1,4 +1,4 @@
 object A {
   val b = new B()
-  b.a
+  println(b.a)
 }


### PR DESCRIPTION
With the previous test code, one additional warning was reported
(something like _expression in statement position_). The fix was
to wrap the expression in a `println`.

Failure was introduced in commit SHA: 56e4328e736e5f3aa2e424f741cf80e92e3d1d2b
