### PR TITLE
[backport 3.0.x-juno] Deprecation warnings no longer accumulate

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/TestsSuite.java
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/TestsSuite.java
@@ -18,6 +18,7 @@ import scala.tools.eclipse.lexical.ScalaDocumentPartitionerTest;
 import scala.tools.eclipse.occurrences.OccurrencesFinderTest;
 import scala.tools.eclipse.pc.PresentationCompilerRefreshTest;
 import scala.tools.eclipse.pc.PresentationCompilerTest;
+import scala.tools.eclipse.sbtbuilder.DeprecationWarningsTests;
 import scala.tools.eclipse.sbtbuilder.MultipleErrorsTest;
 import scala.tools.eclipse.sbtbuilder.NestedProjectsTest;
 import scala.tools.eclipse.sbtbuilder.OutputFoldersTest;
@@ -65,6 +66,7 @@ import scala.tools.eclipse.wizards.QualifiedNameSupportTest;
   OutputFoldersTest.class,
   ProjectDependenciesTest.class,
   SbtBuilderTest.class,
+  DeprecationWarningsTests.class,
   ScalaCompilerClasspathTest.class,
   ScalaJavaDepTest.class, 
   TodoBuilderTest.class,

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/sbtbuilder/DeprecationWarningsTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/sbtbuilder/DeprecationWarningsTests.scala
@@ -1,0 +1,57 @@
+package scala.tools.eclipse.sbtbuilder
+
+import scala.tools.eclipse.SettingConverterUtil
+import scala.tools.eclipse.properties.PropertyStore
+import scala.tools.eclipse.testsetup.SDTTestUtils
+import scala.tools.eclipse.testsetup.TestProjectSetup
+import scala.tools.eclipse.util.FileUtils
+
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IMarker
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.ICompilationUnit
+import org.junit.Assert
+import org.junit.Test
+
+object deprecationWarningsProject extends TestProjectSetup("builder-deprecation-warnings") {
+  // enable deprecation warnings for this project 
+  val storage = deprecationWarningsProject.project.projectSpecificStorage.asInstanceOf[PropertyStore]
+  storage.setValue(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE, true)
+  storage.setValue("deprecation", "true")
+  storage.save()
+}
+
+class DeprecationWarningsTests {
+  private type Warnings = Seq[String]
+
+  @Test def deprecationWarningsDoNotAccumulate_1001595 {
+    val expectedDeprecationWarnings = Seq("method a in class B is deprecated")
+
+    val unitA = deprecationWarningsProject.compilationUnit("A.scala")
+    val warningsAfterFullClean = doBuild(IncrementalProjectBuilder.FULL_BUILD) andGetProblemsOf unitA
+    Assert.assertEquals(expectedDeprecationWarnings, warningsAfterFullClean)
+
+    // let's modify the compilation unit B, which is referenced by A
+    val unitB = deprecationWarningsProject.compilationUnit("B.scala")
+    val newContentB = """
+      |class B {
+      |  @deprecated
+      |  var a = 2
+      |  
+      |  var c = 2
+      |}
+      """.stripMargin
+    SDTTestUtils.changeContentOfFile(unitB.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], newContentB)
+
+    val warningsAfterIncrementalBuild = doBuild(IncrementalProjectBuilder.INCREMENTAL_BUILD) andGetProblemsOf unitA
+    Assert.assertEquals(expectedDeprecationWarnings, warningsAfterIncrementalBuild)
+  }
+
+  private def doBuild(buildFlag: Int) = new {
+    def andGetProblemsOf(unit: ICompilationUnit): Warnings = {
+      deprecationWarningsProject.project.underlying.build(buildFlag, new NullProgressMonitor)
+      FileUtils.findBuildErrors(unit.getResource()).map(_.getAttribute(IMarker.MESSAGE).toString)
+    }
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>builder-deprecation-warnings</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/src/A.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/src/A.scala
@@ -1,0 +1,4 @@
+object A {
+  val b = new B()
+  println(b.a)
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/src/B.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/builder-deprecation-warnings/src/B.scala
@@ -1,0 +1,4 @@
+class B {
+  @deprecated
+  var a = 2
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
@@ -44,12 +44,16 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
     private var savedTotal = 0
     private var throttledMessages = 0
   
-    // Direct copy of the mechanism in the refined build managers
-    def startUnit(phaseName: String, unitPath: String) {
+    override def startUnit(phaseName: String, unitPath: String) {
+      def unitIPath: IPath = Path.fromOSString(unitPath)
+
+      // dirty-hack for ticket #1001595 until Sbt provides a better API for tracking sources recompiled by the incremental compiler
+      if(phaseName == "parser") FileUtils.toIFile(unitIPath).foreach(clearMarkers)
+
+      // What follows is a direct copy of the mechanism in the refined build managers
       throttledMessages += 1
       if (throttledMessages == 10) {
         throttledMessages = 0
-        val unitIPath: IPath = Path.fromOSString(unitPath)
         val projectPath = project.javaProject.getProject.getLocation
         monitor.subTask("phase " + phaseName + " for " + unitIPath.makeRelativeTo(projectPath))
       }
@@ -184,15 +188,16 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
     if (!hasErrors)
       pendingSources.clear
   }
-  
+
   override def buildingFiles(included: scala.collection.Set[AbstractFile]) {
-    for(file <- included) {
-      file match {
-        case EclipseResource(f : IFile) =>
-          FileUtils.clearBuildErrors(f, null)
-          FileUtils.clearTasks(f, null)
-        case _ =>
-      }
+    included foreach {
+      case EclipseResource(f : IFile) => clearMarkers(f)
+      case _ =>
     }
+  }
+
+  private def clearMarkers(f: IFile): Unit = {
+    FileUtils.clearBuildErrors(f, null)
+    FileUtils.clearTasks(f, null)
   }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/FileUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/FileUtils.scala
@@ -8,7 +8,6 @@ package scala.tools.eclipse.util
 import scala.tools.eclipse.ScalaPlugin.plugin
 import scala.tools.eclipse.util.EclipseUtils.workspaceRunnableIn
 import scala.tools.nsc.io.AbstractFile
-
 import org.eclipse.core.filebuffers.FileBuffers
 import org.eclipse.core.internal.resources.ResourceException
 import org.eclipse.core.resources.IFile
@@ -21,6 +20,7 @@ import org.eclipse.jdt.core.IJavaModelMarker
 import org.eclipse.jdt.core.JavaCore
 import org.eclipse.jdt.core.compiler.IProblem
 import org.eclipse.jdt.internal.core.builder.JavaBuilder
+import org.eclipse.core.runtime.IPath
 
 object FileUtils {
   
@@ -28,14 +28,15 @@ object FileUtils {
     case null => None
     case EclipseResource(file: IFile) => Some(file)
     case abstractFile =>
-      
-      val file = ResourcesPlugin.getWorkspace.getRoot.getFileForLocation(Path.fromOSString(abstractFile.path))
-      
-      if (file == null || !file.exists) {
-        None
-      } else {
-        Some(file)
-      }
+      val path = Path.fromOSString(abstractFile.path)
+      toIFile(path)
+  }
+  
+  def toIFile(path: IPath): Option[IFile] = {
+    val file = ResourcesPlugin.getWorkspace.getRoot.getFileForLocation(path)
+
+    if (file == null || !file.exists) None
+    else Some(file)
   }
 
   


### PR DESCRIPTION
The reason why that used to happen is that the Eclipse markers attached to the
dependent sources recompiled by Sbt were not removed, and hence the deprecation
warnings (or any other kind of problem marker) were being accumulated after
each incremental build.

The fix consists in deleting all problem's marker attached to a unit when the
unit is about to be parsed. This should really be seen as a workaround until
Sbt provides a better interface for incremental compilation. In fact, ideally
Sbt should provide a notification mechanism to know what is the set of
compilation units that are about to be recompiled, **before** the actual
recompilation step is performed.  Unfortunately, that is not possible at the
moment, hence we are left with the current hack.

Huge thanks to @gkossakowski for suggesting this very effective workaround.

Fixed #1001595

(cherry picked from commit 56e4328e736e5f3aa2e424f741cf80e92e3d1d2b)
(squashed commit 1112d0aefbf01bef9d93db0518aae67bedc5a39d)

Conflicts:

```
    org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
```

(cherry picked from commit 631f3168c0880b3c184951f8e8f095319eacebd5)
