### PR TITLE
Don't consider `$` as part of Scala identifiers.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkDetectorTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkDetectorTests.scala
@@ -27,7 +27,8 @@ class HyperlinkDetectorTests {
       Link("type scala.Predef.String"),
       Link("object scala.Some"),
       Link("class scala.Option"),
-      Link("type scala.Predef.String"))
+      Link("type scala.Predef.String"),
+      Link("value hyperlinks.SimpleHyperlinking.arr"))
 
     loadTestUnit("hyperlinks/SimpleHyperlinking.scala").andCheckAgainst(oracle)
   }

--- a/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/hyperlinks/SimpleHyperlinking.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/hyperlinks/SimpleHyperlinking.scala
@@ -13,5 +13,6 @@ class SimpleHyperlinking {
     val x: String/*^*/ = "Hello, world"
     val Some/*^*/(x): Option/*^*/[Int] = Some(10)
     classOf[String/*^*/]
+    val str = s"Hello, $arr/*^*/"
   }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
@@ -32,7 +32,17 @@ object ScalaWordFinder extends IScalaWordFinder {
 
   def findWord(buffer : IBuffer, offset : Int) : IRegion =
     findWord(bufferToSeq(buffer), offset)
-    
+
+  /**
+   * Find the word enclosing the given `offset`. `$` is not considered part of
+   * an identifier, even though the Scala Specification allows it. We choose this
+   * tradeoff so the word finder does the right thing in interpolated strings, where
+   * `$` is used as a delimiter:
+   *
+   * {{{ s"Hello, $name" }}}
+   *
+   * Here, the identifier is only `name`.
+   */
   def findWord(document : Seq[Char], offset : Int) : IRegion = {
 
     def find(p : Char => Boolean) : IRegion = {
@@ -69,7 +79,7 @@ object ScalaWordFinder extends IScalaWordFinder {
         null
     }
     
-    val idRegion = find(isIdentifierPart)
+    val idRegion = find(ch => isIdentifierPart(ch) && ch != '$')
     if (idRegion == null || idRegion.getLength == 0)
       find(isOperatorPart)
     else


### PR DESCRIPTION
'$' are implementation specific, but can appear in legitimate programs as escape
sequences in interpolated strings. Hyperlinking should only consider the identifier
without '$' signs. 

Fixed #1001408

(should be backported)
