### PR TITLE
Synchronize access to `Names` in the presentation compiler.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -33,8 +33,17 @@ import scala.tools.nsc.io.VirtualFile
 import scala.tools.nsc.interactive.MissingResponse
 
 
-class ScalaPresentationCompiler(project: ScalaProject, settings: Settings)
-  extends Global(settings, new ScalaPresentationCompiler.PresentationReporter, project.underlying.getName)
+class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) extends {
+  /**
+   * Lock object for protecting compiler names. Names are cached in a global `Array[Char]`
+   * and concurrent access may lead to overwritten names.
+   *
+   * @note This field is EARLY because `newTermName` is hit during construction of the superclass `Global`,
+   *       and the lock object has to be constructed already.
+   */
+  private val nameLock = new Object
+
+} with Global(settings, new ScalaPresentationCompiler.PresentationReporter, project.underlying.getName)
   with ScalaStructureBuilder
   with ScalaIndexBuilder
   with ScalaMatchLocator
@@ -216,6 +225,14 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings)
         sourceFiles.remove(scu)
       }
     }
+  }
+
+  override def newTermName(str: String) = {
+    nameLock synchronized { super.newTermName(str) }
+  }
+
+  override def newTypeName(str: String) = {
+    nameLock synchronized { super.newTypeName(str) }
   }
 
   def withResponse[A](op: Response[A] => Any): Response[A] = {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
@@ -38,9 +38,9 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
   }
 
   // We cache these names since they are used for each ValDef during structure building
-  val GET = newTermName("get")
-  val IS  = newTermName("is")
-  val SET = newTermName("set")
+  private lazy val GET = nme.get //newTermName("get")
+  private lazy val IS  = newTermName("is")
+  private lazy val SET = newTermName("set")
 
   class StructureBuilderTraverser(scu : ScalaCompilationUnit, unitInfo : OpenableElementInfo, newElements0 : JMap[AnyRef, AnyRef], sourceLength : Int) {
 


### PR DESCRIPTION
This may lead to subtle errors, like the mysterious
assertion error in pickler.

Refs #1001607, #1001606

Should be backported.
