### PR TITLE
Issue/structure builder throws exception 1001707

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
@@ -61,11 +61,15 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
       }
     }
 
-    /**
-     * Returns a type name for an untyped tree which the JDT should be able to consume,
-     * in particular org.eclipse.jdt.internal.compiler.parser.TypeConverter
+    /** If the `tree` is defined, returns its type's full name. Otherwise, returns an untyped tree which
+     *  the JDT should be able to consume (in particular org.eclipse.jdt.internal.compiler.parser.TypeConverter).
      */
-    def unresolvedType: String = "null-Type"
+    def typeNameOf(tree: Option[Tree]): String = {
+      def unresolvedType: String = "null-Type"
+
+      val tpe = tree.flatMap(t => Option(t.tpe))
+      tpe.map(_.typeSymbol.fullName) getOrElse unresolvedType
+    }
 
     trait Owner {self =>
       def parent : Owner
@@ -387,7 +391,6 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
         sym.initialize
 
         val name = c.name.toString
-        val parentTree = c.impl.parents.head
         val isAnon = sym.isAnonymousClass
         val superClass = sym.superClass
         val superName = mapType(superClass)
@@ -444,8 +447,11 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
           val start0 = c.pos.point
           (start0, start0 + name.length - 1)
         } else {
-          val start0 = parentTree.pos.point
-          (start0, start0-1)
+          val parentTree = c.impl.parents.headOption
+          parentTree map { tree =>
+              val start0 = tree.pos.point
+              (start0, start0-1)
+          } getOrElse (-1,-1) // undefined
         }
 
         classElemInfo.setNameSourceStart0(start)
@@ -504,17 +510,12 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
         }
         newElements0.put(moduleElem, moduleElemInfo)
 
-        val parentTree = m.impl.parents.head
-        val superclassType = parentTree.tpe
-        val superclassName = (if (superclassType ne null) superclassType.typeSymbol.fullName
-          else unresolvedType).toCharArray
-        moduleElemInfo.setSuperclassName(superclassName)
+        val parentTree = m.impl.parents.headOption
+        val superclassName = typeNameOf(parentTree)
+        moduleElemInfo.setSuperclassName(superclassName.toCharArray)
 
         val interfaceTrees = m.impl.parents.drop(1)
-        val interfaceNames = interfaceTrees.map { t =>
-          val tpe = t.tpe
-          (if (tpe ne null) tpe.typeSymbol.fullName else unresolvedType).toCharArray
-        }
+        val interfaceNames = interfaceTrees.map { t => typeNameOf(Option(t)).toCharArray }
         moduleElemInfo.setSuperInterfaceNames(interfaceNames.toArray)
 
         fillOverrideInfos(sym)


### PR DESCRIPTION
Calling `List.head` is in general a bad idea, so that alone should be good
motivation for not doing it. Furthermore, as ticket #1001707 demonstrates, the
call to `head` can throw an exception in the `ScalaStructureBuilder`.

The most likely reason why that could happen is because the source contains
type errors, and hence not all expected information are available in some of
the inspected symbols. For instance, a class is expected to always have at
least one superclass, however if there are type errors it is possible for a
class symbol to have no superclasses, and hence accessing the `head` of an
empty `List` could result in a `NoSuchElementException` being thrown.

This fix comes with no tests because the ticket doesn't provide a reproducible
test case.

Fix #1001707

backport to _release/3.0.x_
