### PR TITLE
Correctly resolve overloaded Java methods in hyperlinking

### DIFF
--- a/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks-sub/src/util/JavaMethods.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks-sub/src/util/JavaMethods.java
@@ -1,0 +1,29 @@
+package util;
+
+public class JavaMethods<T> {
+  public static Object nArray(double [] d)
+  {
+    return null;
+  }
+  
+  public static Object nArray(int[] iA)
+  {
+    return null;
+  }
+
+  public static Object nArray(String[] iS)
+  {
+    return null;
+  }
+  
+  public Object typeparam(T iS)
+  {
+    return null;
+  }
+  
+  public Object typeparam2(T[] iS)
+  {
+    return null;
+  }
+}
+

--- a/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/javalinks/JavaLinks.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/javalinks/JavaLinks.scala
@@ -1,0 +1,15 @@
+package javalinks
+
+import util.JavaMethods
+
+class JavaLinks {
+  def foo {
+    val x = JavaMethods.nArray/*^*/(Array("2", "3"))
+    val y = JavaMethods.nArray/*^*/(Array(2, 3))
+    val over = new JavaMethods[Integer]
+
+    over.typeparam/*^*/(10)
+    over.typeparam2/*^*/(Array(10, 11, 12))
+  }
+
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -219,19 +219,6 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with SymbolNameUtil with Has
     }
   }
 
-  def mapParamTypeName(t : Type) : String = {
-    if (t.typeSymbolDirect.isTypeParameter)
-      t.typeSymbolDirect.name.toString
-    else if (isScalaSpecialType(t))
-      "java.lang.Object"
-    else {
-      if (definitions.isPrimitiveValueType(t))
-        t.toString
-      else
-        mapTypeName(t.typeSymbol)
-    }
-  }
-
   def mapParamTypeSignature(t : Type) : String = {
     val objectSig = "Ljava.lang.Object;"
     if (t.typeSymbolDirect.isTypeParameter)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSelectionEngine.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSelectionEngine.scala
@@ -107,7 +107,7 @@ class ScalaSelectionEngine(nameEnvironment: SearchableEnvironment, requestor: Sc
         val packageName = enclosingPackage(m0).toArray
         val typeName = mapTypeName(owner).toArray
         val parameterPackageNames = paramTypes.map(mapParamTypePackageName(_).toArray).toArray
-        val parameterTypeNames = paramTypes.map(mapParamTypeName(_).toArray).toArray
+        val parameterTypeNames = paramTypes.map(mapType(_).toArray).toArray
         val parameterSignatures = paramTypes.map(mapParamTypeSignature(_)).toArray
         Cont(requestor.acceptMethod(
           packageName,


### PR DESCRIPTION
The Scala selection engine didn't build the correct signature
for Java methods taking array parameters. It turns out that
the special-handling `mapParamType` wasn't needed, and the
existing `mapType` method in `ScalaJavaMapper` was already
working correctly.

The test is @Ignored because of [SI-7548](https://issues.scala-lang.org/browse/SI-7548).

Fixed #1000421
