### PR TITLE
[backport] Implemented `skipAllBreakpoints` for the Scala Debugger

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugComputeDetailTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugComputeDetailTest.scala
@@ -45,7 +45,7 @@ class ScalaDebugComputeDetailTest {
    */
   @Test
   def computeDetailObject() {
-    session = new ScalaDebugTestSession(file("Variables.launch"))
+    session = ScalaDebugTestSession(file("Variables.launch"))
 
     session.runToLine(TYPENAME_VARIABLES + "$", 30)
     
@@ -61,7 +61,7 @@ class ScalaDebugComputeDetailTest {
    */
   @Test
   def computeDetailArrayOfMixedElements() {
-    session = new ScalaDebugTestSession(file("Variables.launch"))
+    session = ScalaDebugTestSession(file("Variables.launch"))
 
     session.runToLine(TYPENAME_VARIABLES + "$", 30)
     
@@ -77,7 +77,7 @@ class ScalaDebugComputeDetailTest {
    */
   @Test
   def computeDetailNullReference() {
-    session = new ScalaDebugTestSession(file("Variables.launch"))
+    session = ScalaDebugTestSession(file("Variables.launch"))
 
     session.runToLine(TYPENAME_VARIABLES + "$", 30)
     
@@ -93,7 +93,7 @@ class ScalaDebugComputeDetailTest {
    */
   @Test
   def checkVersionAvailable() {
-    session = new ScalaDebugTestSession(file("HelloWorld.launch"))
+    session = ScalaDebugTestSession(file("HelloWorld.launch"))
 
     session.runToLine(TYPENAME_HELLOWORLD + "$", 7)
     
@@ -105,7 +105,7 @@ class ScalaDebugComputeDetailTest {
    */
   @Test
   def logicalStructureStringList() {
-    session = new ScalaDebugTestSession(file("Variables.launch"))
+    session = ScalaDebugTestSession(file("Variables.launch"))
 
     session.runToLine(TYPENAME_VARIABLES + "$", 30)
     

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugResumeTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugResumeTest.scala
@@ -41,7 +41,7 @@ class ScalaDebugResumeTest {
   @Test
   def resumeToBreakpoindAndToCompletion() {
 
-    session = new ScalaDebugTestSession(file("ForComprehensionListString.launch"))
+    session = ScalaDebugTestSession(file("ForComprehensionListString.launch"))
 
     session.runToLine(TYPENAME_FC_LS + "$", 9)
 

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugSteppingTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugSteppingTest.scala
@@ -18,7 +18,7 @@ object ScalaDebugSteppingTest extends TestProjectSetup("debug", bundleName = "or
 
   var initialized = false
 
-  def initDebugSession(launchConfigurationName: String): ScalaDebugTestSession = new ScalaDebugTestSession(file(launchConfigurationName + ".launch"))
+  def initDebugSession(launchConfigurationName: String): ScalaDebugTestSession = ScalaDebugTestSession(file(launchConfigurationName + ".launch"))
 
   @AfterClass
   def deleteProject() {

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
@@ -17,6 +17,8 @@ import org.eclipse.debug.core.ILaunchConfiguration
 import scala.tools.eclipse.debug.breakpoints.BreakpointSupport
 import scala.tools.eclipse.debug.model.ScalaValue
 import org.eclipse.jface.viewers.StructuredSelection
+import org.eclipse.jdt.debug.core.IJavaBreakpoint
+import org.junit.Assert
 
 object EclipseDebugEvent {
   def unapply(event: DebugEvent): Option[(Int, AnyRef)] = Some((event.getKind, event.getSource()))
@@ -35,12 +37,18 @@ object ScalaDebugTestSession {
     DebugPlugin.getDefault.addDebugEventListener(debugEventListener)
     debugEventListener
   }
+
+  def apply(launchConfiguration: ILaunchConfiguration): ScalaDebugTestSession = {
+    val session = new ScalaDebugTestSession(launchConfiguration)
+    session.skipAllBreakpoints(false)
+    session
+  }
+
+  def apply(launchConfigurationFile: IFile): ScalaDebugTestSession =
+    apply(DebugPlugin.getDefault.getLaunchManager.getLaunchConfiguration(launchConfigurationFile))
 }
 
-class ScalaDebugTestSession(launchConfiguration: ILaunchConfiguration) extends HasLogger {
-
-  def this(launchConfigurationFile: IFile) = this(DebugPlugin.getDefault.getLaunchManager.getLaunchConfiguration(launchConfigurationFile))
-
+class ScalaDebugTestSession private(launchConfiguration: ILaunchConfiguration) extends HasLogger {
   object State extends Enumeration {
     type State = Value
     val ACTION_REQUESTED, NOT_LAUNCHED, RUNNING, SUSPENDED, TERMINATED = Value
@@ -256,7 +264,13 @@ class ScalaDebugTestSession(launchConfiguration: ILaunchConfiguration) extends H
     if (state ne NOT_LAUNCHED) {
       debugTarget.breakpointManager.waitForAllCurrentEvents()
       waitUntil(15000) {
-        breakpoint.getMarker().getAttribute(BreakpointSupport.ATTR_VM_REQUESTS_ENABLED, !enabled) == enabled
+        debugTarget.breakpointManager.getBreakpointRequestState(breakpoint) match {
+          case Some(state) =>
+            state == enabled
+          case _ =>
+            Assert.fail("No BreakpointSupportActor exist for the passed breakpoint")
+            false
+        }
       }
     }
   }
@@ -299,4 +313,6 @@ class ScalaDebugTestSession(launchConfiguration: ILaunchConfiguration) extends H
     currentStackFrame.getVariables.find(_.getName == name).get.getValue.asInstanceOf[ScalaValue]
   }
 
+  def skipAllBreakpoints(enabled: Boolean): Unit =
+    DebugPlugin.getDefault().getBreakpointManager().setEnabled(!enabled)
 }

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebuggerDisconnectTests.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebuggerDisconnectTests.scala
@@ -18,7 +18,7 @@ object ScalaDebuggerDisconnectTests extends TestProjectSetup("debug", bundleName
 
   var initialized = false
 
-  def initDebugSession(launchConfigurationName: String): ScalaDebugTestSession = new ScalaDebugTestSession(file(launchConfigurationName + ".launch"))
+  def initDebugSession(launchConfigurationName: String): ScalaDebugTestSession = ScalaDebugTestSession(file(launchConfigurationName + ".launch"))
 
   @AfterClass
   def deleteProject() {

--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/launching/RemoteConnectorTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/launching/RemoteConnectorTest.scala
@@ -56,7 +56,7 @@ object RemoteConnectorTest extends TestProjectSetup("debug", bundleName = "org.s
     vmArgs.put(SocketConnectorScala.PortKey, port.toString)
     workingLaunchConfiguration.setAttribute(VmArgsKey, vmArgs)
 
-    new ScalaDebugTestSession(workingLaunchConfiguration)
+    ScalaDebugTestSession(workingLaunchConfiguration)
   }
 
   /**

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/BreakpointSupport.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/BreakpointSupport.scala
@@ -23,15 +23,11 @@ import com.sun.jdi.VMDisconnectedException
 import com.sun.jdi.request.InvalidRequestStateException
 import scala.tools.eclipse.debug.BaseDebuggerActor
 import scala.tools.eclipse.debug.model.ScalaDebugCache
+import org.eclipse.debug.core.DebugPlugin
 
 private[debug] object BreakpointSupport {
   /** Attribute Type Name */
   final val ATTR_TYPE_NAME = "org.eclipse.jdt.debug.core.typeName"
-
-  /** A boolean marker attribute that indicates whether the JDI requests
-   *  corresponding to this breakpoint are enabled or disabled.
-   */
-  final val ATTR_VM_REQUESTS_ENABLED = "org.scala-ide.sdt.debug.breakpoint.vm_enabled"
 
   /** Create the breakpoint support actor.
    *  
@@ -50,14 +46,12 @@ private object BreakpointSupportActor {
 
   def apply(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget): Actor = {
     val typeName= breakpoint.typeName
-    
-    val breakpointRequests   = createBreakpointsRequests(breakpoint, typeName, debugTarget)
+
+    val breakpointRequests = createBreakpointsRequests(breakpoint, typeName, debugTarget)
 
     val actor = new BreakpointSupportActor(breakpoint, debugTarget, typeName, ListBuffer(breakpointRequests: _*))
 
     debugTarget.cache.addClassPrepareEventListener(actor, typeName)
-    initializeVMRequests(breakpoint, debugTarget, actor, breakpointRequests, enabled = breakpoint.isEnabled())
-    breakpoint.setVmRequestEnabled(breakpoint.isEnabled())
 
     actor.start()
     actor
@@ -78,16 +72,6 @@ private object BreakpointSupportActor {
   private def createBreakpointRequest(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget, referenceType: ReferenceType): Option[BreakpointRequest] = {
     JdiRequestFactory.createBreakpointRequest(referenceType, breakpoint.lineNumber, debugTarget)
   }
-
-  /** Register the actor for each event request, and enable/disbale the request according to the argument.  */
-  private def initializeVMRequests(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget, actor: Actor, eventRequests: Seq[EventRequest], enabled: Boolean): Unit = {
-    val eventDispatcher = debugTarget.eventDispatcher
-    // enable the requests
-    eventRequests.foreach { eventRequest =>
-      eventDispatcher.setActorFor(actor, eventRequest)
-      eventRequest.setEnabled(enabled)
-    }
-  }
 }
 
 /**
@@ -102,6 +86,28 @@ private class BreakpointSupportActor private (
     typeName: String,
     breakpointRequests: ListBuffer[EventRequest]) extends BaseDebuggerActor {
   import BreakpointSupportActor.{ Changed, createBreakpointRequest }
+
+  /** Return true if the state of the `breakpointRequests` associated to this breakpoint is (or, if not yet loaded, will be) enabled in the VM. */
+  private var requestsEnabled = false
+
+  private val eventDispatcher = debugTarget.eventDispatcher
+
+  override def postStart(): Unit =  {
+    breakpointRequests.foreach(listenForBreakpointRequest)
+    updateBreakpointRequestState(isEnabled)
+  }
+
+  /** Returns true if the `breakpoint` is enabled and its state should indeed be considered. */
+  private def isEnabled: Boolean = breakpoint.isEnabled() && DebugPlugin.getDefault().getBreakpointManager().isEnabled()
+
+  /** Register `this` actor to receive all notifications from the `eventDispatcher` related to the passed `request`.*/
+  private def listenForBreakpointRequest(request: EventRequest): Unit =
+    eventDispatcher.setActorFor(this, request)
+
+  private def updateBreakpointRequestState(enabled: Boolean): Unit = {
+    breakpointRequests.foreach (_.setEnabled(enabled))
+    requestsEnabled = enabled
+  }
 
   // Manage the events
   override protected def behavior: PartialFunction[Any, Unit] = {
@@ -118,6 +124,8 @@ private class BreakpointSupportActor private (
       changed(delta)
     case ScalaDebugBreakpointManager.ActorDebug =>
       reply(None)
+    case ScalaDebugBreakpointManager.GetBreakpointRequestState(_) =>
+      reply(requestsEnabled)
   }
 
   /**
@@ -142,16 +150,7 @@ private class BreakpointSupportActor private (
    *        breakpoint is disabled.
    */
   private def changed(delta: IMarkerDelta) {
-    if (breakpoint.isEnabled()) {
-      if (!breakpoint.vmRequestEnabled){
-        breakpointRequests foreach { _.enable() }
-        logger.info("enabled " + breakpointRequests)
-      }
-    } else if (breakpoint.vmRequestEnabled) {
-      breakpointRequests foreach { _.disable() }
-      logger.info("disabled " + breakpointRequests)
-    }
-    breakpoint.setVmRequestEnabled(breakpoint.isEnabled())
+    if(isEnabled ^ requestsEnabled) updateBreakpointRequestState(isEnabled)
   }
 
   /** Create the line breakpoint for the newly loaded class.
@@ -161,8 +160,8 @@ private class BreakpointSupportActor private (
 
     breakpointRequest.foreach { br =>
       breakpointRequests append br
-      debugTarget.eventDispatcher.setActorFor(this, br)
-      br.setEnabled(breakpoint.isEnabled())
+      listenForBreakpointRequest(br)
+      br.setEnabled(requestsEnabled)
     }
   }
 

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/RichBreakpoint.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/RichBreakpoint.scala
@@ -14,18 +14,6 @@ class RichBreakpoint(bp: IBreakpoint) {
   def lineNumber: Int = {
     bp.getMarker.getAttribute(IMarker.LINE_NUMBER, -1)
   }
-
-  /** Return true if the VM request attribute of this breakpoint is enabled */
-  def vmRequestEnabled: Boolean =
-    bp.getMarker().getAttribute(BreakpointSupport.ATTR_VM_REQUESTS_ENABLED, false)
-
-  /** Set the value of the VM request attribute.
-   *
-   *  This method only sets the marker attribute. It does not have any effect on the
-   *  vm requests used by this breakpoint.
-   */
-  def setVmRequestEnabled(value: Boolean) =
-    bp.getMarker().setAttribute(BreakpointSupport.ATTR_VM_REQUESTS_ENABLED, value)
 }
 
 object RichBreakpoint {

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/ScalaDebugBreakpointManager.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/breakpoints/ScalaDebugBreakpointManager.scala
@@ -11,8 +11,14 @@ import scala.tools.eclipse.debug.BaseDebuggerActor
 import scala.tools.eclipse.debug.PoisonPill
 
 object ScalaDebugBreakpointManager {
-  /** A debug message used to wait until all required messages have been processed. */
-  object ActorDebug
+  /** A debug message used to wait until all required messages have been processed.
+   *  @note Use this for test purposes only!
+   */
+  case object ActorDebug
+  /** A debug message used to know if the event request associated to the passed `breakpoint` is enabled.
+   *  @note Use this for test purposes only!
+   */
+  case class GetBreakpointRequestState(breakpoint: IBreakpoint)
 
   def apply(debugTarget: ScalaDebugTarget): ScalaDebugBreakpointManager = {
     val companionActor = ScalaDebugBreakpointManagerActor(debugTarget)
@@ -58,14 +64,22 @@ class ScalaDebugBreakpointManager private (/*public field only for testing purpo
   }
   
   /**
-   * Test support method.
    * Wait for a dummy event to be processed, to indicate that all previous events
    * have been processed.
+   *
+   * @note Use this for test purposes only!
    */
   protected[debug] def waitForAllCurrentEvents() {
     companionActor !? ScalaDebugBreakpointManager.ActorDebug
   }
 
+  /** Check if the event request associated to the passed `breakpoint` is enabled/disabled.
+   *
+   *  @return None if the `breakpoint` isn't registered. Otherwise, the enabled state of the associated request is returned, wrapped in a `Some`.
+   *  @note Use this for test purposes only!
+   */
+  protected[debug] def getBreakpointRequestState(breakpoint: IBreakpoint): Option[Boolean] =
+    (companionActor !? ScalaDebugBreakpointManager.GetBreakpointRequestState(breakpoint)).asInstanceOf[Option[Boolean]]
 }
 
 private[debug] object ScalaDebugBreakpointManagerActor {
@@ -126,6 +140,13 @@ private class ScalaDebugBreakpointManagerActor private(debugTarget: ScalaDebugTa
       }
     case ScalaDebugBreakpointManager.ActorDebug =>
       reply(None)
+
+    case msg @ ScalaDebugBreakpointManager.GetBreakpointRequestState(breakpoint) =>
+      breakpoints.get(breakpoint) match {
+        case Some(breakpointSupport) =>
+          reply(Some(breakpointSupport !? msg))
+        case None => reply(None)
+      }
   }
 
   private def createBreakpointSupport(breakpoint: IBreakpoint): Unit = {


### PR DESCRIPTION
The Scala debugger now reacts consistently to `skipAllBreakpoints` requests,
which can be triggered by users from the Debugger UI.

The enabled state of a breakpoint does now depend not just on the breakpoint
state, but also on the `BreakpointManager` state, which can be queried to know
if breakpoints should be ignored during a running debug session.  When a user
hit the `skipAllBreakpoint` button in the UI, the `BreakpointManager`'s
isEnabled state  is set to false, entailing that any enabled breakpoint should
be ignored.

Prior to this commit, we used to store in the breakpoint's marker a flag to
know if the `eventRequests` associated to the breakpoint were (or will, if
lazily loaded) enabled. However, using the breakpoint's marker for keeping
track of this information isn't safe, because markers can be shared across
multiple debug sessions. Now, this information is stored in the
`BreakpointSupport` actor.

Unfortunately, the above change made testing more difficult, as we need a way
to inspect the the `BreakpointSupport`'s requests state. At the moment, the
simplest solution was to add a new message `GetBreakpointRequestState` which
can be used to retrieve this information in tests. Considering we plan to
move away from actor, the tradeoff seems reasonable.

Fix #1001437
(cherry picked from commit eb47006594199a1fc6a16497323946105ed84fde)
