### PR TITLE
Refactorings in ScalaSourceViewerConfiguration

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScaladocTokenScannerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScaladocTokenScannerTest.scala
@@ -75,12 +75,12 @@ class ScaladocTokenScannerTest {
     when(taskTagClass.getTextAttribute(scalaPreferenceStore)).thenReturn(taskTagAtt)
 
     val scanner = new ScaladocTokenScanner(
+        scalaPreferenceStore,
+        javaPreferenceStore,
         scaladocClass,
         annotationClass,
         macroClass,
-        taskTagClass,
-        scalaPreferenceStore,
-        javaPreferenceStore)
+        taskTagClass)
 
     val doc = {
       val rawInput = str.filterNot(_ == '^')

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
@@ -3,15 +3,34 @@
  */
 // $Id$
 
-package scala.tools.eclipse;
+package scala.tools.eclipse
 
-import org.eclipse.jface.text.formatter.MultiPassContentFormatter
-import org.eclipse.jface.util.PropertyChangeEvent
-import scala.tools.eclipse.semicolon.InferredSemicolonPainter
-import org.eclipse.jface.text.ITextViewerExtension2
-import org.eclipse.jdt.core.IJavaProject
-import org.eclipse.jdt.core.IJavaElement
+import scala.tools.eclipse.formatter.ScalaFormattingStrategy
+import scala.tools.eclipse.hyperlink.text.detector.CompositeHyperlinkDetector
+import scala.tools.eclipse.hyperlink.text.detector.DeclarationHyperlinkDetector
+import scala.tools.eclipse.hyperlink.text.detector.ImplicitHyperlinkDetector
+import scala.tools.eclipse.javaelements.ScalaCompilationUnit
+import scala.tools.eclipse.lexical.ScalaCodeScanner
+import scala.tools.eclipse.lexical.ScalaCommentScanner
+import scala.tools.eclipse.lexical.ScalaPartitions
+import scala.tools.eclipse.lexical.ScaladocTokenScanner
+import scala.tools.eclipse.lexical.SingleTokenScanner
+import scala.tools.eclipse.lexical.StringTokenScanner
+import scala.tools.eclipse.lexical.XmlCDATAScanner
+import scala.tools.eclipse.lexical.XmlCommentScanner
+import scala.tools.eclipse.lexical.XmlPIScanner
+import scala.tools.eclipse.lexical.XmlTagScanner
+import scala.tools.eclipse.ui.BracketAutoEditStrategy
+import scala.tools.eclipse.ui.CommentAutoIndentStrategy
+import scala.tools.eclipse.ui.JdtPreferenceProvider
+import scala.tools.eclipse.ui.LiteralAutoEditStrategy
+import scala.tools.eclipse.ui.MultiLineStringAutoEditStrategy
+import scala.tools.eclipse.ui.ScalaAutoIndentStrategy
+import scala.tools.eclipse.ui.StringAutoEditStrategy
+
 import org.eclipse.jdt.core.ICodeAssist
+import org.eclipse.jdt.core.IJavaElement
+import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.internal.ui.JavaPlugin
 import org.eclipse.jdt.internal.ui.javaeditor.IClassFileEditorInput
 import org.eclipse.jdt.internal.ui.javaeditor.ICompilationUnitDocumentProvider
@@ -19,64 +38,49 @@ import org.eclipse.jdt.internal.ui.javaeditor.JavaElementHyperlinkDetector
 import org.eclipse.jdt.internal.ui.text.ContentAssistPreference
 import org.eclipse.jdt.internal.ui.text.java.JavaAutoIndentStrategy
 import org.eclipse.jdt.internal.ui.text.java.SmartSemicolonAutoEditStrategy
-import org.eclipse.jdt.internal.ui.text.java.hover.AbstractJavaEditorTextHover
-import org.eclipse.jdt.internal.ui.text.java.hover.BestMatchHover
-import org.eclipse.jdt.internal.ui.text.javadoc.JavaDocAutoIndentStrategy
-import org.eclipse.jdt.ui.text.JavaSourceViewerConfiguration
 import org.eclipse.jdt.ui.text.IJavaPartitions
+import org.eclipse.jdt.ui.text.JavaSourceViewerConfiguration
 import org.eclipse.jface.preference.IPreferenceStore
+import org.eclipse.jface.text.DefaultTextHover
 import org.eclipse.jface.text.IAutoEditStrategy
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.ITextHover
-import org.eclipse.jface.text.formatter.ContentFormatter
-import org.eclipse.jface.text.contentassist.ContentAssistant
-import org.eclipse.jface.text.contentassist.IContentAssistant
+import org.eclipse.jface.text.formatter.IContentFormatter
+import org.eclipse.jface.text.formatter.MultiPassContentFormatter
 import org.eclipse.jface.text.hyperlink.IHyperlinkDetector
-import org.eclipse.jface.text.presentation.PresentationReconciler
+import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector
 import org.eclipse.jface.text.rules.DefaultDamagerRepairer
-import org.eclipse.jface.text.rules.RuleBasedScanner
-import org.eclipse.jface.text.rules.ITokenScanner
 import org.eclipse.jface.text.source.ISourceViewer
 import org.eclipse.jface.util.PropertyChangeEvent
-import org.eclipse.ui.texteditor.HyperlinkDetectorDescriptor
 import org.eclipse.ui.texteditor.ITextEditor
-import org.eclipse.swt.SWT
-import scala.tools.eclipse.ui.JdtPreferenceProvider
-import scala.tools.eclipse.ui.ScalaAutoIndentStrategy
-import scala.tools.eclipse.ui.ScalaIndenter
-import scala.tools.eclipse.util.ReflectionUtils
-import scala.tools.eclipse.lexical._
-import scala.tools.eclipse.formatter.ScalaFormattingStrategy
-import scala.tools.eclipse.ui.BracketAutoEditStrategy
-import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClasses
-import scala.tools.eclipse.hyperlink.text.detector.CompositeHyperlinkDetector
-import scala.tools.eclipse.hyperlink.text.detector.DeclarationHyperlinkDetector
-import scala.tools.eclipse.hyperlink.text.detector.ImplicitHyperlinkDetector
-import scalariform.ScalaVersions
-import org.eclipse.jface.text.DefaultTextHover
-import scala.tools.eclipse.javaelements.ScalaCompilationUnit
-import scala.tools.eclipse.ui.CommentAutoIndentStrategy
-import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector
-import scala.tools.eclipse.ui.LiteralAutoEditStrategy
-import scala.tools.eclipse.ui.StringAutoEditStrategy
-import scala.tools.eclipse.ui.MultiLineStringAutoEditStrategy
 
-class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceStore: IPreferenceStore, editor: ITextEditor)
-   extends JavaSourceViewerConfiguration(JavaPlugin.getDefault.getJavaTextTools.getColorManager, store, editor, IJavaPartitions.JAVA_PARTITIONING) {
+import scalariform.ScalaVersions
+
+class ScalaSourceViewerConfiguration(
+  javaPreferenceStore: IPreferenceStore,
+  scalaPreferenceStore: IPreferenceStore,
+  editor: ITextEditor)
+    extends JavaSourceViewerConfiguration(
+      JavaPlugin.getDefault.getJavaTextTools.getColorManager,
+      javaPreferenceStore,
+      editor,
+      IJavaPartitions.JAVA_PARTITIONING) {
 
   private val codeHighlightingScanners = {
+    import scala.tools.eclipse.properties.syntaxcolouring.{ ScalaSyntaxClasses => SSC }
+
     val scalaCodeScanner = new ScalaCodeScanner(scalaPreferenceStore, ScalaVersions.DEFAULT)
-    val singleLineCommentScanner = new ScalaCommentScanner(ScalaSyntaxClasses.SINGLE_LINE_COMMENT, ScalaSyntaxClasses.TASK_TAG, scalaPreferenceStore, store)
-    val multiLineCommentScanner = new ScalaCommentScanner(ScalaSyntaxClasses.MULTI_LINE_COMMENT, ScalaSyntaxClasses.TASK_TAG, scalaPreferenceStore, store)
-    val scaladocScanner = new ScaladocTokenScanner(ScalaSyntaxClasses.SCALADOC, ScalaSyntaxClasses.SCALADOC_ANNOTATION, ScalaSyntaxClasses.SCALADOC_MACRO, ScalaSyntaxClasses.TASK_TAG, scalaPreferenceStore, store)
-    val scaladocCodeBlockScanner = new SingleTokenScanner(ScalaSyntaxClasses.SCALADOC_CODE_BLOCK, scalaPreferenceStore)
-    val stringScanner = new StringTokenScanner(ScalaSyntaxClasses.ESCAPE_SEQUENCE, ScalaSyntaxClasses.STRING, scalaPreferenceStore)
-    val characterScanner = new StringTokenScanner(ScalaSyntaxClasses.ESCAPE_SEQUENCE, ScalaSyntaxClasses.CHARACTER, scalaPreferenceStore)
-    val multiLineStringScanner = new SingleTokenScanner(ScalaSyntaxClasses.MULTI_LINE_STRING, scalaPreferenceStore)
+    val singleLineCommentScanner = new ScalaCommentScanner(scalaPreferenceStore, javaPreferenceStore, SSC.SINGLE_LINE_COMMENT, SSC.TASK_TAG)
+    val multiLineCommentScanner = new ScalaCommentScanner(scalaPreferenceStore, javaPreferenceStore, SSC.MULTI_LINE_COMMENT, SSC.TASK_TAG)
+    val scaladocScanner = new ScaladocTokenScanner(scalaPreferenceStore, javaPreferenceStore, SSC.SCALADOC, SSC.SCALADOC_ANNOTATION, SSC.SCALADOC_MACRO, SSC.TASK_TAG)
+    val scaladocCodeBlockScanner = new SingleTokenScanner(scalaPreferenceStore, SSC.SCALADOC_CODE_BLOCK)
+    val stringScanner = new StringTokenScanner(scalaPreferenceStore, SSC.ESCAPE_SEQUENCE, SSC.STRING)
+    val characterScanner = new StringTokenScanner(scalaPreferenceStore, SSC.ESCAPE_SEQUENCE, SSC.CHARACTER)
+    val multiLineStringScanner = new SingleTokenScanner(scalaPreferenceStore, SSC.MULTI_LINE_STRING)
     val xmlTagScanner = new XmlTagScanner(scalaPreferenceStore)
     val xmlCommentScanner = new XmlCommentScanner(scalaPreferenceStore)
     val xmlCDATAScanner = new XmlCDATAScanner(scalaPreferenceStore)
-    val xmlPCDATAScanner = new SingleTokenScanner(ScalaSyntaxClasses.DEFAULT, scalaPreferenceStore)
+    val xmlPCDATAScanner = new SingleTokenScanner(scalaPreferenceStore, SSC.DEFAULT)
     val xmlPIScanner = new XmlPIScanner(scalaPreferenceStore)
 
     Map(
@@ -106,82 +110,91 @@ class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceSto
       reconciler.setRepairer(dr, partitionType)
     }
     reconciler
- }
+  }
 
-   override def getTextHover(sv: ISourceViewer, contentType: String, stateMask: Int) = {
-//     new ScalaHover(getCodeAssist _)
-     val scuOption = getCodeAssist match {
-       case Some(scu: ScalaCompilationUnit) => Some(scu)
-       case _ => None
-     }
-     scuOption match {
-       case Some(scu) => new ScalaHover(scu)
-       case None => new DefaultTextHover(sv)
-     }
-   }
+  override def getTextHover(sv: ISourceViewer, contentType: String, stateMask: Int): ITextHover =
+    getCodeAssist match {
+      case Some(scu: ScalaCompilationUnit) => new ScalaHover(scu)
+      case _                               => new DefaultTextHover(sv)
+    }
 
-   override def getHyperlinkDetectors(sv: ISourceViewer): Array[IHyperlinkDetector] = {
-     val strategies = List(DeclarationHyperlinkDetector(), ImplicitHyperlinkDetector())
-     val detector = new CompositeHyperlinkDetector(strategies)
-     if (editor != null) detector.setContext(editor)
-     Array(detector, new URLHyperlinkDetector())
-   }
+  override def getHyperlinkDetectors(sv: ISourceViewer): Array[IHyperlinkDetector] = {
+    val strategies = List(DeclarationHyperlinkDetector(), ImplicitHyperlinkDetector())
+    val detector = new CompositeHyperlinkDetector(strategies)
+    if (editor != null) detector.setContext(editor)
+    Array(detector, new URLHyperlinkDetector())
+  }
 
-   def getCodeAssist: Option[ICodeAssist] = Option(editor) map { editor =>
-      val input = editor.getEditorInput
-      val provider = editor.getDocumentProvider
+  def getCodeAssist: Option[ICodeAssist] = Option(editor) map { editor =>
+    val input = editor.getEditorInput
+    val provider = editor.getDocumentProvider
 
-      (provider, input) match {
-         case (icudp: ICompilationUnitDocumentProvider, _) => icudp getWorkingCopy input
-         case (_, icfei: IClassFileEditorInput) => icfei.getClassFile
-         case _ => null
-      }
-   }
+    (provider, input) match {
+      case (icudp: ICompilationUnitDocumentProvider, _) => icudp getWorkingCopy input
+      case (_, icfei: IClassFileEditorInput)            => icfei.getClassFile
+      case _                                            => null
+    }
+  }
 
   def getProject: IJavaProject =
     getCodeAssist.map(_.asInstanceOf[IJavaElement].getJavaProject).orNull
 
-   /**
-    * Replica of JavaSourceViewerConfiguration#getAutoEditStrategies that returns
-    * a ScalaAutoIndentStrategy instead of a JavaAutoIndentStrategy.
-    *
-    * @see org.eclipse.jface.text.source.SourceViewerConfiguration#getAutoEditStrategies(org.eclipse.jface.text.source.ISourceViewer, java.lang.String)
-    */
-   override def getAutoEditStrategies(sourceViewer: ISourceViewer, contentType: String): Array[IAutoEditStrategy] = {
-      val partitioning = getConfiguredDocumentPartitioning(sourceViewer)
-      contentType match {
-         case IJavaPartitions.JAVA_DOC | IJavaPartitions.JAVA_MULTI_LINE_COMMENT | ScalaPartitions.SCALADOC_CODE_BLOCK =>
-           Array(new CommentAutoIndentStrategy(ScalaPlugin.prefStore, partitioning))
-         case ScalaPartitions.SCALA_MULTI_LINE_STRING =>
-           Array(new SmartSemicolonAutoEditStrategy(partitioning), new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, new JdtPreferenceProvider(getProject)), new MultiLineStringAutoEditStrategy(partitioning, ScalaPlugin.prefStore))
-         case IJavaPartitions.JAVA_STRING =>
-            Array(new SmartSemicolonAutoEditStrategy(partitioning), new StringAutoEditStrategy(partitioning, ScalaPlugin.prefStore))
-         case IJavaPartitions.JAVA_CHARACTER | IDocument.DEFAULT_CONTENT_TYPE =>
-            Array(new SmartSemicolonAutoEditStrategy(partitioning), new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, new JdtPreferenceProvider(getProject)), new BracketAutoEditStrategy(ScalaPlugin.prefStore), new LiteralAutoEditStrategy(ScalaPlugin.prefStore))
-         case _ =>
-            Array(new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, new JdtPreferenceProvider(getProject)))
-      }
-   }
+  /**
+   * Replica of JavaSourceViewerConfiguration#getAutoEditStrategies that returns
+   * a ScalaAutoIndentStrategy instead of a JavaAutoIndentStrategy.
+   *
+   * @see org.eclipse.jface.text.source.SourceViewerConfiguration#getAutoEditStrategies(org.eclipse.jface.text.source.ISourceViewer, java.lang.String)
+   */
+  override def getAutoEditStrategies(sourceViewer: ISourceViewer, contentType: String): Array[IAutoEditStrategy] = {
+    def prefProvider = new JdtPreferenceProvider(getProject)
+    val partitioning = getConfiguredDocumentPartitioning(sourceViewer)
 
-  override def getContentFormatter(sourceViewer: ISourceViewer) = {
+    contentType match {
+      case IJavaPartitions.JAVA_DOC | IJavaPartitions.JAVA_MULTI_LINE_COMMENT | ScalaPartitions.SCALADOC_CODE_BLOCK =>
+        Array(new CommentAutoIndentStrategy(ScalaPlugin.prefStore, partitioning))
+
+      case ScalaPartitions.SCALA_MULTI_LINE_STRING =>
+        Array(
+          new SmartSemicolonAutoEditStrategy(partitioning),
+          new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, prefProvider),
+          new MultiLineStringAutoEditStrategy(partitioning, ScalaPlugin.prefStore))
+
+      case IJavaPartitions.JAVA_STRING =>
+        Array(
+          new SmartSemicolonAutoEditStrategy(partitioning),
+          new StringAutoEditStrategy(partitioning, ScalaPlugin.prefStore))
+
+      case IJavaPartitions.JAVA_CHARACTER | IDocument.DEFAULT_CONTENT_TYPE =>
+        Array(
+          new SmartSemicolonAutoEditStrategy(partitioning),
+          new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, prefProvider),
+          new BracketAutoEditStrategy(ScalaPlugin.prefStore),
+          new LiteralAutoEditStrategy(ScalaPlugin.prefStore))
+
+      case _ =>
+        Array(new ScalaAutoIndentStrategy(partitioning, getProject, sourceViewer, prefProvider))
+    }
+  }
+
+  override def getContentFormatter(sourceViewer: ISourceViewer): IContentFormatter = {
     val formatter = new MultiPassContentFormatter(getConfiguredDocumentPartitioning(sourceViewer), IDocument.DEFAULT_CONTENT_TYPE)
     formatter.setMasterStrategy(new ScalaFormattingStrategy(editor))
     formatter
   }
 
-   override def handlePropertyChangeEvent(event: PropertyChangeEvent) {
-      super.handlePropertyChangeEvent(event)
-      codeHighlightingScanners.values foreach (_ adaptToPreferenceChange event)
-   }
+  override def handlePropertyChangeEvent(event: PropertyChangeEvent) {
+    super.handlePropertyChangeEvent(event)
+    codeHighlightingScanners.values foreach (_ adaptToPreferenceChange event)
+  }
 
-   /**
-    * Adds Scala related partition types to the list of configured content types,
-    * in order that they are available for several features of the IDE.
-    */
-   override def getConfiguredContentTypes(sourceViewer: ISourceViewer): Array[String] =
-     super.getConfiguredContentTypes(sourceViewer) ++
-       Seq(ScalaPartitions.SCALA_MULTI_LINE_STRING, ScalaPartitions.SCALADOC_CODE_BLOCK)
+  /**
+   * Adds Scala related partition types to the list of configured content types,
+   * in order that they are available for several features of the IDE.
+   */
+  override def getConfiguredContentTypes(sourceViewer: ISourceViewer): Array[String] =
+    super.getConfiguredContentTypes(sourceViewer) ++
+      Seq(ScalaPartitions.SCALA_MULTI_LINE_STRING, ScalaPartitions.SCALADOC_CODE_BLOCK)
 
-   override def affectsTextPresentation(event: PropertyChangeEvent) = true
+  override def affectsTextPresentation(event: PropertyChangeEvent) = true
 
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCommentScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCommentScanner.scala
@@ -33,11 +33,19 @@ import org.eclipse.jface.util.PropertyChangeEvent
  *        the preference store from JDT
  */
 class ScalaCommentScanner(
-    syntaxClass: ScalaSyntaxClass,
-    taskTagClass: ScalaSyntaxClass,
     val preferenceStore: IPreferenceStore,
-    javaPreferenceStore: IPreferenceStore
-) extends RuleBasedScanner with AbstractScalaScanner {
+    javaPreferenceStore: IPreferenceStore,
+    syntaxClass: ScalaSyntaxClass,
+    taskTagClass: ScalaSyntaxClass)
+      extends RuleBasedScanner with AbstractScalaScanner {
+
+  @deprecated("use primary constructor instead", "4.0")
+  def this(
+      syntaxClass: ScalaSyntaxClass,
+      taskTagClass: ScalaSyntaxClass,
+      preferenceStore: IPreferenceStore,
+      javaPreferenceStore: IPreferenceStore) =
+    this(preferenceStore, javaPreferenceStore, syntaxClass, taskTagClass)
 
   private val wordMatcher = {
     val taskTags = javaPreferenceStore.getString(JavaCore.COMPILER_TASK_TAGS)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScaladocTokenScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScaladocTokenScanner.scala
@@ -16,13 +16,23 @@ import org.eclipse.jface.text.rules.WordRule
  * not search for Scaladoc content inside of arbitrary passed input.
  */
 class ScaladocTokenScanner(
+    preferenceStore: IPreferenceStore,
+    javaPreferenceStore: IPreferenceStore,
     scaladocClass: ScalaSyntaxClass,
     annotationClass: ScalaSyntaxClass,
     macroClass: ScalaSyntaxClass,
-    taskTagClass: ScalaSyntaxClass,
-    preferenceStore: IPreferenceStore,
-    javaPreferenceStore: IPreferenceStore
-) extends ScalaCommentScanner(scaladocClass, taskTagClass, preferenceStore, javaPreferenceStore) {
+    taskTagClass: ScalaSyntaxClass)
+      extends ScalaCommentScanner(preferenceStore, javaPreferenceStore, scaladocClass, taskTagClass) {
+
+  @deprecated("use primary constructor instead", "4.0")
+  def this(
+      scaladocClass: ScalaSyntaxClass,
+      annotationClass: ScalaSyntaxClass,
+      macroClass: ScalaSyntaxClass,
+      taskTagClass: ScalaSyntaxClass,
+      preferenceStore: IPreferenceStore,
+      javaPreferenceStore: IPreferenceStore) =
+    this(preferenceStore, javaPreferenceStore, scaladocClass, annotationClass, macroClass, taskTagClass)
 
   private val annotationRule = new ScaladocWordRule(new AnnotationDetector, getToken(scaladocClass), getToken(annotationClass))
   private val macroRule = new ScaladocWordRule(new MacroDetector, getToken(scaladocClass), getToken(macroClass))

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/SingleTokenScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/SingleTokenScanner.scala
@@ -8,8 +8,12 @@ import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClass
 import org.eclipse.jface.preference.IPreferenceStore
 
 class SingleTokenScanner(
-  syntaxClass: ScalaSyntaxClass, val preferenceStore: IPreferenceStore)
-  extends AbstractScalaScanner {
+  val preferenceStore: IPreferenceStore, syntaxClass: ScalaSyntaxClass)
+    extends AbstractScalaScanner {
+
+  @deprecated("use primary constructor instead", "4.0")
+  def this(syntaxClass: ScalaSyntaxClass, preferenceStore: IPreferenceStore) =
+    this(preferenceStore, syntaxClass)
 
   private var offset: Int = _
   private var length: Int = _

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/StringTokenScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/StringTokenScanner.scala
@@ -13,10 +13,17 @@ import org.eclipse.jface.text.rules.Token
  * sequence tokens.
  */
 class StringTokenScanner(
+  val preferenceStore: IPreferenceStore,
   escapeSequenceClass: ScalaSyntaxClass,
-  stringClass: ScalaSyntaxClass,
-  val preferenceStore: IPreferenceStore)
+  stringClass: ScalaSyntaxClass)
     extends AbstractScalaScanner with StringTokenizer {
+
+  @deprecated("use primary constructor instead", "4.0")
+  def this(
+      escapeSequenceClass: ScalaSyntaxClass,
+      stringClass: ScalaSyntaxClass,
+      preferenceStore: IPreferenceStore) =
+    this(preferenceStore, escapeSequenceClass, stringClass)
 
   private var offset: Int = _
   private var length: Int = _


### PR DESCRIPTION
The order of parameters in the constructors of the scanner classes
has changed.

All other changes are formatting related.

---

I reverted the previous change that introduced implicit parameters. The parameters that were implicit have moved to the beginning of the parameter lists.
