### PR TITLE
[backport] Fixed build -  keyword was removed from scalariform

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ScalaSyntaxClasses.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/syntaxcolouring/ScalaSyntaxClasses.scala
@@ -106,8 +106,6 @@ object ScalariformToSyntaxClass {
     case STRING_LITERAL                                                  => ssc.STRING
     case TRUE | FALSE | NULL                                             => ssc.KEYWORD
     case RETURN                                                          => ssc.RETURN
-    /* `requires` is not a keyword anymore, translation to default content type */
-    case REQUIRES                                                        => ssc.DEFAULT
     case t if t.isKeyword                                                => ssc.KEYWORD
     case LINE_COMMENT                                                    => ssc.SINGLE_LINE_COMMENT
     case MULTILINE_COMMENT if token.isScalaDocComment                    => ssc.SCALADOC


### PR DESCRIPTION
(cherry picked from commit a4c5c8bd60366a5fd30f98100f0f4d6764d95477)
