### PR TITLE
Correctly handle boundary conditions in the ScalaWordFinder

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/TestsSuite.java
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/TestsSuite.java
@@ -10,6 +10,7 @@ import scala.tools.eclipse.compiler.settings.ContinuationPluginSettingsTest;
 import scala.tools.eclipse.completion.CompletionTests;
 import scala.tools.eclipse.findreferences.FindReferencesTests;
 import scala.tools.eclipse.hyperlink.HyperlinkDetectorTests;
+import scala.tools.eclipse.hyperlink.ScalaWordFinderTest;
 import scala.tools.eclipse.jcompiler.AbstractMethodVerifierTest;
 import scala.tools.eclipse.launching.RunAsTest;
 import scala.tools.eclipse.launching.MainClassVerifierTest;
@@ -80,6 +81,7 @@ import scala.tools.eclipse.wizards.QualifiedNameSupportTest;
   CachedTest.class,
   CollectionUtilTest.class,
   ImportSupportTest.class,
-  QualifiedNameSupportTest.class
+  QualifiedNameSupportTest.class,
+  ScalaWordFinderTest.class
 })
 class TestsSuite { }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/ScalaWordFinderTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/ScalaWordFinderTest.scala
@@ -1,0 +1,78 @@
+package scala.tools.eclipse.hyperlink
+
+import scala.tools.eclipse.ScalaWordFinder
+import org.eclipse.jface.text.IRegion
+import org.junit.Test
+import org.junit.Assert
+import org.eclipse.jface.text.Region
+
+class ScalaWordFinderTest {
+  private def findWord(doc: String): IRegion = {
+    val pos = doc.indexOf('|')
+    val filteredDoc = doc.filterNot(_ == '|')
+    ScalaWordFinder.findWord(filteredDoc.toSeq, pos)
+  }
+
+  private def test(doc: String, r: (Int, Int)) {
+    val range = findWord(doc)
+    val expected = new Region(r._1, r._2)
+    Assert.assertEquals(s"Unexpected region for $doc", expected, range)
+  }
+
+  @Test
+  def atEndOfDoc() {
+    test("word|", (0, 4))
+    test("|word", (0, 4))
+  }
+
+  @Test
+  def middleWords() {
+    test("wor|d", (0, 4))
+    test("w|ord", (0, 4))
+    test(" wor|d  ", (1, 4))
+  }
+
+  @Test
+  def delimiters() {
+    test("ref.sel|ection", (4, 9))
+    test("ref.sel|ection.other", (4, 9))
+  }
+
+  @Test
+  def delimitersArg() {
+    test("ref(arg|ument", (4, 8))
+    test("ref(|argument)", (4, 8))
+    test("ref(argument|)", (4, 8))
+    test("ref|(argument)", (0, 3))
+  }
+
+  @Test
+  def zeroLen() {
+    test("|", (0, 0))
+    test("ref(|)", (4, 0))
+    test("ref.|", (4, 0))
+  }
+
+  @Test
+  def interpolated() {
+    test(""" s"$fo|o" """, (4, 3))
+    test(""" s"${fo|o}" """, (5, 3))
+    test(""" s"${|foo}" """, (5, 3))
+    test(""" s"${foo|}" """, (5, 3))
+  }
+
+  @Test
+  def middleOperators() {
+    test("==|==", (0, 4))
+    test("=|-~/", (0, 4))
+    test(" <|<<=  ", (1, 4))
+  }
+
+  @Test
+  def delimitersAndOperators() {
+    test("foo(==|==)", (4, 4))
+    test("foo(|=-~/)", (4, 4))
+    test("foo(<<<=|)  ", (4, 4))
+    test("foo(<<<=|", (4, 4))
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
@@ -50,7 +50,7 @@ object ScalaWordFinder extends IScalaWordFinder {
       var end = -1
 
       try {
-        var pos = offset
+        var pos = Math.min(offset - 1, document.size - 1)
 
         while (pos >= 0 && p(document(pos)))
           pos -= 1
@@ -67,16 +67,7 @@ object ScalaWordFinder extends IScalaWordFinder {
         case ex : BadLocationException => // Deliberately ignored
       }
 
-      if (start >= -1 && end > -1) {
-        if (start == offset && end == offset)
-          new Region(offset, 0)
-        else if (start == offset)
-          new Region(start, end - start)
-        else
-          new Region(start+1, end-start-1)
-      }
-      else
-        null
+      new Region(start + 1, end - start - 1)
     }
 
     val idRegion = find(ch => isIdentifierPart(ch) && ch != '$')


### PR DESCRIPTION
I reorganized and simplified the logic in the ScalaWordFinder,
and added a few tests. It seems to fix at least the exception
and a couple of other boundary conditions (revealed by pressing
F3 at the very beginning or very end of an identifier, or even
an identifier between `{}`).

Fixed #1001526

Should be backported.
