### PR TITLE
Updated `sbt.version` for Scala 2.10 and 2.11 profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
             in this case because the Scala version is stable!)
         <sbt.version>0.13.0-M2-SNAPSHOT</sbt.version>
         -->
-        <sbt.version>0.13.0-Beta1-SNAPSHOT</sbt.version> <!-- We use Sbt 0.13 master because of source-incompatible changes in master -->
+        <sbt.version>0.13.0-SNAPSHOT</sbt.version> <!-- We use Sbt 0.13 master because of source-incompatible changes in master -->
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-210x</repo.scala-refactoring>
         <repo.scalariform>${repo.scala-ide.root}/scalariform-210x</repo.scalariform>
@@ -99,7 +99,7 @@
         <scala.version>2.11.0-SNAPSHOT</scala.version>
         <scala.era.major.version>2.11</scala.era.major.version>
         <version.suffix>2_11</version.suffix>
-        <sbt.version>0.13.0-Beta1-SNAPSHOT</sbt.version> <!-- We use Sbt 0.13 master for building against Scala 2.11.0-SNAPSHOT -->
+        <sbt.version>0.13.0-SNAPSHOT</sbt.version> <!-- We use Sbt 0.13 master for building against Scala 2.11.0-SNAPSHOT -->
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-211x</repo.scala-refactoring>
         <repo.scalariform>${repo.scala-ide.root}/scalariform-211x</repo.scalariform>


### PR DESCRIPTION
The version of Sbt 0.13 (master) changed back from Beta1 to
SNAPSHOT, hence we need to update the profiles for Scala 2.10
and 2.11 to pass the right value fot `sbt.version`.

This commit basically reverts the changes in the POM made by
SHA: c4f66e5324a014d7587b4bdfaa9a47f7b3a221b5
