### PR TITLE
[backport] Delete color manager from AbstractScalaScanner and subtypes

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
@@ -46,19 +46,19 @@ class ScalaSourceViewerConfiguration(store: IPreferenceStore, scalaPreferenceSto
    extends JavaSourceViewerConfiguration(JavaPlugin.getDefault.getJavaTextTools.getColorManager, store, editor, IJavaPartitions.JAVA_PARTITIONING) {
 
   private val codeHighlightingScanners = {
-    val scalaCodeScanner = new ScalaCodeScanner(getColorManager, scalaPreferenceStore, ScalaVersions.DEFAULT)
-    val singleLineCommentScanner = new SingleTokenScanner(ScalaSyntaxClasses.SINGLE_LINE_COMMENT, getColorManager, scalaPreferenceStore)
-    val multiLineCommentScanner = new SingleTokenScanner(ScalaSyntaxClasses.MULTI_LINE_COMMENT, getColorManager, scalaPreferenceStore)
-    val scaladocScanner = new ScaladocTokenScanner(ScalaSyntaxClasses.SCALADOC, ScalaSyntaxClasses.SCALADOC_ANNOTATION, ScalaSyntaxClasses.SCALADOC_MACRO, getColorManager, scalaPreferenceStore)
-    val scaladocCodeBlockScanner = new SingleTokenScanner(ScalaSyntaxClasses.SCALADOC_CODE_BLOCK, getColorManager, scalaPreferenceStore)
-    val stringScanner = new StringTokenScanner(ScalaSyntaxClasses.ESCAPE_SEQUENCE, ScalaSyntaxClasses.STRING, getColorManager, scalaPreferenceStore)
-    val characterScanner = new StringTokenScanner(ScalaSyntaxClasses.ESCAPE_SEQUENCE, ScalaSyntaxClasses.CHARACTER, getColorManager, scalaPreferenceStore)
-    val multiLineStringScanner = new SingleTokenScanner(ScalaSyntaxClasses.MULTI_LINE_STRING, getColorManager, scalaPreferenceStore)
-    val xmlTagScanner = new XmlTagScanner(getColorManager, scalaPreferenceStore)
-    val xmlCommentScanner = new XmlCommentScanner(getColorManager, scalaPreferenceStore)
-    val xmlCDATAScanner = new XmlCDATAScanner(getColorManager, scalaPreferenceStore)
-    val xmlPCDATAScanner = new SingleTokenScanner(ScalaSyntaxClasses.DEFAULT, getColorManager, scalaPreferenceStore)
-    val xmlPIScanner = new XmlPIScanner(getColorManager, scalaPreferenceStore)
+    val scalaCodeScanner = new ScalaCodeScanner(scalaPreferenceStore, ScalaVersions.DEFAULT)
+    val singleLineCommentScanner = new SingleTokenScanner(ScalaSyntaxClasses.SINGLE_LINE_COMMENT, scalaPreferenceStore)
+    val multiLineCommentScanner = new SingleTokenScanner(ScalaSyntaxClasses.MULTI_LINE_COMMENT, scalaPreferenceStore)
+    val scaladocScanner = new ScaladocTokenScanner(ScalaSyntaxClasses.SCALADOC, ScalaSyntaxClasses.SCALADOC_ANNOTATION, ScalaSyntaxClasses.SCALADOC_MACRO, scalaPreferenceStore)
+    val scaladocCodeBlockScanner = new SingleTokenScanner(ScalaSyntaxClasses.SCALADOC_CODE_BLOCK, scalaPreferenceStore)
+    val stringScanner = new StringTokenScanner(ScalaSyntaxClasses.ESCAPE_SEQUENCE, ScalaSyntaxClasses.STRING, scalaPreferenceStore)
+    val characterScanner = new StringTokenScanner(ScalaSyntaxClasses.ESCAPE_SEQUENCE, ScalaSyntaxClasses.CHARACTER, scalaPreferenceStore)
+    val multiLineStringScanner = new SingleTokenScanner(ScalaSyntaxClasses.MULTI_LINE_STRING, scalaPreferenceStore)
+    val xmlTagScanner = new XmlTagScanner(scalaPreferenceStore)
+    val xmlCommentScanner = new XmlCommentScanner(scalaPreferenceStore)
+    val xmlCDATAScanner = new XmlCDATAScanner(scalaPreferenceStore)
+    val xmlPCDATAScanner = new SingleTokenScanner(ScalaSyntaxClasses.DEFAULT, scalaPreferenceStore)
+    val xmlPIScanner = new XmlPIScanner(scalaPreferenceStore)
 
     Map(
       IDocument.DEFAULT_CONTENT_TYPE -> scalaCodeScanner,

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/AbstractScalaScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/AbstractScalaScanner.scala
@@ -3,12 +3,9 @@ package scala.tools.eclipse.lexical
 import org.eclipse.jface.text.rules._
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClass
 import org.eclipse.jface.util.PropertyChangeEvent
-import org.eclipse.jdt.ui.text.IColorManager
 import org.eclipse.jface.preference.IPreferenceStore
 
 trait AbstractScalaScanner extends ITokenScanner {
-
-  protected def colorManager: IColorManager
 
   protected def preferenceStore: IPreferenceStore
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
@@ -3,7 +3,6 @@ package scala.tools.eclipse.lexical
 import scala.annotation.tailrec
 import scala.tools.eclipse.properties.syntaxcolouring._
 
-import org.eclipse.jdt.ui.text.IColorManager
 import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.rules.{ IToken, Token }
@@ -17,7 +16,6 @@ import scalariform.lexer.Tokens._
  * token.
  */
 class ScalaCodeScanner(
-  val colorManager: IColorManager,
   val preferenceStore: IPreferenceStore,
   val scalaVersion: ScalaVersion)
     extends AbstractScalaScanner with ScalaCodeTokenizer {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScaladocTokenScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScaladocTokenScanner.scala
@@ -3,7 +3,6 @@ package scala.tools.eclipse.lexical
 import scala.annotation.tailrec
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClass
 
-import org.eclipse.jdt.ui.text.IColorManager
 import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.rules.{ IToken, Token }
@@ -18,7 +17,6 @@ class ScaladocTokenScanner(
   scaladocClass: ScalaSyntaxClass,
   annotationClass: ScalaSyntaxClass,
   macroClass: ScalaSyntaxClass,
-  val colorManager: IColorManager,
   val preferenceStore: IPreferenceStore)
     extends AbstractScalaScanner with ScaladocTokenizer {
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/SingleTokenScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/SingleTokenScanner.scala
@@ -2,14 +2,13 @@ package scala.tools.eclipse.lexical
 
 import org.eclipse.jface.text._
 import org.eclipse.jface.text.rules._
-import org.eclipse.jdt.ui.text.IColorManager
 import org.eclipse.jface.util.PropertyChangeEvent
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClasses._
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClass
 import org.eclipse.jface.preference.IPreferenceStore
 
 class SingleTokenScanner(
-  syntaxClass: ScalaSyntaxClass, val colorManager: IColorManager, val preferenceStore: IPreferenceStore)
+  syntaxClass: ScalaSyntaxClass, val preferenceStore: IPreferenceStore)
   extends AbstractScalaScanner {
 
   private var offset: Int = _

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/StringTokenScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/StringTokenScanner.scala
@@ -3,7 +3,6 @@ package scala.tools.eclipse.lexical
 import scala.annotation.tailrec
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClass
 
-import org.eclipse.jdt.ui.text.IColorManager
 import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.rules.{ IToken, Token }
@@ -15,7 +14,6 @@ import org.eclipse.jface.text.rules.{ IToken, Token }
 class StringTokenScanner(
   escapeSequenceClass: ScalaSyntaxClass,
   stringClass: ScalaSyntaxClass,
-  val colorManager: IColorManager,
   val preferenceStore: IPreferenceStore)
     extends AbstractScalaScanner with StringTokenizer {
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlCDATAScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlCDATAScanner.scala
@@ -1,13 +1,12 @@
 package scala.tools.eclipse.lexical
 import org.eclipse.jface.text._
 import org.eclipse.jface.text.rules._
-import org.eclipse.jdt.ui.text.IColorManager
 import scala.collection.mutable.ListBuffer
 import org.eclipse.jface.util.PropertyChangeEvent
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClasses._
 import org.eclipse.jface.preference.IPreferenceStore
 
-class XmlCDATAScanner(val colorManager: IColorManager, val preferenceStore: IPreferenceStore) extends AbstractScalaScanner {
+class XmlCDATAScanner(val preferenceStore: IPreferenceStore) extends AbstractScalaScanner {
 
   import XmlCDATAScanner._
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlCommentScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlCommentScanner.scala
@@ -1,12 +1,11 @@
 package scala.tools.eclipse.lexical
 import org.eclipse.jface.text._
 import org.eclipse.jface.text.rules._
-import org.eclipse.jdt.ui.text.IColorManager
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClasses._
 import org.eclipse.jface.util.PropertyChangeEvent
 import org.eclipse.jface.preference.IPreferenceStore
 
-class XmlCommentScanner(val colorManager: IColorManager, val preferenceStore: IPreferenceStore) extends RuleBasedScanner with AbstractScalaScanner {
+class XmlCommentScanner(val preferenceStore: IPreferenceStore) extends RuleBasedScanner with AbstractScalaScanner {
 
   setRules(Array(new MultiLineRule("<!--", "-->", getToken(XML_COMMENT))))
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlPIScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlPIScanner.scala
@@ -2,12 +2,11 @@ package scala.tools.eclipse.lexical
 
 import org.eclipse.jface.text._
 import org.eclipse.jface.text.rules._
-import org.eclipse.jdt.ui.text.IColorManager
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClasses._
 import org.eclipse.jface.util.PropertyChangeEvent
 import org.eclipse.jface.preference.IPreferenceStore
 
-class XmlPIScanner(val colorManager: IColorManager, val preferenceStore: IPreferenceStore) extends RuleBasedScanner with AbstractScalaScanner {
+class XmlPIScanner(val preferenceStore: IPreferenceStore) extends RuleBasedScanner with AbstractScalaScanner {
 
   setRules(Array(new MultiLineRule("<?", "?>", getToken(XML_PI))))
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlTagScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/XmlTagScanner.scala
@@ -1,8 +1,6 @@
 package scala.tools.eclipse.lexical
 import org.eclipse.jface.text._
 import org.eclipse.jface.text.rules._
-import org.eclipse.jdt.ui.text.IColorManager
-import org.eclipse.jdt.internal.ui.text.CombinedWordRule
 import scala.annotation.{ switch, tailrec }
 import org.eclipse.swt.SWT
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClass
@@ -11,7 +9,7 @@ import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClasses
 import org.eclipse.jface.util.PropertyChangeEvent
 import org.eclipse.jface.preference.IPreferenceStore
 
-class XmlTagScanner(val colorManager: IColorManager, val preferenceStore: IPreferenceStore) extends AbstractScalaScanner {
+class XmlTagScanner(val preferenceStore: IPreferenceStore) extends AbstractScalaScanner {
   import XmlTagScanner._
 
   var pos: Int = -1


### PR DESCRIPTION
(cherry picked from commit 0b26673d9948d5160d5b51f1aacbdda66fcf43b6)

I had to slightly adapt the set of changes, as we are only interested in
cherr-picking the deletion of `colorManager` from AbstractScalaScanner and
subtypes. Below follows the list of changes wrt the original commit:
- Use `SingleTokenScanner` in place of `ScalaCommentScanner` 
- Removed ScalaCommentScanner.scala from the set of cherry-picked changes

Conflicts:

```
org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCommentScanner.scala
```
