### PR TITLE
Tuned ``MainClassVerifier`` to consider classfiles instead of sourcefiles

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchDelegate.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchDelegate.scala
@@ -119,7 +119,7 @@ class ScalaLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
       ScalaPlugin.plugin.asScalaProject(project.getProject) map { scalaProject =>
         val mainClassVerifier = new MainClassVerifier(new UIErrorReporter)
         val status = mainClassVerifier.execute(scalaProject, mainTypeName)
-        status.getCode() == IStatus.OK
+        status.isOK
       } getOrElse false
     }
   }


### PR DESCRIPTION
With the former implementation, an error was reported every time the _package
name in the source did not match the source's physical location_. This is too
eager, in fact the two don't need to be in sync for the user to be able to
launch a Scala Application.

The minimal condition for running a Scala Application is that the Main binary
file exists. Hence, I've updated the code to reflect this requirement.

Moreover, if a class file for the `mainTypeName` exist, but no companion
module class file can be found, a new error is now reported to inform the user
that he should change the class declaration into an object.

Fix #1001760
