### PR TITLE
Implement completion overwrites

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposal.scala
@@ -25,7 +25,19 @@ import org.eclipse.swt.events.VerifyEvent
 import org.eclipse.jface.text.link.LinkedModeUI.ExitFlags
 import org.eclipse.swt.SWT
 import scala.tools.refactoring.common.TextChange
-
+import org.eclipse.jface.text.contentassist.ICompletionProposalExtension2
+import org.eclipse.jdt.internal.ui.JavaPlugin
+import org.eclipse.jdt.ui.PreferenceConstants
+import org.eclipse.jface.preference.PreferenceConverter
+import org.eclipse.swt.graphics.Color
+import org.eclipse.jface.text.ITextViewerExtension4
+import org.eclipse.jface.text.TextPresentation
+import org.eclipse.swt.custom.StyleRange
+import org.eclipse.jface.text.ITextPresentationListener
+import org.eclipse.jface.text.ITextViewerExtension2
+import org.eclipse.jface.text.ITextViewerExtension5
+import org.eclipse.jface.text.DocumentEvent
+import org.eclipse.jface.text.IRegion
 
 /** A UI class for displaying completion proposals.
  *
@@ -33,10 +45,16 @@ import scala.tools.refactoring.common.TextChange
  *  between them.
  */
 class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: ISelectionProvider)
-    extends IJavaCompletionProposal with ICompletionProposalExtension with ICompletionProposalExtension6 {
+  extends IJavaCompletionProposal
+  with ICompletionProposalExtension
+  with ICompletionProposalExtension2
+  with ICompletionProposalExtension6 {
 
   import proposal._
   import ScalaCompletionProposal._
+
+  private var cachedStyleRange: StyleRange = null
+  private val ScalaProposalCategory = "ScalaProposal"
 
   def getRelevance = relevance
 
@@ -49,7 +67,7 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
       case Trait         => traitImage
       case Package       => packageImage
       case PackageObject => packageObjectImage
-      case Object        =>
+      case Object =>
         if (isJava) javaClassImage
         else objectImage
       case Type => typeImage
@@ -66,14 +84,14 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
   private lazy val explicitParamNames = getParamNames()
 
   /** The string that will be inserted in the document if this proposal is chosen.
-   *  It consists of the method name, followed by all explicit parameter sections,
-   *  and inside each section the parameter names, delimited by commas.
+   *  By default, it consists of the method name, followed by all explicit parameter sections,
+   *  and inside each section the parameter names, delimited by commas. If `overwrite`
+   *  is on, it won't add parameter names
    *
-   *  @note This field needs to be lazy because it triggers the potentially expensive
-   *        `getParameterNames` operation.
+   *  @note It triggers the potentially expensive `getParameterNames` operation.
    */
-  private lazy val completionString =
-    if (explicitParamNames.isEmpty)
+  def completionString(overwrite: Boolean) =
+    if (explicitParamNames.isEmpty || overwrite)
       completion
     else {
       val buffer = new StringBuffer(completion)
@@ -92,34 +110,39 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
       new ScalaContextInformation(display, tooltip, image, startOfArgumentList)
     else null
 
-  /**
-   * A simple display string
+  /** A simple display string
    */
   def getDisplayString() = display
 
-  /**
-   * A display string with grayed out extra details
+  /** A display string with grayed out extra details
    */
-  def getStyledDisplayString() : StyledString = {
-       val styledString= new StyledString(display)
-       if (displayDetail != null && displayDetail.length > 0)
-         styledString.append(" - ", StyledString.QUALIFIER_STYLER).append(displayDetail, StyledString.QUALIFIER_STYLER)
-      styledString
-    }
+  def getStyledDisplayString(): StyledString = {
+    val styledString = new StyledString(display)
+    if (displayDetail != null && displayDetail.length > 0)
+      styledString.append(" - ", StyledString.QUALIFIER_STYLER).append(displayDetail, StyledString.QUALIFIER_STYLER)
+    styledString
+  }
 
-  /**
-   * Some additional info (like javadoc ...)
+  /** Some additional info (like javadoc ...)
    */
   def getAdditionalProposalInfo() = null
   def getSelection(d: IDocument) = null
   def apply(d: IDocument) { throw new IllegalStateException("Shouldn't be called") }
 
   def apply(d: IDocument, trigger: Char, offset: Int) {
+    throw new IllegalStateException("Shouldn't be called")
+  }
 
+  def apply(viewer: ITextViewer, trigger: Char, stateMask: Int, offset: Int): Unit = {
+    val d: IDocument = viewer.getDocument()
+    val overwrite = !insertCompletion ^ ((stateMask & SWT.CTRL) != 0)
+
+    val completionFullString = completionString(overwrite)
     withScalaFileAndSelection { (scalaSourceFile, textSelection) =>
 
       val completionChange = scalaSourceFile.withSourceFile { (sourceFile, _) =>
-        TextChange(sourceFile, startPos, offset, completionString)
+        val endPos = if (overwrite) startPos + existingIdentifier(d, offset).getLength() else offset
+        TextChange(sourceFile, startPos, endPos, completionFullString)
       }()
 
       val importStmt = if (needImport) { // add an import statement if required
@@ -135,16 +158,18 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
       // another `waitLoadedType` to update the positions for the refactoring
       // to work properly.
       EditorHelpers.applyChangesToFileWhileKeepingSelection(
-          d, textSelection, scalaSourceFile.file, completionChange :: importStmt)
+        d, textSelection, scalaSourceFile.file, completionChange :: importStmt)
 
       None
     }
 
-    selectionProvider match {
+    if (!overwrite) selectionProvider match {
       case viewer: ITextViewer if explicitParamNames.flatten.nonEmpty =>
-        addArgumentTemplates(d, viewer)
+        addArgumentTemplates(d, viewer, completionFullString)
       case _ => ()
     }
+    else
+      EditorHelpers.doWithCurrentEditor(editor => editor.selectAndReveal(startPos + completionFullString.length(), 0))
   }
 
   def getTriggerCharacters = null
@@ -158,8 +183,8 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
    *  This means that TAB can be used to navigate to the next argument, and Enter or Esc
    *  can be used to exit this mode.
    */
-  def addArgumentTemplates(document: IDocument, textViewer: ITextViewer) {
-    val model= new LinkedModeModel()
+  def addArgumentTemplates(document: IDocument, textViewer: ITextViewer, completionFullString: String) {
+    val model = new LinkedModeModel()
 
     document.addPositionCategory(ScalaProposalCategory)
     var offset = startPos + completion.length
@@ -168,14 +193,14 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
       offset += 1 // open parenthesis
       var idx = 0 // the index of the current argument
       for (proposal <- section) {
-        val group = new LinkedPositionGroup();
+        val group = new LinkedPositionGroup()
         val positionOffset = offset + 2 * idx // each argument is followed by ", "
         val positionLength = proposal.length
         offset += positionLength
 
         document.addPosition(ScalaProposalCategory, new Position(positionOffset, positionLength))
         group.addPosition(new LinkedPosition(document, positionOffset, positionLength, LinkedPositionGroup.NO_STOP))
-        model.addGroup(group);
+        model.addGroup(group)
         idx += 1
       }
       offset += 1 + 2 * (idx - 1) // close parenthesis around section (and the last argument isn't followed by comma and space)
@@ -183,23 +208,23 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
 
     model.addLinkingListener(new ILinkedModeListener() {
       def left(environment: LinkedModeModel, flags: Int) {
-        document.removePositionCategory(ScalaProposalCategory);
+        document.removePositionCategory(ScalaProposalCategory)
       }
 
       def suspend(environment: LinkedModeModel) {}
       def resume(environment: LinkedModeModel, flags: Int) {}
     })
 
-    model.forceInstall();
+    model.forceInstall()
 
-    val ui = mkEditorLinkedMode(document, textViewer, model)
-    ui.enter();
+    val ui = mkEditorLinkedMode(document, textViewer, model, completionFullString.length)
+    ui.enter()
   }
 
   /** Prepare a linked mode for the given editor. */
-  private def mkEditorLinkedMode(document: IDocument, textViewer: ITextViewer, model: LinkedModeModel): EditorLinkedModeUI = {
+  private def mkEditorLinkedMode(document: IDocument, textViewer: ITextViewer, model: LinkedModeModel, len: Int): EditorLinkedModeUI = {
     val ui = new EditorLinkedModeUI(model, textViewer)
-    ui.setExitPosition(textViewer, startPos + completionString.length(), 0, Integer.MAX_VALUE)
+    ui.setExitPosition(textViewer, startPos + len, 0, Integer.MAX_VALUE)
     ui.setExitPolicy(new IExitPolicy {
       def doExit(environment: LinkedModeModel, event: VerifyEvent, offset: Int, length: Int) = {
         event.character match {
@@ -216,13 +241,96 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
             null
         }
       }
-    });
-    ui.setCyclingMode(LinkedModeUI.CYCLE_WHEN_NO_PARENT);
-    ui.setDoContextInfo(true);
+    })
+    ui.setCyclingMode(LinkedModeUI.CYCLE_WHEN_NO_PARENT)
+    ui.setDoContextInfo(true)
     ui
   }
 
-  private val ScalaProposalCategory = "ScalaProposal"
+  /** Highlight the part of the text that would be overwritten by the current selection
+   */
+  override def selected(viewer: ITextViewer, smartToggle: Boolean) {
+    repairPresentation(viewer)
+    if (!insertCompletion() ^ smartToggle) {
+      cachedStyleRange = createStyleRange(viewer)
+      if (cachedStyleRange == null)
+        return
+
+      viewer match {
+        case viewerExtension4: ITextViewerExtension4 =>
+          this.viewer = viewer
+          viewerExtension4.addTextPresentationListener(presListener)
+        case _ => ()
+      }
+      repairPresentation(viewer)
+    }
+  }
+
+  override def unselected(viewer: ITextViewer) {
+    viewer.asInstanceOf[ITextViewerExtension4].removeTextPresentationListener(presListener)
+    repairPresentation(viewer)
+    cachedStyleRange = null
+  }
+
+  private def repairPresentation(viewer: ITextViewer) {
+    if (cachedStyleRange != null) viewer match {
+      case viewer2: ITextViewerExtension2 =>
+        // attempts to reduce the redraw area
+        viewer2.invalidateTextPresentation(cachedStyleRange.start, cachedStyleRange.length)
+      case _ =>
+        viewer.invalidateTextPresentation()
+    }
+  }
+
+  /** Create the style range to highlight the part that would be overwritten
+   *  by this completion.
+   *
+   *  @note It uses the same settings as Java for the foreground/background color
+   */
+  private def createStyleRange(viewer: ITextViewer): StyleRange = {
+    val text = viewer.getTextWidget()
+    if (text == null || text.isDisposed())
+      return null
+
+    val widgetCaret = text.getCaretOffset()
+
+    var modelCaret = 0
+    viewer match {
+      case viewer2: ITextViewerExtension5 =>
+        modelCaret = viewer2.widgetOffset2ModelOffset(widgetCaret)
+      case _ =>
+        val visibleRegion = viewer.getVisibleRegion()
+        modelCaret = widgetCaret + visibleRegion.getOffset()
+    }
+
+    if (modelCaret > startPos + completion.length)
+      return null
+
+    val region = existingIdentifier(viewer.getDocument(), modelCaret)
+    val length = startPos + region.getLength() - modelCaret
+
+    new StyleRange(modelCaret, length, getForegroundColor, getBackgroundColor)
+  }
+
+  private def existingIdentifier(doc: IDocument, offset: Int): IRegion = {
+    ScalaWordFinder.findWord(doc, offset)
+  }
+
+  private var viewer: ITextViewer = null
+
+  object presListener extends ITextPresentationListener {
+    override def applyTextPresentation(textPresentation: TextPresentation) {
+      if (viewer ne null) {
+        cachedStyleRange = createStyleRange(viewer)
+        if (cachedStyleRange != null)
+          textPresentation.mergeStyleRange(cachedStyleRange)
+      }
+    }
+  }
+
+  def validate(doc: IDocument, offset: Int, event: DocumentEvent): Boolean = {
+    isValidFor(doc, offset)
+  }
 }
 
 object ScalaCompletionProposal {
@@ -240,4 +348,20 @@ object ScalaCompletionProposal {
   val packageImage = JavaPluginImages.get(JavaPluginImages.IMG_OBJS_PACKAGE)
 
   def apply(selectionProvider: ISelectionProvider)(proposal: CompletionProposal) = new ScalaCompletionProposal(proposal, selectionProvider)
+
+  def insertCompletion(): Boolean = {
+    val preference = JavaPlugin.getDefault().getPreferenceStore()
+    preference.getBoolean(PreferenceConstants.CODEASSIST_INSERT_COMPLETION)
+  }
+
+  private def colorFor(name: String) = {
+    val preference = JavaPlugin.getDefault().getPreferenceStore()
+    val rgb = PreferenceConverter.getColor(preference, name)
+    val textTools = JavaPlugin.getDefault().getJavaTextTools()
+    textTools.getColorManager().getColor(rgb)
+  }
+
+  def getForegroundColor(): Color = colorFor(PreferenceConstants.CODEASSIST_REPLACEMENT_FOREGROUND)
+
+  def getBackgroundColor(): Color = colorFor(PreferenceConstants.CODEASSIST_REPLACEMENT_BACKGROUND)
 }


### PR DESCRIPTION
Allow completions to overwrite existing code. The user can
toggle between insert and overwrite modes by pressing `Ctrl`,
just like in the Java editor. This also respects the Java
editor option for preferring inserts always.

In addition to replacing the existing identifier, we also suppress
the linked mode for arguments (since likely the existing arguments
are not valid, but also we can't erase them, as they may be useful).
This is the same behaviour as in the Java editor

Fix #1000569
