### PR TITLE
Correct completion for no-args method

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
@@ -259,4 +259,25 @@ class CompletionTests {
       }
     }
   }
+
+  @Test
+  def empty_parens_completion_ticket1001766() {
+    withCompletions("ticket_1001766/Ticket1001766.scala") {
+      (index, position, completions) =>
+        index match {
+        case 0 =>
+          assertTrue("The completion should return the `buz` method name with empty-parens", completions.exists {
+            case CompletionProposal(MemberKind.Def, _, "buz", _, _, _, _, getParamNames, _, _, _) =>
+              getParamNames() == List(Nil) // List(Nil) is how an empty-args list is encoded
+        })
+        case 1 =>
+          assertTrue("The completion should return the `bar` method name with NO empty-parens", completions.exists {
+            case CompletionProposal(MemberKind.Def, _, "bar", _, _, _, _, getParamNames, _, _, _) =>
+              getParamNames() == Nil
+          })
+        case _ =>
+          assert(false, "Unhandled completion position")
+      }
+    }
+  }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/completion/src/ticket_1001766/Ticket1001766.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/completion/src/ticket_1001766/Ticket1001766.scala
@@ -1,0 +1,15 @@
+package ticket_1001766
+
+class Ticket1001766 {
+  /* Test 1 */
+  def buz() = ()
+
+  // this should be completed with empty-parens
+  buz /*!*/
+
+  /* Test 2 */
+  def bar = ()
+
+  // this should be completed without adding empty-parens
+  bar /*!*/
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -307,7 +307,7 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
 
     val namesAndTypes = for {
       section <- sym.paramss
-      if section.nonEmpty && !section.head.isImplicit
+      if section.isEmpty || !section.head.isImplicit
     } yield for (param <- section) yield (param.name.toString, param.tpe.toString)
 
     val (scalaParamNames, paramTypes) = namesAndTypes.map(_.unzip).unzip


### PR DESCRIPTION
Method are now completed according to their definition, i.e., if the method was
declared with parens, the completion engine inserts the empty parens.

Fix #1001766
