### PR TITLE
[backport] Tuned ``MainClassVerifier`` to consider classfiles instead of sourcefile...

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/launching/MainClassVerifierTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/launching/MainClassVerifierTest.scala
@@ -90,20 +90,35 @@ class MainClassVerifierTest {
         && delegate.finalLaunchCheck(config, ILaunchManager.DEBUG_MODE, new NullProgressMonitor))
   }
 
+  /** Test that an error is reported if the `mainTypeName` is a class (it ought to be an `object`).*/
   @Test
-  def reportErrorWhenPackageDeclarationInMainTypeDoesntMatchPhysicalLocation() {
+  def reportErrorWhenMainIsInScalaClass() {
+    val pkg = ""
+    val mainName = "Main"
+    val main = "class %s extends App".format(mainName) // note: need an object, not a class!
+
+    createSource(pkg, mainName, main)
+    val mainTypeName = mainName // this is the correct fully-qualified name
+
+    runTest(mainTypeName, main, times(1))
+  }
+
+  /** Test that an error is reported if the `mainTypeName` used to run the code does not match the binary location.*/
+  @Test
+  def reportErrorWhenPackageDeclarationInMainTypeDoesntMatchBinaryLocation_inEmptyPackage() {
     val pkg = "foo"
     val mainName = "Main"
     val main = "object %s extends App".format(mainName) // note: no package declaration here!
 
     createSource(pkg, mainName, main) // source is created in foo/ (look at the value of `pkg`)
-    val mainTypeName = mainName // this is the correct fully-qualified name
+    val mainTypeName = pkg + "." + mainName // this is NOT the correct fully-qualified name
 
     runTest(mainTypeName, main, times(1))
   }
-  
+
+  /** Test that an error is reported if the `mainTypeName` used to run the code does not match the binary location.*/
   @Test
-  def reportErrorWhenPackageDeclarationInMainTypeDoesntMatchPhysicalLocation2() {
+  def reportErrorWhenPackageDeclarationInMainTypeDoesntMatchBinaryLocation_inNonEmptyPackage() {
     val sourceLocation = "foo"
     val pkg = "bar"
     val mainName = "Main"
@@ -113,9 +128,39 @@ class MainClassVerifierTest {
     """.format(pkg, mainName) // note: no package declaration here!
 
     createSource(sourceLocation, mainName, main) // source is created in foo/
-    val mainTypeName = pkg + "." + mainName // this is the correct fully-qualified name
+    val mainTypeName = sourceLocation + "." + mainName // this is NOT the correct fully-qualified name
 
     runTest(mainTypeName, main, times(1))
+  }
+
+  /** Test that no error is reported if the `mainTypeName` used to run the code matches the binary location.*/
+  @Test
+  def doNotReportErrorWhenPackageDeclarationInMainTypeMatchBinaryLocation_inEmptyPackage() {
+    val pkg = "foo"
+    val mainName = "Main"
+    val main = "object %s extends App".format(mainName) // note: no package declaration here!
+
+    createSource(pkg, mainName, main) // source is created in foo/ (look at the value of `pkg`)
+    val mainTypeName = mainName // this is the correct fully-qualified name
+
+    runTest(mainTypeName, main, never())
+  }
+
+  /** Test that no error is reported if the `mainTypeName` used to run the code matches the binary location.*/
+  @Test
+  def doNotReportErrorWhenPackageDeclarationInMainTypeMatchBinaryLocation_inNonEmptyPackage() {
+    val sourceLocation = "foo"
+    val pkg = "bar"
+    val mainName = "Main"
+    val main = """
+      package %s
+      object %s extends App
+    """.format(pkg, mainName)
+
+    createSource(sourceLocation, mainName, main) // source is created in foo/
+    val mainTypeName = pkg + "." + mainName // this is the correct fully-qualified name
+
+    runTest(mainTypeName, main, never())
   }
 
   @Test

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchDelegate.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchDelegate.scala
@@ -119,7 +119,7 @@ class ScalaLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
       ScalaPlugin.plugin.asScalaProject(project.getProject) map { scalaProject =>
         val mainClassVerifier = new MainClassVerifier(new UIErrorReporter)
         val status = mainClassVerifier.execute(scalaProject, mainTypeName)
-        status.getCode() == IStatus.OK
+        status.isOK
       } getOrElse false
     }
   }


### PR DESCRIPTION
...s

The Problem
+++++++++++

With the former implementation, an error was reported every time the _package
name in the source did not match the source's physical location_. This is too
eager, in fact the two don't need to be in sync for the user to be able to
launch a Scala Application.

However, despite the error dialog, the Scala Main class was still run. The
reason for this is that there was a double bug! (I'm gonna name tihs one
_hadouken-bug_) [This
line](https://github.com/scala-ide/scala-ide/pull/444/files#L2L122) was always
returning `true`. What that line wanted to check is the `IStatus.severity`
field, but it was actually comparing the `IStatus.code` (the IStatus
interface is definitely not the cleanest API ever, can't really blame people
for getting confused...).

The Solution
++++++++++++

The minimal condition for running a Scala Application is that the class' Main
binary exists. Hence, I've updated the code to reflect this requirement.

Moreover, if a class file for the `mainTypeName` exist, but no companion
module class file can be found, an error is now reported to inform the user
that he needs to change the class declaration into an object.

Fix #1001760
