### PR TITLE
Depend on mockito-core instead of mockito-all in the integration test projects.

### DIFF
--- a/org.scala-ide.sdt.core.tests/pom.xml
+++ b/org.scala-ide.sdt.core.tests/pom.xml
@@ -12,7 +12,7 @@
   <dependencies>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/org.scala-ide.sdt.debug.tests/pom.xml
+++ b/org.scala-ide.sdt.debug.tests/pom.xml
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
     

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,18 @@
         <version>${mockito.version}</version>
         <scope>compile</scope>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Additionally, exclude dependency on org.hamcrest:hamcrest-core.

This fixes test failures on Kepler caused by conflicting versions of
hamcrest-core present on classpath: version 1.1 embedded in mockito-all and
version 1.3 pulled in as P2 dependency.
