### PR TITLE
Fix create method quickfix exception

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickFixProcessor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickFixProcessor.scala
@@ -33,6 +33,7 @@ import scala.tools.eclipse.logging.HasLogger
 import scala.tools.eclipse.quickfix.createmethod.CreateMethodProposal
 import scala.tools.refactoring.implementations.AddToClass
 import scala.tools.refactoring.implementations.AddToObject
+import scala.tools.refactoring.implementations.AddToClosest
 
 // Scala
 import scala.util.matching.Regex
@@ -101,7 +102,7 @@ class ScalaQuickFixProcessor extends IQuickFixProcessor with HasLogger {
     val possibleMatch = problemMessage match {
       case valueNotAMemberOfObject(member, theType) => List(CreateMethodProposal(Some(theType), member, AddToObject, compilationUnit, pos))
       case valueNotAMember(member, theType) => List(CreateMethodProposal(Some(theType), member, AddToClass, compilationUnit, pos))
-      case valueNotFoundError(member) => List(CreateMethodProposal(None, member, AddToClass, compilationUnit, pos))
+      case valueNotFoundError(member) => List(CreateMethodProposal(None, member, AddToClosest(pos.offset), compilationUnit, pos))
       case _ => Nil
     }
     possibleMatch.filter(_.isApplicable)


### PR DESCRIPTION
The create method quickfix failed with an exception (calling None.get) when the error message triggering the quickfix was "not found: value <method name>".
This is because we would mistakenly tell the refactoring library that the target was always a class, even though it could have been something else (eg, an object).
The scala-refactoring library now supports targetting the definition by offset, so we use that here.

Fix #1001740
