### PR TITLE
ScalaCodeTokenizer.tokenize takes String instead of IDocument.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaCodeScannerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaCodeScannerTest.scala
@@ -39,7 +39,7 @@ class ScalaCodeScannerTest {
     }
 
     val document = new MockDocument(str)
-    val token = scanner.tokenize(document.get(), offset, length) map {
+    val token = scanner.tokenize(document.get(offset, length), offset) map {
       case scanner.Range(start, length, syntaxClass) =>
         (syntaxClass, start, length)
     }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
@@ -30,7 +30,7 @@ class ScalaCodeScanner(
   private var offset: Int = _
 
   def setRange(document: IDocument, offset: Int, length: Int) {
-    ranges = tokenize(document.get(), offset, length)
+    ranges = tokenize(document.get(offset, length), offset)
     index = 0
 
     if (!ranges.isEmpty) {
@@ -75,13 +75,17 @@ trait ScalaCodeTokenizer {
 
   /** Tokenizes a string given by its offset and length in a document. */
   @deprecated
-  def tokenize(document: IDocument, offset: Int, length: Int): IndexedSeq[Range] = 
-    tokenize(document.get(), offset, length)
+  def tokenize(document: IDocument, offset: Int, length: Int): IndexedSeq[Range] =
+    tokenize(document.get(offset, length))
 
-  /** Tokenizes a string given by its offset and length in a document. */
-  def tokenize(contents: String, offset: Int, length: Int): IndexedSeq[Range] = {
-    val source = contents.substring(offset, offset + length)
-    val token = ScalaLexer.createRawLexer(source, forgiveErrors = true).toIndexedSeq.init
+  /**
+   * Tokenizes a string.
+   *
+   * @param contents - the string to tokenize
+   * @param offset - If `contents` is a snippet within a larger document, use `offset` to indicate it `contents` offset within the larger document so that resultant tokens are properly positioned with respect to the larger document.
+   */
+  def tokenize(contents: String, offset: Int = 0): IndexedSeq[Range] = {
+    val token = ScalaLexer.createRawLexer(contents, forgiveErrors = true).toIndexedSeq.init
 
     /**
      * Heuristic to distinguish the macro keyword from uses as an identifier. To be 100% accurate requires a full parse,


### PR DESCRIPTION
ScalaCodeTokenizer.tokenize asked for a IDocument only to right away get the IDocument's contents and then never use it [the IDocument] again. It makes more sense to just take the contents as a string directly, which is what this change does.
