### PR TITLE
Fix potential resource leak caused by missing socket close statement

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/spy/TcpipSpy.java
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/spy/TcpipSpy.java
@@ -100,10 +100,12 @@ public class TcpipSpy extends Thread {
 			}
 		}
 		out.println();
+		ServerSocket serverSock = null;
+		Socket outSock = null;
 		try {
-			ServerSocket serverSock = new ServerSocket(inPort);
+			serverSock = new ServerSocket(inPort);
 			Socket inSock = serverSock.accept();
-			Socket outSock = new Socket(InetAddress.getByName(serverHost),
+			outSock = new Socket(InetAddress.getByName(serverHost),
 					outPort);
 			Thread inThread = new TcpipSpy(listenMode, inSock.getInputStream(),
 					outSock.getOutputStream());
@@ -117,6 +119,17 @@ public class TcpipSpy extends Thread {
 			outThread.join();
 		} catch (Exception e) {
 			out.println(e);
+		} finally {
+			try {
+				if (serverSock != null) {
+					serverSock.close();
+				}
+			} catch (IOException e) {}
+			try {
+				if (outSock != null) {
+					outSock.close();
+				}
+			} catch (Exception e) {}
 		}
 	}
 


### PR DESCRIPTION
Eclipse Keplers error detection is updated. It told me that this is a resource leak. It shouldn't matter because the application is closed afterwards but a potential resource leak is a potential resource leak.

Btw, I didn't use the enhanced try of Java7, didn't know if you want to keep Java6 compatibility. Do you?
