### PR TITLE
Refactorings for quickfixes

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/RelevanceValues.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/RelevanceValues.scala
@@ -1,0 +1,22 @@
+package scala.tools.eclipse.completion
+
+object RelevanceValues {
+
+  final val ProposalRefactoringActionAdapter = 100
+
+  final val ExpandingProposalBase = 100
+
+  final val ImportCompletionProposal = 100
+
+  /**
+   * Relevance should be less than [[ImportCompletionProposal]] since import quick
+   * fix should be first.
+   */
+  final val CreateClassProposal = 90
+
+  /**
+   * Should be higher than most others, because you probably want to correct the
+   * method/field name rather than create a new one.
+   */
+  final val ChangeCaseProposal = 95
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/BasicCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/BasicCompletionProposal.scala
@@ -6,6 +6,18 @@ import org.eclipse.jface.text.contentassist.IContextInformation
 import org.eclipse.swt.graphics.Image
 import org.eclipse.swt.graphics.Point
 
+/**
+ * Models an entry in the completion proposal.
+ *
+ * @param relevance
+ *        Denotes at which position in among all available entries this entry occurs.
+ *        A higher value means a better position. For a better overview on the current
+ *        ordering, this value should be stored in [[scala.tools.eclipse.completion.RelevanceValues]].
+ * @param displayString
+ *        A text of explanation shown in the completion proposal.
+ * @param image
+ *        An image shown beside the [displayString]. If this is null no image is shown.
+ */
 abstract class BasicCompletionProposal(relevance: Int, displayString: String, image: Image = null) extends IJavaCompletionProposal {
   override def getRelevance = relevance
   override def getDisplayString(): String = displayString

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ChangeCaseProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ChangeCaseProposal.scala
@@ -3,10 +3,10 @@ package scala.tools.eclipse.quickfix
 import scala.reflect.internal.util.RangePosition
 import scala.tools.eclipse.ScalaImages
 import scala.tools.eclipse.javaelements.ScalaCompilationUnit
-
 import org.eclipse.jdt.core.ICompilationUnit
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.Position
+import scala.tools.eclipse.completion.RelevanceValues
 
 /*
  * Find another member with the same spelling but different capitalization.
@@ -14,7 +14,7 @@ import org.eclipse.jface.text.Position
  */
 
 case class ChangeCaseProposal(originalName: String, newName: String, pos: Position) extends BasicCompletionProposal(
-  relevance = 95, //should be higher than most others, because you probably want to correct the method/field name rather than create a new one
+  relevance = RelevanceValues.ChangeCaseProposal,
   displayString = s"Change to '${newName}'",
   image = ScalaImages.CORRECTION_RENAME.createImage()) {
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/CreateClassProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/CreateClassProposal.scala
@@ -1,6 +1,7 @@
 package scala.tools.eclipse.quickfix
 
 import scala.tools.eclipse.ScalaImages
+import scala.tools.eclipse.completion.RelevanceValues
 import scala.tools.eclipse.wizards.NewClassWizard
 import scala.tools.eclipse.wizards.NewClassWizardPage
 
@@ -13,7 +14,7 @@ import org.eclipse.jface.wizard.WizardDialog
 
 case class CreateClassProposal(className: String, compilationUnit: ICompilationUnit)
   extends BasicCompletionProposal(
-    relevance = 90, //relevance should be less than ImportCompletionProposal since import quick fix should be first
+    relevance = RelevanceValues.CreateClassProposal,
     displayString = s"Create class '$className'",
     image = ScalaImages.NEW_CLASS.createImage()) {
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandingProposalBase.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandingProposalBase.scala
@@ -1,19 +1,15 @@
 package scala.tools.eclipse
 package quickfix
 
-import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
-import org.eclipse.jface.text.IDocument
-import org.eclipse.jface.text.contentassist.IContextInformation
-import org.eclipse.swt.graphics.Image
-import org.eclipse.swt.graphics.Point
-import org.eclipse.jface.text.TextUtilities
-import org.eclipse.jdt.ui.text.java.IProblemLocation
-import org.eclipse.jface.text.Position
-import scala.util.matching.Regex
+import scala.tools.eclipse.completion.RelevanceValues
 import scala.tools.eclipse.semantichighlighting.implicits.ImplicitHighlightingPresenter
+import scala.tools.eclipse.util.Utils
+
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.text.Position
 
 class ExpandingProposalBase(msg: String, displayString: String, pos: Position)
-  extends BasicCompletionProposal(relevance = 100, displayString = displayString + msg) {
+  extends BasicCompletionProposal(relevance = RelevanceValues.ExpandingProposalBase, displayString = displayString + msg) {
 
   /**
    * Inserts the proposed completion into the given document.
@@ -21,9 +17,9 @@ class ExpandingProposalBase(msg: String, displayString: String, pos: Position)
    * @param document the document into which to insert the proposed completion
    */
   def apply(document: IDocument): Unit = {
+    import Utils._
     // We extract the replacement string from the marker's message.
-    val ReplacementExtractor = new Regex("(?s).*"+ ImplicitHighlightingPresenter.DisplayStringSeparator +"(.*)")
-    val ReplacementExtractor(replacement) = msg
+    val r"(?s).*${ImplicitHighlightingPresenter.DisplayStringSeparator}(.*)$replacement" = msg
     document.replace(pos.getOffset(), pos.getLength(), replacement);
   }
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ImportCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ImportCompletionProposal.scala
@@ -9,17 +9,14 @@ import org.eclipse.jface.text.TextUtilities
 import org.eclipse.jface.text.IDocument
 import org.eclipse.swt.graphics.Point
 import org.eclipse.swt.graphics.Image
-
 import scala.tools.eclipse.refactoring.EditorHelpers
 import scala.tools.eclipse.logging.HasLogger
 import scala.tools.refactoring.implementations.AddImportStatement
+import scala.tools.eclipse.completion.RelevanceValues
 
 case class ImportCompletionProposal(val importName: String) extends IJavaCompletionProposal with HasLogger {
 
-  /**
-   * Fixed relevance at 100 for now.
-   */
-  def getRelevance = 100
+  def getRelevance = RelevanceValues.ImportCompletionProposal
 
   /**
    * Inserts the proposed completion into the given document.

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ProposalRefactoringActionAdapter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ProposalRefactoringActionAdapter.scala
@@ -11,11 +11,12 @@ import scala.tools.eclipse.refactoring.rename.RenameAction
 import scala.tools.eclipse.refactoring.ScalaIdeRefactoring
 import scala.tools.eclipse.logging.HasLogger
 import org.eclipse.core.runtime.NullProgressMonitor
+import scala.tools.eclipse.completion.RelevanceValues
 
 abstract class ProposalRefactoringActionAdapter(
     action: ActionAdapter,
     displayString: String,
-    relevance: Int = 100)
+    relevance: Int = RelevanceValues.ProposalRefactoringActionAdapter)
   extends BasicCompletionProposal(relevance, displayString) {
 
   override def apply(document: IDocument): Unit = {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/EditorUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/EditorUtils.scala
@@ -13,7 +13,7 @@ import org.eclipse.ui.texteditor.ITextEditor
 import scala.tools.eclipse.InteractiveCompilationUnit
 import scala.tools.eclipse.ui.InteractiveCompilationUnitEditor
 
-// FIXME: This should be merged with merged with {{{scala.tools.eclipse.refactoring.EditorHelpers}}}
+// FIXME: This should be merged with merged with [[scala.tools.eclipse.refactoring.EditorHelpers]]
 object EditorUtils {
 
   def openEditorAndApply[T](element: IJavaElement)(editor: IEditorPart => T): T =

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
@@ -25,7 +25,7 @@ object Utils extends HasLogger {
     val res = op
     val end = System.currentTimeMillis
 
-    logger.debug("%s: \t %,3d ms".format(name, end - start))
+    logger.debug(f"$name: \t ${end-start}%,3d ms")
     res
   }
 
@@ -50,6 +50,10 @@ object Utils extends HasLogger {
       val typeOfObj = m.reflect(obj).symbol.toType
       if (typeOfObj <:< typeOf[B]) Some(obj.asInstanceOf[B]) else None
     }
+  }
+
+  implicit class RichRegex(sc: StringContext) {
+    def r = new util.matching.Regex(sc.parts.mkString, sc.parts.tail.map(_ => "x"): _*)
   }
 
 }


### PR DESCRIPTION
The relevance of quickfixes for the completion proposal is moved
to its own location in order to keep a better overview over them.
