### PR TITLE
Deprecated ScalaCodeScanner.tokenize(IDocument, Int, Int) incorrectly handled offset in generated tokens.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaCodeScannerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScalaCodeScannerTest.scala
@@ -83,6 +83,21 @@ class ScalaCodeScannerTest {
   }
 
   @Test
+  def correct_offset() {
+    val str = "return"
+    val offset = 3 // arbitrary non-zero number
+
+    val scanner = new ScalaCodeTokenizer { val scalaVersion = ScalaVersions.DEFAULT }
+    val document = new MockDocument(str)
+    val token = scanner.tokenize(document.get(0, str.length), offset) map {
+      case scanner.Range(start, length, syntaxClass) =>
+        (syntaxClass, start, length)
+    }
+
+    token.toList == Seq((RETURN, 3, 6))
+  }
+
+  @Test
   def return_keyword() {
     tokenize("return") === Seq((RETURN, 0, 6))
   }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScalaCodeScanner.scala
@@ -76,7 +76,7 @@ trait ScalaCodeTokenizer {
   /** Tokenizes a string given by its offset and length in a document. */
   @deprecated
   def tokenize(document: IDocument, offset: Int, length: Int): IndexedSeq[Range] =
-    tokenize(document.get(offset, length))
+    tokenize(document.get(offset, length), offset)
 
   /**
    * Tokenizes a string.


### PR DESCRIPTION
This fixes a bug I introduced in the ScalaCodeScanner.tokenize in this PR https://github.com/scala-ide/scala-ide/pull/462

Essentially, the API I deprecated wasn't forwarding the offset parameter to the new API.

I've also included a new test for this.
