### PR TITLE
Updated version of Sbt dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <!-- fixed versions -->
     <sbt.version>Select a profile</sbt.version>
-    <sbinary.version>0.4.1-pretending-SNAPSHOT</sbinary.version>
+    <sbinary.version>0.4.2-SNAPSHOT</sbinary.version>
     <jline.version>2.10</jline.version>
     <ivy.version>2.2.0</ivy.version>
     <miglayout.version>3.7.4</miglayout.version>
@@ -76,18 +76,10 @@
     <profile>
       <id>scala-2.10.x</id>
       <properties>
-        <scala.version>2.10.2-SNAPSHOT</scala.version>
+        <scala.version>2.10.3-SNAPSHOT</scala.version>
         <scala.era.major.version>2.10</scala.era.major.version>
         <version.suffix>2_10</version.suffix>
-        <!-- The version is odd, but correct. We need the `SNAPSHOT` in the sbt version
-            because we need to grab the latest Sbt artifacts compiled against the latest
-            Scala 2.10.2-SNAPSHOT.
-            If you want to build the Scala IDE against Scala 2.10.0 or Scala 2.10.1, make
-            sure to pass -Dsbt.version=0.13.0-M2 to the build script (no SNAPSHOT is needed
-            in this case because the Scala version is stable!)
-        <sbt.version>0.13.0-M2-SNAPSHOT</sbt.version>
-        -->
-        <sbt.version>0.13.0-SNAPSHOT</sbt.version> <!-- We use Sbt 0.13 master because of source-incompatible changes in master -->
+        <sbt.version>0.13.0-RC3-SNAPSHOT</sbt.version>
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-210x</repo.scala-refactoring>
         <repo.scalariform>${repo.scala-ide.root}/scalariform-210x</repo.scalariform>
@@ -101,7 +93,7 @@
         <scala.version>2.11.0-SNAPSHOT</scala.version>
         <scala.era.major.version>2.11</scala.era.major.version>
         <version.suffix>2_11</version.suffix>
-        <sbt.version>0.13.0-SNAPSHOT</sbt.version> <!-- We use Sbt 0.13 master for building against Scala 2.11.0-SNAPSHOT -->
+        <sbt.version>0.13.1-SNAPSHOT</sbt.version>
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-211x</repo.scala-refactoring>
         <repo.scalariform>${repo.scala-ide.root}/scalariform-211x</repo.scalariform>


### PR DESCRIPTION
Updated version of Sbt dependencies to 0.13.0-RC3-SNAPSHOT.
The odd version number is due to the fact that we rebuild
Sbt artifacts every night against the latest Scala
2.10.3-SNAPSHOT and 2.11.0-SNAPSHOT, and hence the trailing
SNAPSHOT is needed to make Maven happy.
