### PR TITLE
Updated version of Sbt dependencies to use 0.13.0-RC3

### DIFF
--- a/org.scala-ide.sbt.full.library/.classpath
+++ b/org.scala-ide.sbt.full.library/.classpath
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/api_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/classfile_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/classpath_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/compile_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/compiler-integration_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/compiler-interface_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/control_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/incremental-compiler_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/interface_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/io_2.10.2-SNAPSHOT.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/api_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/classfile_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/classpath_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/compile_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/compiler-integration_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/compiler-interface_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/control_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/incremental-compiler_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/interface_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/io_2.10.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jline.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/logging_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/persist_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/process_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/relation_2.10.2-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/sbinary_2.10.2-SNAPSHOT.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/logging_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/persist_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/process_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/relation_2.10.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/sbinary_2.10.2.jar"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/SbtBuildReporter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/SbtBuildReporter.scala
@@ -9,7 +9,7 @@ import scala.tools.eclipse.util.EclipseResource
 
 /**  An Sbt Reporter that forwards to an underlying [[BuildReporter]]
  */
-private[sbtintegration] class SbtBuildReporter(underlying: BuildReporter) extends xsbti.ExtendedReporter {
+private[sbtintegration] class SbtBuildReporter(underlying: BuildReporter) extends xsbti.Reporter {
   val probs = new mutable.ArrayBuffer[xsbti.Problem]
   
   def reset() = {

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <!-- fixed versions -->
     <sbt.version>Select a profile</sbt.version>
-    <sbinary.version>0.4.1-pretending-SNAPSHOT</sbinary.version>
+    <sbinary.version>0.4.2-SNAPSHOT</sbinary.version>
     <jline.version>2.10</jline.version>
     <ivy.version>2.2.0</ivy.version>
     <miglayout.version>3.7.4</miglayout.version>
@@ -75,17 +75,10 @@
     <profile>
       <id>scala-2.10.x</id>
       <properties>
-        <scala.version>2.10.2-SNAPSHOT</scala.version>
+        <scala.version>2.10.2</scala.version>
         <scala.era.major.version>2.10</scala.era.major.version>
         <version.suffix>2_10</version.suffix>
-        <!-- The version is odd, but correct. We need the `SNAPSHOT` in the sbt version
-            because we need to grab the latest Sbt artifacts compiled against the latest
-            Scala 2.10.2-SNAPSHOT.
-            If you want to build the Scala IDE against Scala 2.10.0 or Scala 2.10.1, make
-            sure to pass -Dsbt.version=0.13.0-M2 to the build script (no SNAPSHOT is needed
-            in this case because the Scala version is stable!)
-        -->
-        <sbt.version>0.13.0-M2-SNAPSHOT</sbt.version>
+        <sbt.version>0.13.0-RC3-SNAPSHOT</sbt.version>
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-210x</repo.scala-refactoring>
         <repo.scalariform>${repo.scala-ide.root}/scalariform-210x</repo.scalariform>
@@ -99,7 +92,7 @@
         <scala.version>2.11.0-SNAPSHOT</scala.version>
         <scala.era.major.version>2.11</scala.era.major.version>
         <version.suffix>2_11</version.suffix>
-        <sbt.version>0.13.0-SNAPSHOT</sbt.version> <!-- We use Sbt 0.13 master for building against Scala 2.11.0-SNAPSHOT -->
+        <sbt.version>0.13.1-SNAPSHOT</sbt.version>
 
         <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-211x</repo.scala-refactoring>
         <repo.scalariform>${repo.scala-ide.root}/scalariform-211x</repo.scalariform>


### PR DESCRIPTION
- Updated Scala version to 2.10.2 (2.10.2-SNAPSHOT can no longer be resolved,
  which is why some people in the community have reported issues building)
- Updated version of Sbt dependencies to 0.13.0-RC3-SNAPSHOT (when building
  against Scala 2.10.2), and 0.13.1-SNAPSHOT (when building against
  Scala 2.11.0-SNAPSHOT).  The odd version number is due to the fact that we
  rebuild Sbt artifacts every night against the latest Scala 2.10.3 and
  2.11.0-SNAPSHOT, and hence the trailing SNAPSHOT is needed to make Maven happy.
  Also, sbinary version is now 0.4.2-SNAPSHOT because that is the version used
  by Sbt 0.13.0-RC3.
  The reason for moving the 3.0.x release branch to Sbt 0.13.0-RC3 is that an
  important fix related to cancellation was fixed in Sbt (more details in
  https://github.com/sbt/sbt/pull/821)
  (cherry picked from commit 3b7d628b8439082c9e7cc4b4400aac18e3f2f01a)
- Fix build for latest changes to Sbt 0.13.0-RC3. That is not a problem,
  as the next release off this branch would be on the next
  final 0.13.0 Sbt release.
  (cherry picked from commit c4f66e5324a014d7587b4bdfaa9a47f7b3a221b5)
- Updated `org.scala-ide.sbt.full.library` .classpath
