### PR TITLE
Resolve exception when using type mismatch quick fix

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandingProposalBase.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ExpandingProposalBase.scala
@@ -17,10 +17,10 @@ class ExpandingProposalBase(msg: String, displayString: String, pos: Position)
    * @param document the document into which to insert the proposed completion
    */
   def apply(document: IDocument): Unit = {
-    import Utils._
     // We extract the replacement string from the marker's message.
-    val r"(?s).*${ImplicitHighlightingPresenter.DisplayStringSeparator}(.*)$replacement" = msg
-    document.replace(pos.getOffset(), pos.getLength(), replacement);
+    val ReplacementExtractor = s"(?s).*${ImplicitHighlightingPresenter.DisplayStringSeparator}(.*)".r
+    val ReplacementExtractor(replacement) = msg
+    document.replace(pos.getOffset(), pos.getLength(), replacement)
   }
 
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Utils.scala
@@ -51,9 +51,4 @@ object Utils extends HasLogger {
       if (typeOfObj <:< typeOf[B]) Some(obj.asInstanceOf[B]) else None
     }
   }
-
-  implicit class RichRegex(sc: StringContext) {
-    def r = new util.matching.Regex(sc.parts.mkString, sc.parts.tail.map(_ => "x"): _*)
-  }
-
 }


### PR DESCRIPTION
This is a regression due to refactorings in 8f42b9de31c9365d6f9c.

The regex that was used to check an internal message was updated to
work with Scalas new string interpolation feature. Unfortunately,
while the regex was the same the semantics changed because it was
tried to insert and extract a value into and from the string
interpolator at the same time, which is in this situation not possible.

Fixes #1001809
