### PR TITLE
Removes reference to non-existing command

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -627,7 +627,6 @@
           objectClass="org.eclipse.core.resources.IProject">
         <action
              class="scala.tools.eclipse.actions.RestartPresentationCompilerAction"
-             definitionId="org.scala-ide.sdt.core.action.restartScalaPresentationCompiler"
              enablesFor="+"
              id="org.scala-ide.sdt.core.action.restartScalaPresentationCompiler"
              label="Restart Presentation Compiler"


### PR DESCRIPTION
As no command exists for this action, the attribute `definitionId` should not be set.

review @dotta

Fixes #1001807
