### PR TITLE
[Backport] Sync 'isDefined' in presentation compiler cache.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Cached.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Cached.scala
@@ -15,7 +15,7 @@ package scala.tools.eclipse.util
  */
 trait Cached[T] {
   private var inProgress = false
-  @volatile private var elem: Option[T] = None
+  private var elem: Option[T] = None
 
   def apply[U](op: T => U): U = {
     val e = synchronized {
@@ -42,7 +42,7 @@ trait Cached[T] {
   }
   
   /** Is the cached object initialized, at this point in time? */
-  def initialized: Boolean = elem.isDefined
+  def initialized: Boolean = synchronized { elem.isDefined }
 
   def invalidate() {
     val oldElem = synchronized {


### PR DESCRIPTION
This fixes one race condition when hyperlinking between projects. Project
'client' depends on project 'base'. The sequence of events was:
- dependent project 'base' starts building
- the indexer for `client` kicks in and starts the PC. The PC is not
  yet initialized. PC starts without `base` classfiles on its class path
- `base` finished building and triggers a reset of the PC for `client`,
  that normally restarts with `base` classfiles on the class path
- reset is ignored (PC is still starting, and `isDefined` returns false)
- hyperlinking fails, because the target is not available on the class path
