### PR TITLE
Highlights Scaladoc macros that are wrapped in braces

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScaladocTokenScannerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/lexical/ScaladocTokenScannerTest.scala
@@ -116,7 +116,7 @@ class ScaladocTokenScannerTest {
     groupedToken
   }
 
-  class Assert_===[A](actual: A) {
+  implicit class Assert_===[A](actual: A) {
     def ===(expected: A) {
       if (actual != expected)
         throw new ComparisonFailure("actual != expected,",
@@ -124,7 +124,6 @@ class ScaladocTokenScannerTest {
           actual.toString())
     }
   }
-  implicit def Assert_===[A](actual: A): Assert_===[A] = new Assert_===(actual)
 
   @Test
   def no_annotation() {
@@ -232,6 +231,12 @@ class ScaladocTokenScannerTest {
   def single_task_tag() {
     val res = tokenize("/**TODO*/")
     res === Seq((scaladocAtt, 0, 3), (taskTagAtt, 3, 4), (scaladocAtt, 7, 2))
+  }
+
+  @Test
+  def braces_macro() {
+    val res = tokenize("/**${abc}d*/")
+    res === Seq((scaladocAtt, 0, 3), (macroAtt, 3, 6), (scaladocAtt, 9, 3))
   }
 
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScaladocTokenScanner.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/lexical/ScaladocTokenScanner.scala
@@ -6,6 +6,7 @@ import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.text.rules.ICharacterScanner
 import org.eclipse.jface.text.rules.IToken
 import org.eclipse.jface.text.rules.IWordDetector
+import org.eclipse.jface.text.rules.SingleLineRule
 import org.eclipse.jface.text.rules.Token
 import org.eclipse.jface.text.rules.WordRule
 
@@ -36,8 +37,9 @@ class ScaladocTokenScanner(
 
   private val annotationRule = new ScaladocWordRule(new AnnotationDetector, getToken(scaladocClass), getToken(annotationClass))
   private val macroRule = new ScaladocWordRule(new MacroDetector, getToken(scaladocClass), getToken(macroClass))
+  private val bracesMacroRule = new SingleLineRule("${", "}", getToken(macroClass))
 
-  appendRules(Array(annotationRule, macroRule))
+  appendRules(Array(annotationRule, bracesMacroRule, macroRule))
 }
 
 /**


### PR DESCRIPTION
The new rule needs to be placed in front of the normal macro rule
because it starts with the same identifier but contains more
characters to detect. Thus it needs to be detected first.

Fixes #1001836
