### PR TITLE
Fix/cross compiled modules 211

### DIFF
--- a/org.scala-ide.sbt.full.library/pom.xml
+++ b/org.scala-ide.sbt.full.library/pom.xml
@@ -34,8 +34,8 @@
           <artifactId>scala-xml_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-parser-combinators</artifactId>
+          <groupId>org.scala-lang.modules</groupId>
+          <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/org.scala-ide.scala.library/pom.xml
+++ b/org.scala-ide.scala.library/pom.xml
@@ -27,8 +27,8 @@
           <artifactId>scala-xml_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-parser-combinators</artifactId>
+          <groupId>org.scala-lang.modules</groupId>
+          <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
         </dependency>
       </dependencies>
       <build>
@@ -54,8 +54,8 @@
                       <destFileName>scala-xml-src.jar</destFileName>
                     </artifactItem>
                     <artifactItem>
-                      <groupId>org.scala-lang</groupId>
-                      <artifactId>scala-parser-combinators</artifactId>
+                      <groupId>org.scala-lang.modules</groupId>
+                      <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
                       <classifier>sources</classifier>
                       <type>jar</type>
                       <destFileName>scala-parser-combinators-src.jar</destFileName>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
      <scala.version>2.10.0</scala.version>
      <scala.binary.version>2.10</scala.binary.version>
      <scala.xml.version>1.0-RC2</scala.xml.version>
+     <scala.parser-combinators.version>1.0-RC1</scala.parser-combinators.version>
      <scala.library.version>${scala.version}</scala.library.version>
      <version.suffix>2_10</version.suffix>
      <version.tag>local</version.tag>
@@ -353,9 +354,9 @@
         <version>${scala.xml.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-parser-combinators</artifactId>
-        <version>${scala.library.version}</version>
+        <groupId>org.scala-lang.modules</groupId>
+        <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
+        <version>${scala.parser-combinators.version}</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
Switched to cross-compiled modules for 2.11, with the new groupID
- `org.scala-lang.modules % scala-xml_...`
- `org.scala-lang.modules % scala-parser-combinators_...`
