### PR TITLE
Upgrade to scala-maven-plugin 3.1.5, scala-xml 1.0-RC3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
      <!-- default values, can be overwritten by profiles -->
      <scala.version>2.10.0</scala.version>
      <scala.binary.version>2.10</scala.binary.version>
-     <scala.xml.version>1.0-RC2</scala.xml.version>
+     <scala.xml.version>1.0-RC3</scala.xml.version>
      <scala.parser-combinators.version>1.0-RC1</scala.parser-combinators.version>
      <scala.library.version>${scala.version}</scala.library.version>
      <version.suffix>2_10</version.suffix>


### PR DESCRIPTION
This newer version of the scala plugin for maven doesn't crash on a modularized scala (scala/scala#2855).

Full disclosure: I wouldn't go as far as saying that 3.1.5 fully supports a modularized Scala -- a fix is in the works for 3.1.6

When I submitted this, scala-xml hadn't synched to maven central yet (it has now). That reminds me: does the build use the sonatype resolver? Could one be added for faster round-trips?

Review by @dotta
