### PR TITLE
Uses new debug view selection support

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/ScalaDebugTestSession.scala
@@ -26,6 +26,7 @@ import scala.tools.eclipse.debug.model.ScalaValue
 import org.eclipse.jface.viewers.StructuredSelection
 import org.eclipse.jdt.debug.core.IJavaBreakpoint
 import org.junit.Assert
+import org.eclipse.debug.ui.contexts.DebugContextEvent
 
 object EclipseDebugEvent {
   def unapply(event: DebugEvent): Option[(Int, AnyRef)] = Some((event.getKind, event.getSource()))
@@ -97,7 +98,7 @@ class ScalaDebugTestSession private(launchConfiguration: ILaunchConfiguration) e
     this.synchronized {
       currentStackFrame = stackFrame
       val selection = new StructuredSelection(stackFrame)
-      ScalaDebugger.selectionChanged(null, selection)
+      ScalaDebugger.updateCurrentThread(selection)
       state = SUSPENDED
       logger.info("SUSPENDED at: %s:%d".format(stackFrame.getMethodFullName, stackFrame.getLineNumber))
       this.notify

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
@@ -55,7 +55,7 @@ object ScalaDebugModelPresentation {
    */
   private def computeDetail(objectReference: ScalaObjectReference): String = {
     try {
-      objectReference.invokeMethod("toString", "()Ljava/lang/String;", ScalaDebugger.currentThreadOrFindFirstSuspendedThread(objectReference)) match {
+      objectReference.invokeMethod("toString", "()Ljava/lang/String;", ScalaDebugger.currentThread) match {
         case s: ScalaStringReference =>
           s.underlying.value
         case n: ScalaNullValue =>

--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaLogicalStructureProvider.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaLogicalStructureProvider.scala
@@ -59,7 +59,7 @@ object ScalaCollectionLogicalStructureType extends ILogicalStructureType with Ha
 
     val scalaValue = value.asInstanceOf[ScalaObjectReference]
 
-    val thread = ScalaDebugger.currentThreadOrFindFirstSuspendedThread(scalaValue)
+    val thread = ScalaDebugger.currentThread
     try {
       // the way to call toArray on a collection is slightly different between Scala 2.9 and 2.10
       // the base object to use to get the Manisfest and the method signature are different


### PR DESCRIPTION
In Eclipse 4.x, a new way to follow the current selection in the debug view was implemented,
as debug specific support.
The old way was slightly broken, and was no more working for selection changes not triggered
by the user. A temporary fix was implemented in Scala 3.0.x, to support Eclipse 3.x and 4.x.
This commit replace the old code and the fix by a solution using the new support.

Fixes #1001585
Need to be backported in 3.0.x-juno.
