### PR TITLE
Mark output folders as "Derived".

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -432,7 +432,12 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
 
   private def refreshOutputFolders(): Unit = {
     sourceOutputFolders foreach {
-      case (_, binFolder) => binFolder.refreshLocal(IResource.DEPTH_INFINITE, null)
+      case (_, binFolder) =>
+        binFolder.refreshLocal(IResource.DEPTH_INFINITE, null)
+        // make sure the folder is marked as Derived, so we don't see classfiles in Open Resource
+        // but don't set it unless necessary (this might be an expensive operation)
+        if (!binFolder.isDerived)
+          binFolder.setDerived(true, null)
     }
   }
 


### PR DESCRIPTION
Derived folders won't appear in "Open Resource", polluting
names with classfiles.

Fixes #1000260 (which regressed at some point in time).
