### PR TITLE
Resolves a compilation error reported with 2.11

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
@@ -30,7 +30,7 @@ object ScalaWordFinder extends IScalaWordFinder {
   }
 
   def bufferToSeq(buf : IBuffer) = new IndexedSeq[Char] {
-    override def apply(i : Int) = if (i >= buf.getLength()) '\0' else buf.getChar(i)
+    override def apply(i : Int) = if (i >= buf.getLength()) 0.toChar else buf.getChar(i)
     override def length = buf.getLength
   }
 


### PR DESCRIPTION
In 2.11 octal escape literals are now unsupported
