### PR TITLE
Revert "Sync 'isDefined' in presentation compiler cache."

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Cached.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Cached.scala
@@ -15,7 +15,7 @@ package scala.tools.eclipse.util
  */
 trait Cached[T] {
   private var inProgress = false
-  private var elem: Option[T] = None
+  @volatile private var elem: Option[T] = None
 
   def apply[U](op: T => U): U = {
     val e = synchronized {
@@ -42,7 +42,7 @@ trait Cached[T] {
   }
 
   /** Is the cached object initialized, at this point in time? */
-  def initialized: Boolean = synchronized { elem.isDefined }
+  def initialized: Boolean = elem.isDefined
 
   def invalidate() {
     val oldElem = synchronized {


### PR DESCRIPTION
This reverts commit 3608a8191c91062aa608beb77da930cdc3c8cda7.

We need to revert this because of a possible deadlock at startup between the PC
and the classpath resolution. More information on the related ticket (#1001875).

backport to release/scala-ide-3.0.x

Review by @dragos

Re #1001880
Fixes #1001875
