### PR TITLE
Issue/launch config does not find main in jar 1001878

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchDelegate.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchDelegate.scala
@@ -30,9 +30,14 @@ import org.eclipse.jdt.launching.JavaRuntime
 import org.eclipse.jdt.launching.VMRunnerConfiguration
 import org.eclipse.jface.dialogs.MessageDialog
 import scala.collection.JavaConverters
+import org.eclipse.debug.core.DebugPlugin
+import org.eclipse.core.runtime.Status
+import org.eclipse.debug.internal.core.IInternalDebugCoreConstants
+import org.eclipse.jface.dialogs.MessageDialogWithToggle
+import org.eclipse.jface.dialogs.IDialogConstants
 
 class ScalaLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
-  /** This code is very heavily inspired from `AbstractJavaLaunchConfigurationDelegate`. */
+  /** This code is very heavily inspired from `JavaLaunchDelegate`. */
   def launch(configuration: ILaunchConfiguration, mode: String, launch: ILaunch, monitor0: IProgressMonitor) {
 
     val monitor = if (monitor0 == null) new NullProgressMonitor() else monitor0
@@ -126,16 +131,17 @@ class ScalaLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
 
   /** Stop a launch if the main class does not exist. */
   override def finalLaunchCheck(configuration: ILaunchConfiguration, mode: String, monitor: IProgressMonitor): Boolean = {
-    super.finalLaunchCheck(configuration, mode, monitor) && {
-      // verify that the main classfile exists
-      val project = getJavaProject(configuration)
-      val mainTypeName = getMainTypeName(configuration)
-      ScalaPlugin.plugin.asScalaProject(project.getProject) map { scalaProject =>
-        val mainClassVerifier = new MainClassVerifier(new UIErrorReporter)
-        val status = mainClassVerifier.execute(scalaProject, mainTypeName)
-        status.isOK
-      } getOrElse false
-    }
+    // verify that the main classfile exists
+    val project = getJavaProject(configuration)
+    val mainTypeName = getMainTypeName(configuration)
+    ScalaPlugin.plugin.asScalaProject(project.getProject) map { scalaProject =>
+      val mainClassVerifier = new MainClassVerifier
+      val status = mainClassVerifier.execute(scalaProject, mainTypeName, existsProblems(project.getProject))
+      if(!status.isOK) {
+        val reporter = new UIErrorReporter
+        reporter.report(status)
+      } else status.isOK
+    } getOrElse false
   }
 
   private def toInclude(vmMap: mutable.Map[String, Array[String]], classpath: List[String],
@@ -160,9 +166,34 @@ class ScalaLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
     bootEntry.toList.map(_.getLocation())
   }
 
-  private class UIErrorReporter extends MainClassVerifier.ErrorReporter {
-    def report(msg: String): Unit = DisplayThread.asyncExec {
-      MessageDialog.openInformation(ScalaPlugin.getShell, "Failed to run Scala Application", msg)
+  // We should replace this with a IStatusHandler - http://help.eclipse.org/juno/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fua_statushandling_sample.htm
+  private class UIErrorReporter {
+    def report(status: IStatus): Boolean = {
+      val latch = new java.util.concurrent.CountDownLatch(1)
+
+      @volatile var continueLaunch = true
+      DisplayThread.asyncExec {
+         try {
+            val dialog = new MessageDialog(
+                ScalaPlugin.getShell,
+                "Detected problem",
+                null,
+                status.getMessage + " Continue launch?",
+                MessageDialog.WARNING,
+                Array(IDialogConstants.YES_LABEL, IDialogConstants.NO_LABEL),
+                1)
+            dialog.open()
+            val returnValue = dialog.getReturnCode()
+            if (returnValue == IDialogConstants.OK_ID) continueLaunch = true
+            else continueLaunch = false
+          }
+          finally {
+            latch.countDown()
+          }
+      }
+
+      latch.await()
+      continueLaunch
     }
   }
 }


### PR DESCRIPTION
### Dumbed down `MainClassVerifier` to only check class vs module mismatch …

Experience taught us that `MainClassVerifier` is trying to be too smart, and
often prevents user from launching perfectly fine Scala launch configurations.
The last manifestation was that it would prevent users from launching a main if
defined in a JAR.

The matter was discussed with the team and the agreed descision is to reduce
the scope of the `MainClassVerifier` to only prevent users from:
- launching a Scala application if the project contains build errors, and
- provide feedback when trying to launch a Scala `class`, instead of a `object`

Consequently, we no longer prevent users from launching a Scala application
that is incorrectly configured (i.e., the classfile doesn't exist). The
consequence is that a `NoClassFoundException` will be reported to the user in
this case, which actually matches the behavior in the Eclipse Java support.

backport to release/scala-ide-3.0.x

Fixes #1001878
