### PR TITLE
Updates continuations option tests for 2.11

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/TestUtil.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/TestUtil.scala
@@ -1,0 +1,11 @@
+package scala.tools.eclipse
+
+import org.osgi.framework.Version
+
+object TestUtil {
+
+  def installedScalaVersionGreaterOrEqualsTo(version: Version): Boolean = {
+    ScalaPlugin.plugin.scalaLibBundle.getVersion().compareTo(version) >= 0
+  }
+
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -6,7 +6,6 @@
 package scala.tools.eclipse
 
 import java.io.File.pathSeparator
-
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.reflect.internal.util.BatchSourceFile
@@ -24,7 +23,6 @@ import scala.tools.eclipse.util.Trim
 import scala.tools.eclipse.util.Utils
 import scala.tools.nsc.MissingRequirementError
 import scala.tools.nsc.Settings
-
 import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IMarker
@@ -47,6 +45,7 @@ import org.eclipse.ui.IEditorPart
 import org.eclipse.ui.IPartListener
 import org.eclipse.ui.IWorkbenchPart
 import org.eclipse.ui.part.FileEditorInput
+import org.eclipse.jface.preference.IPersistentPreferenceStore
 
 trait BuildSuccessListener {
   def buildSuccessful(): Unit
@@ -554,7 +553,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
    *  @see  #1001241.
    *  @see `storage` for a method that decides based on user preference
    */
-  def projectSpecificStorage: IPreferenceStore = {
+  def projectSpecificStorage: IPersistentPreferenceStore = {
     new PropertyStore(underlying, ScalaPlugin.prefStore, plugin.pluginId)
   }
 


### PR DESCRIPTION
In Scala 2.11, the continuation plugin is no more enabled by default when
available.
Two main changes:
- forces enable the continuation plugin when running the tests on Scala 2.11
- modifies the tests to use the project specific preferences, to avoid side effects
  of the configuration changes needed for the tests.

This change is required to have scala/scala#2859 passing the Scala/Scala IDE pr validation.
