### PR TITLE
Pushes the output of InterruptedExceptions to debug log level

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -162,6 +162,10 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
               case e: TypeError                  => logger.info("TypeError in ask:\n" + e)
               case f: FreshRunReq                => logger.info("FreshRunReq in ask:\n" + f)
               case m: MissingResponse            => logger.info("MissingResponse in ask. Called from: " + m.getStackTrace().mkString("\n"))
+              // This can happen if you ask long queries of the
+              // PC, triggering long sleep() sessions on caller
+              // side.
+              case i: InterruptedException       => logger.debug("InterruptedException in ask:\n" + i)
               case e                             => eclipseLog.error("Error during askOption", e)
             }
             None


### PR DESCRIPTION
This is a companion to https://github.com/scala-ide/scala-ide/pull/481 in the
sense that testing this PR revealed InterruptedExceptions being treated and
passed in the askOption exception capture mechanism, in very long
documentation requests. This logs such exceptions at debug level, and hints at
issue in comments.

review by @dotta
