### PR TITLE
Correctly build projects that depend through exported dependencies.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/sbtbuilder/ProjectDependenciesTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/sbtbuilder/ProjectDependenciesTest.scala
@@ -90,4 +90,38 @@ class ProjectDependenciesTest {
 
     deleteProjects(prjA, prjB, prjC)
   }
+
+  @Test def transitive_dep_indirect() {
+    val Seq(prjA, prjB, prjC) = createProjects("A", "B", "C")
+
+    // A -> B -> C
+    addToClasspath(prjB, JavaCore.newProjectEntry(prjA.underlying.getFullPath, /* isExported = */ true))
+    addToClasspath(prjC, JavaCore.newProjectEntry(prjB.underlying.getFullPath, false))
+
+    val Seq(packA, packB, packC) = Seq(prjA, prjB, prjC).map(createSourcePackage("test"))
+
+    // C depends directly on A, through an exported dependency of B
+    val unitA = packA.createCompilationUnit("A.scala", "class A", true, null)
+    val unitC = packC.createCompilationUnit("C.scala", "class C(a: A)", true, null)
+
+    // no errors
+    SDTTestUtils.workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null)
+
+    val unitsToWatch = Seq(unitA, unitC)
+
+    val errors = SDTTestUtils.getErrorMessages(unitsToWatch: _*)
+    Assert.assertEquals("No build errors", Seq(), errors)
+
+    // one error in C
+    val errors1 = SDTTestUtils.buildWith(unitA.getResource, "class A2", unitsToWatch)
+    Assert.assertEquals("One build error in C", Seq("not found: type A"), errors1)
+
+    // fix project A, no errors
+    val errors2 = SDTTestUtils.buildWith(unitA.getResource, "class A", unitsToWatch)
+    Assert.assertEquals("No errors in A", Seq(), SDTTestUtils.getErrorMessages(unitA))
+    Assert.assertEquals("No errors in C", Seq(), SDTTestUtils.getErrorMessages(unitC))
+
+    deleteProjects(prjA, prjB, prjC)
+  }
+
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -435,7 +435,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
         binFolder.refreshLocal(IResource.DEPTH_INFINITE, null)
         // make sure the folder is marked as Derived, so we don't see classfiles in Open Resource
         // but don't set it unless necessary (this might be an expensive operation)
-        if (!binFolder.isDerived)
+        if (!binFolder.isDerived && binFolder.exists)
           binFolder.setDerived(true, null)
     }
   }
@@ -674,9 +674,6 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
   def prepareBuild(): Boolean = if (!hasBeenBuilt) buildManager.invalidateAfterLoad else false
 
   def build(addedOrUpdated: Set[IFile], removed: Set[IFile], monitor: SubMonitor) {
-    if (addedOrUpdated.isEmpty && removed.isEmpty)
-      return
-
     hasBeenBuilt = true
 
     clearBuildProblemMarker()

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
@@ -128,13 +128,13 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
    *  them and their dependent files.
    */
   private def update(added: scala.collection.Set[AbstractFile], removed: scala.collection.Set[AbstractFile]) {
-    logger.info("update files: " + added)
-    if (!added.isEmpty || !removed.isEmpty) {
-      buildingFiles(added)
-      removeFiles(removed)
-      sources ++= added
-      runCompiler(sources.asJFiles)
-    }
+    if (added.isEmpty && removed.isEmpty)
+      logger.info("No changes in project, running the builder for potential transitive changes.")
+
+    buildingFiles(added)
+    removeFiles(removed)
+    sources ++= added
+    runCompiler(sources.asJFiles)
   }
 
   private def runCompiler(sources: Seq[File]) {


### PR DESCRIPTION
The Scala builder optimised the case where the builder was triggered with
no changes in a project, by skipping the call to the underlying Sbt builder.
This is wrong when the project has no changes itself, but a dependent project has.

Fixed #1001904.

Consider for back porting to 3.0.x
