### PR TITLE
Remove copyright headers

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/wizards/ImportSupportTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/wizards/ImportSupportTest.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- */
 package scala.tools.eclipse.wizards
 
 import org.junit.Test

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/wizards/QualifiedNameSupportTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/wizards/QualifiedNameSupportTest.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- */
 package scala.tools.eclipse.wizards
 
 import org.junit.Test

--- a/org.scala-ide.sdt.core.tests/test-workspace/pc/src/t1000692/akka/util/ReflectiveAccess.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/pc/src/t1000692/akka/util/ReflectiveAccess.scala
@@ -1,7 +1,3 @@
-/**
- * Copyright (C) 2009-2011 Scalable Solutions AB <http://scalablesolutions.se>
- */
-
 package t1000692.akka.util
 
 import t1000692.akka.config.ModuleNotAvailableException

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/EclipseBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/EclipseBuildManager.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.core.resources.IFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/JVMUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/JVMUtils.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import scala.tools.nsc.interactive.Global

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/LocateSymbol.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/LocateSymbol.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.core.resources.ResourcesPlugin

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/Nature.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/Nature.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import scala.collection.mutable.ArrayBuffer

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/PerspectiveFactory.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/PerspectiveFactory.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.debug.ui.IDebugUIConstants

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaBuilder.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import scala.collection.mutable.HashSet

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaClassFileDescriber.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaClassFileDescriber.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import java.io.DataInputStream

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaClassFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaClassFileEditor.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import scala.tools.eclipse.javaelements.ScalaClassFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaClasspathContainers.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaClasspathContainers.scala
@@ -1,9 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.core.runtime.IPath

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaEditor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaEditor.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.jface.text.rules.FastPartitioner

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaHover.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaHover.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.jdt.core.ICodeAssist

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaImages.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaImages.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import java.net.MalformedURLException

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaLibraryPluginDependencyUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaLibraryPluginDependencyUtils.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.core.resources.IFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPlugin.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.jdt.core.IJavaProject

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import scala.tools.nsc.interactive.FreshRunReq

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaProject.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import java.io.File.pathSeparator

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaRetargettableActionAdapterFactory.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaRetargettableActionAdapterFactory.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.core.runtime.IAdapterFactory

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceFileEditor.scala
@@ -1,9 +1,4 @@
 
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import java.util.ResourceBundle

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceIndexer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceIndexer.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import org.eclipse.jdt.core.search.SearchDocument

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaSourceViewerConfiguration.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import scala.tools.eclipse.formatter.ScalaFormattingStrategy

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaToggleBreakpointAdapter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaToggleBreakpointAdapter.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import java.util.HashMap

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaWordFinder.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 import scala.collection.immutable.IndexedSeq

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/SettingConverterUtil.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/SettingConverterUtil.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 
 /** Utility to unify how we convert settings to preference names */

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/InterpreterAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/InterpreterAction.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 package actions
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/ToggleScalaNatureAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/actions/ToggleScalaNatureAction.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 package actions
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/Factory.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/Factory.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2009 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.interpreter
 import org.eclipse.core.resources.IProject
 import org.eclipse.jdt.core.IJavaElement

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/InterpreterLaunchConfigurationDelegate.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/InterpreterLaunchConfigurationDelegate.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.interpreter
 
 import java.io.File

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/InterpreterLaunchConstants.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/InterpreterLaunchConstants.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.interpreter
 
 object InterpreterLaunchConstants {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/InterpreterTabGroup.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/interpreter/InterpreterTabGroup.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.interpreter
 
 import org.eclipse.debug.ui._

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/CompilationUnitAdapter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/CompilationUnitAdapter.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import java.util.{ HashMap => JHashMap }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/JDTUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/JDTUtils.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import org.eclipse.core.resources.IFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/JavaElementFactory.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/JavaElementFactory.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import java.lang.reflect.Constructor

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFile.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import java.util.{ HashMap => JHashMap }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFileProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFileProvider.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 package javaelements
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaCompilationUnit.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 package javaelements
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaElementFilter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaElementFilter.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import org.eclipse.jface.viewers.Viewer

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaElements.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaElements.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import scala.collection.immutable.Seq

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaIndexBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaIndexBuilder.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import org.eclipse.core.resources.IFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaMatchLocator.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaMatchLocator.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import org.eclipse.jdt.core.search.SearchMatch

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaOverrideIndicatorBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaOverrideIndicatorBuilder.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import java.util.{ Map => JMap }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSelectionEngine.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSelectionEngine.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 package javaelements
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSourceFile.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import java.util.{ HashMap => JHashMap }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaStructureBuilder.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.javaelements
 
 import java.io.PrintWriter

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ApplicationTabGroup.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ApplicationTabGroup.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.launching;
 import org.eclipse.debug.ui._
 import org.eclipse.debug.ui.sourcelookup._

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchShortcut.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchShortcut.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.launching
 
 import scala.tools.eclipse.javaelements.ScalaSourceFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchableTester.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/launching/ScalaLaunchableTester.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.launching
 
 import org.eclipse.core.expressions.PropertyTester

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/CompilerSettings.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.properties
 
 import org.eclipse.core.resources.IncrementalProjectBuilder

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.properties
 
 import scala.tools.nsc.Settings

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/PropertyStore.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/PropertyStore.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.properties
 
 import org.eclipse.core.runtime.preferences._

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.properties
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaPreferences.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaPreferences.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.properties
 
 import org.eclipse.jface.preference.IPreferenceStore

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/reconciliation/ReconciliationParticipant.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/reconciliation/ReconciliationParticipant.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright 2005-2011 LAMP/EPFL
- */
 package scala.tools.eclipse
 package reconciliation
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/reconciliation/ReconciliationParticipantsExtensionPoint.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/reconciliation/ReconciliationParticipantsExtensionPoint.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright 2005-2011 LAMP/EPFL
- */
 package scala.tools.eclipse
 package reconciliation
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ActionAdapter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ActionAdapter.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 
 import org.eclipse.jface.action.Action

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/EditorHelpers.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/EditorHelpers.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ErrorRefactoringWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ErrorRefactoringWizard.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 
 import org.eclipse.ltk.ui.refactoring.RefactoringWizard

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExpandCaseClassBindingAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExpandCaseClassBindingAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 
 import scala.tools.eclipse.javaelements.ScalaSourceFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractLocalAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractLocalAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractMethodAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ExtractMethodAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 
 import scala.tools.eclipse.javaelements.ScalaSourceFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/InlineLocalAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/InlineLocalAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 
 import scala.tools.eclipse.javaelements.ScalaSourceFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/OrganizeImportsAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/RefactoringAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/RefactoringAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/RefactoringActionWithoutWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/RefactoringActionWithoutWizard.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2011 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/RefactoringMenu.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/RefactoringMenu.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2011 Fabian Steeg. All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Scala License which accompanies this distribution, and
- * is available at http://www.scala-lang.org/node/146
- */
 package scala.tools.eclipse.refactoring
 
 import org.eclipse.core.commands.Command

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ScalaIdeRefactoring.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ScalaIdeRefactoring.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ScalaRefactoringWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/ScalaRefactoringWizard.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 
 import org.eclipse.ltk.ui.refactoring.RefactoringWizard

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/UserPreferencesFormatting.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/UserPreferencesFormatting.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2012 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/GlobalRenameAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 package rename
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/LocalRenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/LocalRenameAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse.refactoring
 package rename
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/RenameAction.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/refactoring/rename/RenameAction.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-
 package scala.tools.eclipse
 package refactoring
 package rename

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaAutoIndentStrategy.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaAutoIndentStrategy.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.ui
 
 import org.eclipse.core.runtime.Assert;

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposalComputer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposalComputer.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 package ui
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaIndenter.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaIndenter.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.ui
 
 import scalariform.formatter.preferences._

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Cached.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Cached.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.util
 
 /** A ref cell to a managed resource. Overwrite 'create' and 'destroy'.

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Colors.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/Colors.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.util
 
 import scala.collection.mutable.LinkedHashMap

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/EclipseFile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/EclipseFile.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse
 package util
 

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/FileUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/FileUtils.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.util
 
 import scala.tools.eclipse.ScalaPlugin.plugin

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/OSGiUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/OSGiUtils.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.util
 
 import java.net.URL

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/ReflectionUtils.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/util/ReflectionUtils.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.util
 
 import java.security.AccessController

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/AbstractNewElementWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/AbstractNewElementWizard.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- */
 package scala.tools.eclipse.wizards
 
 import org.eclipse.core.resources.IFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/AbstractNewElementWizardPage.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/AbstractNewElementWizardPage.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- *
- */
 package scala.tools.eclipse.wizards
 
 import org.eclipse.core.resources.IResource

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/CodeBuilder.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/CodeBuilder.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- *
- */
 package scala.tools.eclipse.wizards
 
 import org.eclipse.jdt.core.Flags

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/ImportSupport.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/ImportSupport.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- */
 package scala.tools.eclipse.wizards
 
 import org.eclipse.jdt.core.ICompilationUnit

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/OptionTraits.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/OptionTraits.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- *
- */
 package scala.tools.eclipse.wizards
 
 import org.eclipse.jdt.core.ICompilationUnit

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/ScalaProjectWizard.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/ScalaProjectWizard.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2005-2010 LAMP/EPFL
- */
-// $Id$
-
 package scala.tools.eclipse.wizards
 
 import scala.collection.mutable.ArrayBuffer

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/core.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/core.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- *
- */
 package scala.tools.eclipse.wizards
 
 import scala.tools.eclipse.ui.DisplayThread

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/support.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/wizards/support.scala
@@ -1,7 +1,3 @@
-/*
- * Copyright 2010 LAMP/EPFL
- *
- */
 package scala.tools.eclipse.wizards
 
 object BufferSupport {


### PR DESCRIPTION
The command used to remove all copyright headers is:

```
find org.scala-ide.sdt.core org.scala-ide.sdt.core.tests -iname
"*.scala" -print0 | xargs -0 perl -p0e
's!/\*.*?Copyright.*?\*/.*?(package)!\1!sg' -i
```

---

Follow-up of  #547.
