### PR TITLE
Removed useless call to `loadedPlugins` in `ContinuationsPluginSettingTest`

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/compiler/settings/ContinuationPluginSettingsTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/compiler/settings/ContinuationPluginSettingsTest.scala
@@ -49,7 +49,6 @@ class ContinuationPluginSettingsTest {
     setPrefToDefault("Xpluginsdir")
     setPrefToDefault("Xplugin")
     forceEnableContinuationForNewerScalaVersion()
-    loadedPlugins(project)
     Assert.assertEquals("Loaded plugins: ", List("continuations"), loadedPlugins(project))
   }
 
@@ -58,7 +57,6 @@ class ContinuationPluginSettingsTest {
     setPrefValue("Xpluginsdir", ScalaPlugin.plugin.defaultPluginsDir)
     setPrefValue("Xplugin", "/doesnotexits")
     forceEnableContinuationForNewerScalaVersion()
-    loadedPlugins(project)
     Assert.assertEquals("Loaded plugins: ", List("continuations"), loadedPlugins(project))
   }
 
@@ -67,7 +65,6 @@ class ContinuationPluginSettingsTest {
     setPrefValue("Xpluginsdir", "/doesnotexist")
     setPrefValue("Xplugin", ScalaPlugin.plugin.defaultPluginsDir + File.separator + "continuations.jar")
     forceEnableContinuationForNewerScalaVersion()
-    loadedPlugins(project)
     Assert.assertEquals("Loaded plugins: ", List("continuations"), loadedPlugins(project))
   }
 


### PR DESCRIPTION
The call to `loadedPlugins` is not needed because the test doesn't depend on
any side-effect that may be caused by the aformentioned method.

This was a leftover of PR #544
