### PR TITLE
'Add explicit type' quick assist.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickassist/ExplicitTypeAssistTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/quickassist/ExplicitTypeAssistTest.scala
@@ -1,0 +1,269 @@
+package scala.tools.eclipse.quickassist
+
+import org.eclipse.jdt.internal.core.util.SimpleDocument
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+
+import java.util.ArrayList
+
+import scala.tools.eclipse.EclipseUserSimulator
+import scala.tools.eclipse.ScalaProject
+import scala.tools.eclipse.javaelements.ScalaSourceFile
+import scala.tools.eclipse.quickfix.explicit.ExplicitReturnType
+import scala.tools.eclipse.testsetup.SDTTestUtils
+import scala.util.control.Exception
+
+object ExplicitTypeAssistTest {
+  var project: ScalaProject = _
+  var simulator = new EclipseUserSimulator
+
+  @BeforeClass
+  def createProject {
+    project = simulator.createProjectInWorkspace("assist")
+  }
+
+  def createSourceFile(packageName: String, unitName: String)(contents: String): ScalaSourceFile = {
+    val pack = SDTTestUtils.createSourcePackage(packageName)(project)
+    simulator.createCompilationUnit(pack, unitName, contents).asInstanceOf[ScalaSourceFile]
+  }
+
+  @AfterClass
+  def deleteProject {
+    Exception.ignoring(classOf[Exception]) { project.underlying.delete(true, null) }
+  }
+
+}
+
+/** This test suite requires the UI. */
+class ExplicitTypeAssistTest {
+  import ExplicitTypeAssistTest._
+
+  def noAssistsFor(contents: String) = {
+    runExplicitTypeWith(contents) { p =>
+      Assert.assertTrue(s"Unexpected explicit type $p", p.isEmpty)
+    }
+  }
+
+  def runExplicitTypeWith(contents: String)(f: Option[IJavaCompletionProposal] => Unit) = {
+    val unit = createSourceFile("test", "Test.scala")(contents.filterNot(_ == '^'))
+
+    try {
+      val Seq(pos) = SDTTestUtils.positionsOf(contents.toCharArray(), "^")
+      val proposals = new ArrayList[IJavaCompletionProposal]
+      // get all corrections for the problem
+
+      f(ExplicitReturnType.suggestsFor(unit, pos).headOption)
+    } finally
+      unit.delete(true, null)
+
+  }
+
+  def assistsFor(contents: String, expected: String): Unit =
+    runExplicitTypeWith(contents) { p =>
+      Assert.assertTrue("Add explicit type proposal not found", p.nonEmpty)
+
+      val doc = new SimpleDocument(contents.filterNot(_ == '^'))
+      p.head.apply(doc)
+      Assert.assertEquals("Changes unexpected", expected, doc.get())
+    }
+
+  @Test
+  def assistVal() {
+    assistsFor("""
+        class Test {
+          val foo = ^42
+        }
+        """.stripMargin, """
+        class Test {
+          val foo: Int = 42
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistDef() {
+    assistsFor("""
+        class Test {
+          def foo(x: Int) = ^x + 1
+        }
+        """.stripMargin, """
+        class Test {
+          def foo(x: Int): Int = x + 1
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistList() {
+    assistsFor("""
+        class Test {
+          def foo(x: Int) = ^List.fill(x)(0)
+        }
+        """.stripMargin, """
+        class Test {
+          def foo(x: Int): List[Int] = List.fill(x)(0)
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistMultiLine() {
+    assistsFor("""
+        class Test {
+          def foo(x: Int) = ^{
+            List.fill(x)(0)
+          }
+        }
+        """.stripMargin, """
+        class Test {
+          def foo(x: Int): List[Int] = {
+            List.fill(x)(0)
+          }
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistComplexSignature() {
+    assistsFor("""
+        class Test {
+          def foo[T](size: Int = 42, init: T)(implicit ord: Ordered[T]) = {
+            ^List.fill(size)(init)
+          }
+        }
+        """.stripMargin, """
+        class Test {
+          def foo[T](size: Int = 42, init: T)(implicit ord: Ordered[T]): List[T] = {
+            List.fill(size)(init)
+          }
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistInnerScopeVal() {
+    assistsFor("""
+        class Test {
+          def foo(x: Int) = {
+            val size = 10
+            val bar = ^List.fill(size)(0)
+          }
+        }
+        """.stripMargin, """
+        class Test {
+          def foo(x: Int) = {
+            val size = 10
+            val bar: List[Int] = List.fill(size)(0)
+          }
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistInnerScopeDef() {
+    assistsFor("""
+        class Test {
+          def foo(x: Int) = {
+            val size = 10
+            def bar[T](init: T) = ^List.fill(size)(init)
+          }
+        }
+        """.stripMargin, """
+        class Test {
+          def foo(x: Int) = {
+            val size = 10
+            def bar[T](init: T): List[T] = List.fill(size)(init)
+          }
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistTransitive() {
+    assistsFor("""
+        class Test {
+          val x = ^initialize()
+
+          def initialize() = {
+            cout += 1
+            count
+          }
+          var count = 0
+        }
+        """.stripMargin, """
+        class Test {
+          val x: Int = initialize()
+
+          def initialize() = {
+            cout += 1
+            count
+          }
+          var count = 0
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistMultiAssign() {
+    assistsFor("""
+        class Test {
+          val x, y, z = ^initialize()
+
+          def initialize() = 0
+        }
+        """.stripMargin, """
+        class Test {
+          val x, y, z: Int = initialize()
+
+          def initialize() = 0
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def noAssistPatMat() {
+    noAssistsFor("""
+        class Test {
+          val Some(x) = ^Option(new Object)
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def noAssistTuple() {
+    noAssistsFor("""
+        class Test {
+          val (x, y) = ^(1, 2)
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistOperatorVal() {
+    assistsFor("""
+        class Test {
+          val ~ = ^42
+        }
+        """.stripMargin, """
+        class Test {
+          val ~ : Int = 42
+        }
+        """.stripMargin)
+  }
+
+  @Test
+  def assistOperatorDef() {
+    assistsFor("""
+        class Test {
+          def ++ = ^42
+        }
+        """.stripMargin, """
+        class Test {
+          def ++ : Int = 42
+        }
+        """.stripMargin)
+  }
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -41,7 +41,7 @@ import scala.tools.eclipse.sourcefileprovider.SourceFileProviderRegistry
 import org.eclipse.core.runtime.Path
 import org.eclipse.core.resources.IFile
 import org.eclipse.jdt.internal.core.util.Util
-
+import scala.tools.eclipse.compiler.CompilerApiExtensions
 
 class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) extends {
   /*
@@ -62,6 +62,7 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
   with JavaSig
   with JVMUtils
   with LocateSymbol
+  with CompilerApiExtensions
   with HasLogger { self =>
 
   def presentationReporter = reporter.asInstanceOf[ScalaPresentationCompiler.PresentationReporter]
@@ -72,7 +73,7 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
     for {
       f <- managedFiles.collect { case ef: EclipseFile => ef }
       icu <- SourceFileProviderRegistry.getProvider(f.workspacePath).createFrom(f.workspacePath)
-        if icu.exists
+      if icu.exists
     } yield icu
   }
 
@@ -189,7 +190,7 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
 
   /** Atomically load a list of units in the current presentation compiler. */
   def askReload(units: List[InteractiveCompilationUnit]): Response[Unit] = {
-    withResponse[Unit]{ res => askReload(units.map(_.sourceFile), res) }
+    withResponse[Unit] { res => askReload(units.map(_.sourceFile), res) }
   }
 
   def filesDeleted(units: List[ScalaCompilationUnit]) {
@@ -203,9 +204,8 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
     askOption { () => removeUnitOf(scu.sourceFile) }
   }
 
-  /**
-   * Tell the presentation compiler to refresh the given files,
-   * if they are not managed by the presentation compiler already.
+  /** Tell the presentation compiler to refresh the given files,
+   *  if they are not managed by the presentation compiler already.
    */
   def refreshChangedFiles(files: List[IFile]) {
     // transform to batch source files

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/compiler/CompilerApiExtensions.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/compiler/CompilerApiExtensions.scala
@@ -1,0 +1,108 @@
+package scala.tools.eclipse
+package compiler
+
+import scala.collection.mutable.ArrayBuffer
+import scala.tools.nsc.ast.parser.Tokens
+import scala.reflect.internal.util.SourceFile
+import scala.collection.immutable
+
+/** Additional compiler APIs. It should eventually migrate in the presentation compiler.
+ */
+trait CompilerApiExtensions { this: ScalaPresentationCompiler =>
+
+  /** Locate the smallest tree that encloses position.
+   *
+   *  @param tree The tree in which to search `pos`
+   *  @param pos  The position to look for
+   *  @param p    An additional condition to be satisfied by the resulting tree
+   *  @return     The innermost enclosing tree for which p is true, or `EmptyTree`
+   *              if the position could not be found.
+   */
+  def locateIn(tree: Tree, pos: Position, p: Tree => Boolean = t => true): Tree =
+    new FilteringLocator(pos, p) locateIn tree
+
+  private class FilteringLocator(pos: Position, p: Tree => Boolean) extends Locator(pos) {
+    override def isEligible(t: Tree) = super.isEligible(t) && p(t)
+  }
+
+  /** Return the smallest enclosing method.
+   *
+   *  @return a parse tree of the innermost enclosing method.
+   *  @note   This method parses the whole sourcefile
+   */
+  def enclosingMethd(src: SourceFile, offset: Int): Tree = {
+    locateIn(parseTree(src), rangePos(src, offset, offset, offset), t => t.isInstanceOf[DefDef])
+  }
+
+  /** Returns the smallest enclosing class or trait.
+   *
+   *  @return a parse tree of the innermost enclosing method.
+   *  @note   This method parses the whole sourcefile
+   */
+  def enclosingClass(src: SourceFile, offset: Int) = {
+    locateIn(parseTree(src), rangePos(src, offset, offset, offset), _.isInstanceOf[ClassDef])
+  }
+
+  /** Return the smallest enclosing method of value definition
+   *
+   *  @return a parse tree of the innermost enclosing {{{DefDef}}} or {{{ValDef}}}
+   *  @note   This method parses the whole sourcefile
+   */
+  def enclosingValOrDef(src: SourceFile, offset: Int): Tree = {
+    locateIn(parseTree(src), rangePos(src, offset, offset, offset), t => t.isInstanceOf[ValOrDefDef])
+  }
+
+  /** A helper class to access the lexical tokens of `source`.
+   *
+   *  Once constructed, instances of this class are thread-safe.
+   */
+  class LexicalStructure(source: SourceFile) {
+    private val token = new ArrayBuffer[Int]
+    private val startOffset = new ArrayBuffer[Int]
+    private val endOffset = new ArrayBuffer[Int]
+    private val scanner = new syntaxAnalyzer.UnitScanner(new CompilationUnit(source))
+    scanner.init()
+
+    while (scanner.token != Tokens.EOF) {
+      startOffset += scanner.offset
+      token += scanner.token
+      scanner.nextToken
+      endOffset += scanner.lastOffset
+    }
+
+    /** Return the index of the token that covers `offset`.
+     */
+    private def locateIndex(offset: Int): Int = {
+      var lo = 0
+      var hi = token.length - 1
+      while (lo < hi) {
+        val mid = (lo + hi + 1) / 2
+        if (startOffset(mid) <= offset) lo = mid
+        else hi = mid - 1
+      }
+      lo
+    }
+
+    /** Return all tokens between start and end offsets.
+     *
+     *  The first token may start before `start` and the last token may span after `end`.
+     */
+    def tokensBetween(start: Int, end: Int): immutable.Seq[Token] = {
+      val startIndex = locateIndex(start)
+      val endIndex = locateIndex(end)
+
+      val tmp = for (i <- startIndex to endIndex)
+        yield Token(token(i), startOffset(i), endOffset(i))
+
+      tmp.toSeq
+    }
+  }
+}
+
+/** A Scala token covering [start, end)
+ *
+ *  @param tokenId one of scala.tools.nsc.ast.parser.Tokens identifiers
+ *  @param start   the offset of the first character in this token
+ *  @param end     the offset of the first character after this token
+ */
+case class Token(tokenId: Int, start: Int, end: Int)

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickAssistProcessor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickAssistProcessor.scala
@@ -10,6 +10,7 @@ import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
 import org.eclipse.jdt.ui.text.java.IProblemLocation
 import org.eclipse.jdt.ui.text.java.IQuickAssistProcessor
 import org.eclipse.jface.text.Position
+import scala.tools.eclipse.quickfix.explicit.ExplicitReturnType
 
 /**
  * Enables all quick fixes that don't resolve errors in the document. Instead they
@@ -28,7 +29,7 @@ class ScalaQuickAssistProcessor extends IQuickAssistProcessor with HasLogger {
     context.getCompilationUnit match {
       case ssf: ScalaSourceFile =>
         import EditorUtils._
-
+        ExplicitReturnType.suggestsFor(ssf, context.getSelectionOffset).toArray ++
         openEditorAndApply(ssf) { editor =>
           val corrections = getAnnotationsAtOffset(editor, context.getSelectionOffset()) flatMap {
             case (ann, pos) =>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/explicit/ExpandText.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/explicit/ExpandText.scala
@@ -1,0 +1,15 @@
+package scala.tools.eclipse.quickfix
+package explicit
+
+import org.eclipse.jface.text.IDocument
+
+/** A generic completion proposal that inserts text at a given offset.
+ */
+class ExpandText(relevance: Int, displayString: String, tpt: String, offset: Int) extends BasicCompletionProposal(relevance, displayString) {
+  def apply(document: IDocument): Unit = {
+    document.replace(offset, 0, tpt)
+  }
+
+  override def toString =
+    s"ExpandText(tpt = $tpt, offset = $offset)"
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/explicit/ExplicitReturnType.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/explicit/ExplicitReturnType.scala
@@ -1,0 +1,73 @@
+package scala.tools.eclipse.quickfix.explicit
+
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
+
+import scala.collection.immutable
+import scala.reflect.internal.Chars
+import scala.tools.eclipse.compiler.Token
+import scala.tools.eclipse.javaelements.ScalaSourceFile
+import scala.tools.nsc.ast.parser.Tokens
+
+/** A quick fix that adds an explicit return type to a given val or def
+ */
+object ExplicitReturnType {
+  def suggestsFor(ssf: ScalaSourceFile, offset: Int): immutable.Seq[IJavaCompletionProposal] = {
+    addReturnType(ssf, offset).toList
+  }
+
+  private def addReturnType(ssf: ScalaSourceFile, offset: Int): Option[IJavaCompletionProposal] = {
+    ssf.withSourceFile { (sourceFile, compiler) =>
+      import compiler.{ Tree, ValDef, EmptyTree, TypeTree, DefDef, ValOrDefDef }
+
+      /** Find the tokens leading to tree `rhs` and return the position before `=`,
+       *  or -1 if not found.
+       */
+      def findInsertionPoint(vdef: ValOrDefDef): Int = {
+        val lexical = new compiler.LexicalStructure(sourceFile)
+        val tokens = lexical.tokensBetween(vdef.pos.startOrPoint, vdef.rhs.pos.startOrPoint)
+
+        tokens.reverse.find(_.tokenId == Tokens.EQUALS) match {
+          case Some(Token(_, start, _)) =>
+            var pos = start
+            while (sourceFile.content(pos - 1).isWhitespace)
+              pos -= 1
+            pos
+          case _ =>
+            -1
+        }
+      }
+
+      def expandProposal(vd: ValOrDefDef): Option[IJavaCompletionProposal] =
+        compiler.askOption { () => vd.tpt.toString } flatMap { tpe =>
+          val insertion = findInsertionPoint(vd)
+          // safety check: don't modify anything outside the original tree range
+          if (vd.pos.startOrPoint <= insertion && insertion <= vd.pos.endOrPoint) {
+
+            // if the last character is an operator char, we need to leave a space
+            val colonSpace =
+              if (Chars.isOperatorPart(sourceFile.content(insertion - 1))) " : "
+              else ": "
+
+            Some(new ExpandText(150, s"Add explicit type $tpe", colonSpace + tpe, insertion))
+          } else None
+        }
+
+      def expandableType(tpt: TypeTree) = compiler.askOption { () =>
+        (tpt.original eq null) && !tpt.tpe.isErroneous
+      }.getOrElse(false)
+
+      val enclosing = compiler.enclosingValOrDef(sourceFile, offset)
+      if (enclosing != EmptyTree) {
+        compiler.withResponse[Tree] { response =>
+          compiler.askTypeAt(enclosing.pos, response)
+        }.get.left.toOption flatMap {
+          case vd @ ValDef(_, _, tpt: TypeTree, _) if expandableType(tpt) =>
+            expandProposal(vd)
+          case dd @ DefDef(_, _, _, _, tpt: TypeTree, _) if expandableType(tpt) =>
+            expandProposal(dd)
+          case _ => None
+        }
+      } else None
+    }.flatten
+  }
+}


### PR DESCRIPTION
Add a quick-assist for adding an explicit type for `val`s and `def`s, if there isn't one already.
- it supports multiple assignment, but not pattern matches (not sure how useful it would be)
- tests depend on the UI (like all other quick fix tests). I think it's possible to decouple them in the same way we did  for code completions, but that's for another PR
- I added a few more general-purpose methods for getting back ASTs from positions, and even tokens. I'll clean them up for M2, but I think they can benefit the scalatest plugin as well

![screen shot 2013-10-13 at 8 12 42 pm](https://f.cloud.github.com/assets/133742/1322400/fdb06ecc-342a-11e3-8dce-c96f4718d59f.png)
