### PR TITLE
Test demonstrating wrong hyperlinking on metod w/ default arg

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkDetectorTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkDetectorTests.scala
@@ -107,4 +107,12 @@ class HyperlinkDetectorTests {
 
     loadTestUnit("t1001215/A.scala").andCheckAgainst(oracle)
   }
+
+  @Ignore("Enable this once Scalac ticket SI-7915 is fixed")
+  @Test
+  def t1001921() {
+    val oracle = List(Link("method t1001921.Bar.bar"))
+
+    loadTestUnit("t1001921/Ticket1001921.scala", forceTypeChecking = true).andCheckAgainst(oracle)
+  }
 }

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkTester.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/hyperlink/HyperlinkTester.scala
@@ -26,16 +26,17 @@ trait HyperlinkTester extends TestProjectSetup {
   case class Link(text: String*)
 
   /** Given a source `path`, load the corresponding scala `unit`. */
-  def loadTestUnit(path: String): VerifyHyperlink = {
+  def loadTestUnit(path: String, forceTypeChecking: Boolean = false): VerifyHyperlink = {
     val unit = scalaCompilationUnit(path)
-    loadTestUnit(unit)
+    loadTestUnit(unit, forceTypeChecking)
   }
 
   /** Load a scala `unit` that contains text markers used
    *  to generate hyperlinking requests to the presentation compiler.
    */
-  def loadTestUnit(unit: ScalaSourceFile): VerifyHyperlink = {
+  def loadTestUnit(unit: ScalaSourceFile, forceTypeChecking: Boolean): VerifyHyperlink = {
     reload(unit)
+    if(forceTypeChecking) waitUntilTypechecked(unit)
     new VerifyHyperlink {
       /** @param expectations A collection of expected `Link` (test's oracle). */
       def andCheckAgainst(expectations: List[Link], checker: (InteractiveCompilationUnit, IRegion, String, Link) => Unit = checkScalaLinks) = {

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/pc/PresentationCompilerTest.scala
@@ -100,7 +100,7 @@ class FreshFile {
     val oracle = List(Link("class t1000692.akka.config.ModuleNotAvailableException"))
     //then
     // it is important to ask hyperlinking before reloading!
-    loadTestUnit(unit).andCheckAgainst(oracle)
+    loadTestUnit(unit, forceTypeChecking = false).andCheckAgainst(oracle)
     reload(unit)
     // verify
     assertNoErrors(unit)

--- a/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/t1001921/Ticket1001921.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/hyperlinks/src/t1001921/Ticket1001921.scala
@@ -1,0 +1,11 @@
+package t1001921 {
+  class Ticket1001921 {
+    def foo() {
+      new Bar().bar/*^*/()
+    }
+  }
+
+  class Bar {
+    def bar(b: Int = 2) {}
+  }
+}


### PR DESCRIPTION
(Even though the bug is on the compiler side, I believe this test is still relevant and should also exist on our side)

This test demonstrates that the Tree returned by `askTypeAt` is wrong when the
request is executed _after_ fully-typechecking the sources used for the test.

I've debugged the problem inside the Scala IDE, and the reason why this happen
is that `askTypeAt` returns the enclosing `foo` DefDef method symbol, instead
of the expected Select `Bar.bar` node. The enclosing method is returned becuase
all Trees inside the method block have a _TransparentPosition_, all the way
down. The impelmentation of `askTypeAt` relies on
`RangePositions.Locator.traverse` to return the deepest, non-transparent, tree
that includes the passed position. And, because all positions are transparent
inside the `foo` method's body, then the `foo` symbol is returned.

An additional interesting fact is that it looks like one of the transformation
happening during typechecking is to blame for updating the Tree with the wrong
kind of positions. In fact, if the source file isn't typechecked, the correct
symbol is returned.

Enable the test once https://issues.scala-lang.org/browse/SI-7915 is fixed

Re #1001921
