### PR TITLE
`retryFlakyTest` now enabled by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <encoding>UTF-8</encoding>
-    <retryFlakyTests>false</retryFlakyTests>
+    <retryFlakyTests>true</retryFlakyTests>
     <!-- p2 repositories location -->
     <repo.eclipse.indigo>http://download.eclipse.org/releases/indigo/</repo.eclipse.indigo>
     <repo.eclipse.juno>http://download.eclipse.org/releases/juno</repo.eclipse.juno>


### PR DESCRIPTION
As the last failures of the PR job validator demonstrate, it's quite easy to
get several flaky builds in a row. This is painful to a degree that cannot be
tolerated anymore, which is why I'm enabling the `retryFlakyTest` flag by
default, and you should explicitly pass `-DretryFlakyTests=false` to the build
if you don't want known flaky test to be re-run.

By the way, I'm not removing the `retryFlakyTests` profile because the scala
validation script uses it, and this way we can easily change again the default
of `retryFlakyTest` without having to go and update the validation script.
