### PR TITLE
`ScalaPresentationCompilerProxy.apply` should never return `Some(null)`

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompilerProxy.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompilerProxy.scala
@@ -46,7 +46,10 @@ final class ScalaPresentationCompilerProxy(project: ScalaProject) extends HasLog
   /** Ask to restart the presentation compiler before processing the next request. */
   def askRestart(): Unit = { restartNextTime = true }
 
-  /** Executes the passed `op` on the presentation compiler. */
+  /** Executes the passed `op` on the presentation compiler.
+   *
+   *  @return `None` if `op` returns `null`, `Some(value)` otherwise.
+   */
   def apply[U](op: ScalaPresentationCompiler => U): Option[U] = {
     def obtainPc(): ScalaPresentationCompiler = {
       pcLock.synchronized {
@@ -66,7 +69,7 @@ final class ScalaPresentationCompilerProxy(project: ScalaProject) extends HasLog
       }
     }
 
-    Option(obtainPc()) map op
+    Option(obtainPc()) flatMap (pc => Option(op(pc)))
   }
 
   /** Updates `pc` with a new Presentation Compiler instance.


### PR DESCRIPTION
The former implementation of `ScalaPresentationCompilerProxy.apply` could return
`Some(null)` if the passed `op` returned `null`. This was not the intended
semantic.

A different issue I'm thinking about is how I can provide an overload of
`ScalaPresentationCompilerProxy.apply` to allow to pass either an `op` of type
`ScalaPresentationCompiler => U` or `ScalaPresentationCompiler => Option[U]`.
The simplest way to do so would be to have two different methods, but I want to
think about this a bit more.

By the way, this fix is needed to make the play2 support work with the latest master (will create a PR shortly, and a test will be failing until this gets merged).
