### PR TITLE
`ScalaClassFileEditor` should always hold a `ScalaClassFile`

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFileProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFileProvider.scala
@@ -17,15 +17,7 @@ import scala.tools.eclipse.logging.HasLogger
 class ScalaClassFileProvider extends IClassFileProvider with HasLogger {
   override def create(contents : Array[Byte], parent : PackageFragment, name : String) : ClassFile =
     ScalaClassFileDescriber.isScala(new ByteArrayInputStream(contents)) match {
-      case Some(sourceFile) =>
-        val scf = new ScalaClassFile(parent, name, sourceFile)
-        val sourceMapper = parent.getSourceMapper
-        if (sourceMapper == null)
-          null
-        else {
-          val source = sourceMapper.findSource(scf.getType, sourceFile)
-          if (source != null) scf else null
-        }
+      case Some(sourcePath) => new ScalaClassFile(parent, name, sourcePath)
       case _ => null
     }
 


### PR DESCRIPTION
There doesn't seem to be a good reason for not creating a `ScalaClassFile` when
source attachments cannot be located.

Doing so has two nice consequences:

1) When sources are manually attached to a Scala JAR, and a classfile is opened
   in an editor, the source is now correctly syntactically highlighted. This
   basically fix half of ticket Re #1001926 (the other half is triggering
   semantic highlighting).

2) `ScalaClassFileEditor` instances are now ensured to be always created with
   an underlying `ScalaClassFile`. This is an important fact, as
   `ScalaClassFileEditor` assumes it (in fact, the `ClassCastException`
   reported in ticket Re #1001925 was happening because this implicit contract
   was broken, i.e., it was possible that a `ScalaClassFileEditor` could be
   created with a (Java) `ClassFile` when no source attachment was found.

By the way, the `ClassCastException` issue mentioned in point 2) could be
reproduced by copying a **Scala** classfile in the root of a project, and then
trying to opening (by double-clicking on it from the Package Explorer view)
would result in an error prompted to the user.

Fixes #1001925
