### PR TITLE
Fixing MatchError on Watch Expression View by defining a default icon.

### DIFF
--- a/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
+++ b/org.scala-ide.sdt.debug/src/scala/tools/eclipse/debug/model/ScalaDebugModelPresentation.scala
@@ -112,6 +112,8 @@ class ScalaDebugModelPresentation extends IDebugModelPresentation {
         // variable used to split large arrays
         // TODO: see ScalaVariable before
         DebugUITools.getImage(IDebugUIConstants.IMG_OBJS_VARIABLE)
+
+      case _ => DebugUITools.getImage(IDebugUIConstants.IMG_OBJS_VARIABLE)
     }
   }
 


### PR DESCRIPTION
Fix #1001933
