### PR TITLE
adds constructor autocomplete. t1001272

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
@@ -294,6 +294,19 @@ class CompletionTests {
   }
 
   @Test
+  def t1001272() {
+    val oraclePos16_18 = List("A(): t1001272.A", "A(Int): t1001272.A")
+    val oraclePos17_18 = List("B(): t1001272.B")
+    val oraclePos18_20 = List("E(Int): t1001272.D.E")
+    val oraclePos19_26 = List("InnerA(Int): t1001272.Test.a.InnerA")
+
+    val unit = scalaCompilationUnit("t1001272/A.scala")
+    reload(unit)
+
+    runTest("t1001272/A.scala", false)(oraclePos16_18, oraclePos17_18, oraclePos18_20, oraclePos19_26)
+  }
+
+  @Test
   def t1001125() {
     withCompletions("t1001125/Ticket1001125.scala") {
       (index, position, completions) =>

--- a/org.scala-ide.sdt.core.tests/test-workspace/completion/src/t1001272/A.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/completion/src/t1001272/A.scala
@@ -1,0 +1,20 @@
+package t1001272
+
+class A(a: Int) {
+  def this() = this(123)
+
+  class InnerA(i: Int)
+}
+
+class B extends A(1)
+
+object D {
+  class E(i: Int)
+}
+
+object Test {
+  val a = new A( /*!*/ )
+  val b = new B( /*!*/ )
+  val e = new D.E( /*!*/ )
+  val ia = new a.InnerA( /*!*/ )
+}

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -281,7 +281,7 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
     else if (sym.isModule) Object
     else if (sym.isType) Type
     else Val
-    val name = sym.decodedName
+    val name = if (sym.isConstructor) sym.owner.decodedName else sym.decodedName
     val signature =
       if (sym.isMethod) {
         name +

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/CompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/completion/CompletionProposal.scala
@@ -25,6 +25,7 @@ object CompletionContext {
   trait ContextType
   case object DefaultContext extends ContextType
   case object ApplyContext extends ContextType
+  case object NewContext extends ContextType
   case object ImportContext extends ContextType
 }
 


### PR DESCRIPTION
The behaviour is similar to how method completion works currently,
no attempt is made to replace existing arguments / parens, but instead
we show the tooltip with the parameter information to help.
