### PR TITLE
Remove rename proposal from quick assists.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/RenameProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/RenameProposal.scala
@@ -1,7 +1,0 @@
-package scala.tools.eclipse.quickfix
-
-import scala.tools.eclipse.refactoring.rename.RenameAction
-
-object RenameProposal
-  extends ProposalRefactoringActionAdapter(
-      new RenameAction, "Rename value")

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickAssistProcessor.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/quickfix/ScalaQuickAssistProcessor.scala
@@ -66,7 +66,6 @@ object ScalaQuickAssistProcessor {
     ExtractLocalProposal,
     ExpandCaseClassBindingProposal,
     InlineLocalProposal,
-    RenameProposal,
     ExtractMethodProposal
   )
 }


### PR DESCRIPTION
Checking for initial conditions requires a full project index, leading
to unnecessary long wait times. As the name implies, we'd like to keep it fast,
especially since it happens on the UI thread.

Fixed #1001947.
