### PR TITLE
Enable editor preferences

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -769,6 +769,9 @@
      <initializer
            class="scala.tools.eclipse.PreferenceInitializer">
      </initializer>
+     <initializer
+           class="scala.tools.eclipse.properties.EditorPreferenceInitializer">
+     </initializer>
   </extension>
 
   <extension point="org.eclipse.core.expressions.propertyTesters">

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/EditorPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/EditorPreferencePage.scala
@@ -53,7 +53,7 @@ object EditorPreferencePage {
   final val P_ENABLE_MARK_OCCURRENCES = BASE + "markOccurences"
 }
 
-class DebugPreferenceInitializer extends AbstractPreferenceInitializer {
+class EditorPreferenceInitializer extends AbstractPreferenceInitializer {
 
   override def initializeDefaultPreferences() {
     val store = ScalaPlugin.plugin.getPreferenceStore


### PR DESCRIPTION
Rename `DebugPreferenceInitializer` to `EditorPreferenceInitializer`

Fixes #1001965
