### PR TITLE
Add semantic highlighting for type Dynamic

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/DynamicTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/DynamicTest.scala
@@ -1,0 +1,110 @@
+package scala.tools.eclipse.semantichighlighting.classifier
+
+import org.junit._
+import org.osgi.framework.Version
+
+import SymbolTypes._
+
+class DynamicTest extends AbstractSymbolClassifierTest {
+
+  @Test
+  def selectDynamic() {
+    checkSymbolClassification("""
+      object X {
+        (new D).field
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def selectDynamic(name: String) = ???
+      }
+      """, """
+      object X {
+        (new D).$VAR$
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def selectDynamic(name: String) = ???
+      }
+      """,
+      Map("VAR" -> TemplateVar))
+  }
+
+  @Test
+  def updateDynamic() {
+    checkSymbolClassification("""
+      object X {
+        val d = new D
+        d.field = 10
+        d.field
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def selectDynamic(name: String) = ???
+        def updateDynamic(name: String)(value: Any) = ???
+      }
+      """, """
+      object X {
+        val d = new D
+        d.$VAR$ = 10
+        d.$VAR$
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def selectDynamic(name: String) = ???
+        def updateDynamic(name: String)(value: Any) = ???
+      }
+      """,
+      Map("VAR" -> TemplateVar))
+  }
+
+  @Test
+  def applyDynamic() {
+    checkSymbolClassification("""
+      object X {
+        val d = new D
+        d.method(10)
+        d(10)
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def applyDynamic(name: String)(value: Any) = ???
+      }
+      """, """
+      object X {
+        val d = new D
+        d.$METH$(10)
+        d(10)
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def applyDynamic(name: String)(value: Any) = ???
+      }
+      """,
+      Map("METH" -> Method))
+  }
+
+  @Test
+  def applyDynamicNamed() {
+    checkSymbolClassification("""
+      object X {
+        val d = new D
+        d.method(value = 10)
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def applyDynamicNamed(name: String)(value: (String, Any)) = ???
+      }
+      """, """
+      object X {
+        val d = new D
+        d.$METH$($ARG$ = 10)
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def applyDynamicNamed(name: String)(value: (String, Any)) = ???
+      }
+      """,
+      Map("METH" -> Method, "ARG" -> Param))
+  }
+
+}

--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassifierTestSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/semantichighlighting/classifier/SymbolClassifierTestSuite.scala
@@ -23,5 +23,6 @@ import org.junit.runners.Suite
   classOf[TemplateVarTest],
   classOf[TraitTest],
   classOf[TypeParameterTest],
-  classOf[TypeTest]))
+  classOf[TypeTest],
+  classOf[DynamicTest]))
 class SymbolClassifierTestSuite


### PR DESCRIPTION
Calls like `d.foo(1)` or `d.foo(param = 1)` are treated as method
calls whereas calls like `d.foo` or `d.foo = 1` are treated as vars.

It can be that a call to `d.foo` must not be a mutable field but an
immutable one when no corresponding call to `updateDynamic` is done
before. However, in such a case `foo` is highlighted as a var becuase
it is impossible for the IDE to detect such runtime informations.

Fixes #1001656
