### PR TITLE
Unused member warning doesn't highlight whole definition anymore

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -490,7 +490,8 @@ object ScalaPresentationCompiler {
       import prob._
       if (pos.isDefined) {
         val source = pos.source
-        val pos1 = pos.toSingleLine
+        val start = pos.point
+        val end = start + ScalaWordFinder.findWord(source.content, start).getLength() - 1
         val fileName =
           source.file match {
             case EclipseFile(file) =>
@@ -506,10 +507,10 @@ object ScalaPresentationCompiler {
           0,
           new Array[String](0),
           nscSeverityToEclipse(severityLevel),
-          pos1.startOrPoint,
-          math.max(pos1.startOrPoint, pos1.endOrPoint - 1),
-          pos1.line,
-          pos1.column))
+          start,
+          end,
+          pos.line,
+          pos.column))
       } else None
     }
 


### PR DESCRIPTION
Previously, the whole definition is highlighted by an unused member
warning, which was very annoying. The new behavior only highlights their
names.

The fix will also affect any other error message that highlights a whole
expression or definition.

No tests included because I have no idea on how to test the behavior.
Only some manual tests were done:

```
class MyClass {
  private def hello(i: Int) = { // <--
    println(i)
    i
  }

  private val abc = { // <--
    0
  }

  def ghi = {
    val abc = { // <--
      0
    }
    5
  }

  private class Xros { // <--
    val xxx = 0
  }
}
```

Fixes #1001983
