### PR TITLE
Remove trailing whitespace in field completion

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -410,7 +410,10 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
     else if (sym.isModule) Object
     else if (sym.isType) Type
     else Val
-    val name = if (sym.isConstructor) sym.owner.decodedName else sym.decodedName
+    val name = {
+      val name = if (sym.isConstructor) sym.owner.decodedName else sym.decodedName
+      name.trim
+    }
     val signature =
       if (sym.isMethod) {
         name +


### PR DESCRIPTION
A field in Scala consists a getter method and an underlying field that
has the same name as the getter. Because of this there would exist two
Symbols with the same name in the same scope, which is not allowed.
Thus, the underlying field contains an trailing whitespace to separate
it from the getter.

This fix just trims all Symbol names coming from scalac to avoid moving
the trailing whitespace around.

Fixes #1001973
