### PR TITLE
Correct completion overwrite behavior when nothing is overwritten

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaCompletionProposal.scala
@@ -212,10 +212,11 @@ class ScalaCompletionProposal(proposal: CompletionProposal, selectionProvider: I
     }
 
     if (!tooltipsOnly && context.contextType != CompletionContext.ImportContext) {
-      if (!overwrite) selectionProvider match {
+      if (!overwrite || !doParamsProbablyExist) selectionProvider match {
         case viewer: ITextViewer if explicitParamNames.flatten.nonEmpty =>
           addArgumentTemplates(d, viewer, completionFullString)
-        case _ => ()
+        case _ =>
+          adjustCursorPosition()
       }
       else
         adjustCursorPosition()


### PR DESCRIPTION
This fixes the problem only partially because it is based on a
heuristic, but it should fix the most important cases.

The logic is overall very complex, nevertheless no tests are provided
because there exists no test suite that can test the contents of a
document after a completion happened and writing such a test suite is
not trivial.

Fixes #1001791
