### PR TITLE
Reverts logic for unloading units in askLoadedType

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -45,70 +45,6 @@ import org.eclipse.core.resources.IFile
 import org.eclipse.jdt.internal.core.util.Util
 import scala.tools.eclipse.compiler.CompilerApiExtensions
 
-/**
- * This hack will be made obsolete once SI-7982 is fixed
- */
-
-trait UnitRemoval extends Global { self: Global =>
-  def removeUnits(sources: List[SourceFile], response: Response[Unit]) {
-    informIDE("units removed: " + sources)
-    sources foreach (removeUnitOf(_))
-    // no new compiler run
-    respond(response)(())
-  }
-}
-
-trait UnitRemovalWorkItem extends UnitRemoval with scala.tools.nsc.interactive.CompilerControl { self:Global =>
-
-  def customPostWorkItem(item: WorkItem) =
-    if (item.onCompilerThread) item() else scheduler.postWorkItem(item)
-
-  case class RemoveUnits(sources: List[SourceFile], response: Response[Unit]) extends WorkItem {
-    def apply() = removeUnits(sources, response)
-    override def toString = "remove "+sources
-
-    def raiseMissing() = response raise new MissingResponse
-  }
-
-}
-
-trait OptionAsking extends Global { self: Global =>
-  def askOption[A](op: () => A): Option[A]
-}
-
-trait LoadedTypeAdapter extends OptionAsking with UnitRemovalWorkItem { self:Global =>
-
-  /*
-   * TODO : this askLoadedTyped semantics should be pushed in the PC
-   */
-
-  @deprecated("Use loadedType instead.", "4.0.0")
-  def body(sourceFile: SourceFile, keepLoaded: Boolean = false): Either[Tree, Throwable] = loadedType(sourceFile, keepLoaded)
-
-  override def askLoadedTyped(sourceFile: SourceFile, response: Response[Tree]):Unit =
-    askLoadedTyped(sourceFile, false, response)
-
-  def askLoadedTyped(sourceFile: SourceFile, keepLoaded: Boolean, response: Response[Tree]):Unit = {
-    // iff the unit was already loaded (e.g. open buffer) we don't force a final reset controlled by keepLoaded
-    val wasLoaded = askOption{() => getUnit(sourceFile).isDefined}.getOrElse(false)
-    try super.askLoadedTyped(sourceFile, response)
-    finally { if (!wasLoaded && !keepLoaded) {
-      val dummyResponse = new Response[Unit]()
-      customPostWorkItem(RemoveUnits(List(sourceFile), dummyResponse))}}
-  }
-
-  def loadedType(sourceFile: SourceFile, keepLoaded:Boolean = false): Either[Tree, Throwable] = {
-    val response = new Response[Tree]
-    if (self.onCompilerThread)
-      throw ScalaPresentationCompiler.InvalidThread("Tried to execute `askLoadedType` while inside `ask`")
-    askLoadedTyped(sourceFile, keepLoaded, response)
-    response.get
-  }
-
-  /*
-   * END askLoadedTyped semantics
-   */
-}
 
 class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) extends {
   /*
@@ -130,8 +66,7 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
   with JVMUtils
   with LocateSymbol
   with CompilerApiExtensions
-  with HasLogger
-  with OptionAsking with LoadedTypeAdapter{ self =>
+  with HasLogger { self =>
 
   def presentationReporter = reporter.asInstanceOf[ScalaPresentationCompiler.PresentationReporter]
   presentationReporter.compiler = this
@@ -246,6 +181,17 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
   @deprecated("Use `InteractiveCompilationUnit.withSourceFile` instead", since = "4.0.0")
   def withSourceFile[T](icu: InteractiveCompilationUnit)(op: (SourceFile, ScalaPresentationCompiler) => T): T =
     icu.withSourceFile(op) getOrElse (throw new UnsupportedOperationException("Use `InteractiveCompilationUnit.withSourceFile`"))
+
+  @deprecated("Use loadedType instead.", "4.0.0")
+  def body(sourceFile: SourceFile, keepLoaded: Boolean = false): Either[Tree, Throwable] = loadedType(sourceFile, keepLoaded)
+
+  def loadedType(sourceFile: SourceFile, keepLoaded: Boolean = false): Either[Tree, Throwable] = {
+    val response = new Response[Tree]
+    if (self.onCompilerThread)
+      throw ScalaPresentationCompiler.InvalidThread("Tried to execute `askLoadedType` while inside `ask`")
+    askLoadedTyped(sourceFile, keepLoaded, response)
+    response.get
+  }
 
   def withParseTree[T](sourceFile: SourceFile)(op: Tree => T): T = {
     op(parseTree(sourceFile))


### PR DESCRIPTION
The loagic for handling loading/unloading of units in `askLoadedType` was moved
in the compiler side. See https://github.com/scala/scala/pull/3209.  (Also,
mind that this commit should be merged together with the previously linked
scala PR).

This reverts most of the changes made in SHA:
43f8f2bdf4bd99cc85da7f54a0f374be737d4b2f

Re #1001388
