### PR TITLE
Make pointcut pick up subclasses of ScalaJavaBuilder.

### DIFF
--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/builderoptions/ScalaJavaBuilderAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/builderoptions/ScalaJavaBuilderAspect.aj
@@ -19,7 +19,7 @@ import org.eclipse.jdt.internal.core.util.Util;
 @SuppressWarnings("restriction")
 public privileged aspect ScalaJavaBuilderAspect {
   pointcut build() :
-    execution(IProject[] ScalaJavaBuilder.build(int, Map, IProgressMonitor) throws CoreException);
+    execution(IProject[] ScalaJavaBuilder+.build(int, Map, IProgressMonitor) throws CoreException);
   
   pointcut cleanOutputFolders(boolean copyBack) :
     args(copyBack) &&
@@ -38,7 +38,7 @@ public privileged aspect ScalaJavaBuilderAspect {
     cleanOutputFolders(copyBack) &&
     cflow(build()) {
     // Suppress the cleaning behaviour but do the extra resource copying if requested
-    if (copyBack) 
+    if (copyBack)
       for (int i = 0, l = builder.sourceLocations.length; i < l; i++) {
         org.eclipse.jdt.internal.core.builder.ClasspathMultiDirectory sourceLocation = builder.sourceLocations[i];
         Class c = sourceLocation.getClass();


### PR DESCRIPTION
This fixes a problem at a customer (cleaning output folders, leading to
empty output folders after successful builds), but I could not reproduce
locally. Confirmed it works for said customer, so rolling back to main
project.

(this is a 3.0.x PR, master-relative fix coming as well).
