### PR TITLE
Make pointcut pick up subclasses of ScalaJavaBuilder.

### DIFF
--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/builderoptions/ScalaJavaBuilderAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/builderoptions/ScalaJavaBuilderAspect.aj
@@ -21,7 +21,7 @@ import org.eclipse.jdt.internal.core.util.Util;
 @SuppressWarnings("restriction")
 public privileged aspect ScalaJavaBuilderAspect {
   pointcut build() :
-    execution(IProject[] ScalaJavaBuilder.build(int, Map, IProgressMonitor) throws CoreException);
+    execution(IProject[] ScalaJavaBuilder+.build(int, Map, IProgressMonitor) throws CoreException);
   
   pointcut cleanOutputFolders(boolean copyBack) :
     args(copyBack) &&


### PR DESCRIPTION
This fixes a problem at a customer (cleaning output folders, leading to
empty output folders after successful builds), but I could not reproduce
locally. Confirmed it works for said customer, so rolling back to main
project.

Fixed #1001995

(cherry picked from commit bcd85b3a3af3b00b3cb195b2561c1c880feac0b9)
