### PR TITLE
Lets the sdt.core pom.xml copy scala-reflect from the m2repo to the target folder

### DIFF
--- a/org.scala-ide.sdt.core/pom.xml
+++ b/org.scala-ide.sdt.core/pom.xml
@@ -162,6 +162,14 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.scala-lang</groupId>
+                  <artifactId>scala-reflect</artifactId>
+                  <classifier>sources</classifier>
+                  <type>jar</type>
+                  <destFileName>scala-reflect-src.jar</destFileName>
+                  <outputDirectory>${project.build.directory}/src</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.scala-lang</groupId>
                   <artifactId>scala-compiler</artifactId>
                   <classifier>sources</classifier>
                   <type>jar</type>

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,11 @@
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
+        <artifactId>scala-reflect</artifactId>
+        <version>${scala.library.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
         <artifactId>scala-actors</artifactId>
         <version>${scala.library.version}</version>
       </dependency>


### PR DESCRIPTION
Fixes #1001987

Monkey-tested with the protocol at the above-mentioned bug report.
