### PR TITLE
Don't skip trees with transparent positions when looking for references

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaMatchLocator.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaMatchLocator.scala
@@ -58,8 +58,8 @@ trait ScalaMatchLocator { self: ScalaPresentationCompiler =>
     def possibleMatch: PossibleMatch
 
     override def traverse(tree: Tree): Unit = try {
-      if (tree.pos.isOpaqueRange && tree.pos.isDefined) {
-        report(tree)
+      if (tree.pos.isRange && tree.pos.isDefined) {
+        if(tree.pos.isOpaqueRange) report(tree)
         /* We need to customize the traversal of the Tree to ensure that the `Traverser.currentOwner`
          * gets updated only when a declaration is traversed (have a look at `enclosingDeclaration`).
          * This is done because reference matches are always reported on the enclosing declaration.


### PR DESCRIPTION
Trees with a transparent position may contain trees with range
positions, hence we should make sure to:

1) Traverse tree with a transparent position, and 2) Only call `report`
on tree that have an opaque range position.

This is a bug that was made apparent by the changes needed to fix the
Scala compiler ticket SI-4287.
