### PR TITLE
Workaround for race condition during source indexing

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaJavaMapper.scala
@@ -16,9 +16,10 @@ import org.eclipse.core.runtime.Path
 
 trait ScalaJavaMapper extends ScalaAnnotationHelper with HasLogger { self : ScalaPresentationCompiler =>
 
+  @deprecated("Remove this when dropping Scala 2.10 support. See SI-8030")
   private[eclipse] def initializeRequiredSymbols() {
     import definitions._
-    Set(UnitClass,
+    val symbols = Vector(UnitClass,
       BooleanClass,
       ByteClass,
       ShortClass,
@@ -27,7 +28,9 @@ trait ScalaJavaMapper extends ScalaAnnotationHelper with HasLogger { self : Scal
       FloatClass,
       DoubleClass,
       NilModule,
-      ListClass).foreach(_.initialize)
+      ListClass) ++ TupleClass.seq
+
+    symbols.foreach(_.initialize)
   }
 
   /** Return the Java Element corresponding to the given Scala Symbol, looking in the


### PR DESCRIPTION
(This is a reopening of https://github.com/scala-ide/scala-ide/pull/595, due to https://github.com/scala-ide/scala-ide/pull/595#issuecomment-30657074)

Initialize the `TupleClass` symbol to prevent the presentation compiler
assertion that checks thread confinement to fail on parse trees, as
demonstrated by Re #1001986. This is a workaround for scalac ticket SI-8030, as
we need the fix to be readily available on Scala 2.10 as well.

Calling `initialize` is sufficient according to @retronym, as highlighted in
this comment https://github.com/scala/scala/pull/3262/files#r8361292
