### PR TITLE
Don't add local suffix (one space character) for field completions

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/scala/tools/eclipse/completion/CompletionTests.scala
@@ -242,7 +242,6 @@ class CompletionTests {
     }
   }
 
-  @Ignore("Ignoring because failing spuriously on 2.11. See #1001973")
   @Test
   def relevanceSortingTests() {
     val unit = scalaCompilationUnit("relevance/RelevanceCompletions.scala")

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala
@@ -356,7 +356,13 @@ class ScalaPresentationCompiler(project: ScalaProject, settings: Settings) exten
     else if (sym.isModule) Object
     else if (sym.isType) Type
     else Val
-    val name = if (sym.isConstructor) sym.owner.decodedName else sym.decodedName
+
+    val name = if (sym.isConstructor)
+      sym.owner.decodedName
+    else if (sym.hasGetter)
+      (sym.getter: Symbol).decodedName
+    else sym.decodedName
+
     val signature =
       if (sym.isMethod) {
         name +


### PR DESCRIPTION
Correctly deal with private local fields backing up a val/var. The
proper way to look at such fields is to look for their getter (who
has the correct name, accessibility flags, etc).

Fixes #1001973
