### PR TITLE
Add synchronisation around map `getOrElse`.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFileProvider.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaClassFileProvider.scala
@@ -54,7 +54,10 @@ class ScalaClassFileProvider extends IClassFileProvider with HasLogger {
   override def isInteresting(classFile: IClassFile): Boolean = {
     if (ScalaPlugin.plugin.isScalaProject(classFile.getJavaProject)) {
       val pfr = ancestorFragmentRoot(classFile)
-      pfr.map(scalaPackageFragments.getOrElse(_, true)).getOrElse(false)
+      // synchronized needed for visibility
+      scalaPackageFragments.synchronized {
+        pfr.map(scalaPackageFragments.getOrElse(_, true)).getOrElse(false)
+      }
     } else
       false
   }


### PR DESCRIPTION
Needed for proper visibility, in case this code
is called on different threads.
(cherry picked from commit 6181d7f57da6c28cc6f6ef0df873a2f7a960ba73)
