### PR TITLE
Add an option to show API diffs when building

### DIFF
--- a/org.scala-ide.sbt.full.library/pom.xml
+++ b/org.scala-ide.sbt.full.library/pom.xml
@@ -43,6 +43,11 @@
         <artifactId>incremental-compiler</artifactId>
         <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.java-diff-utils</groupId>
+      <artifactId>diffutils</artifactId>
+      <version>${diffutils.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -58,7 +63,7 @@
             <Bundle-Name>Sbt Library for Eclipse</Bundle-Name>
             <Bundle-Version>${sbt.osgi.version}</Bundle-Version>
             <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
-            <_exportcontents>sbt.*;version=${sbt.osgi.version},xsbt.*;version=${sbt.osgi.version},xsbti.*;version=${sbt.osgi.version},sbinary.*;version=${sbt.osgi.version}</_exportcontents>
+            <_exportcontents>sbt.*;version=${sbt.osgi.version},xsbt.*;version=${sbt.osgi.version},xsbti.*;version=${sbt.osgi.version},sbinary.*;version=${sbt.osgi.version},difflib.*;version=${diffutils.version}</_exportcontents>
             <Embed-StripVersion>true</Embed-StripVersion>
           </instructions>
         </configuration>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/SbtInputs.scala
@@ -41,7 +41,12 @@ class SbtInputs(sourceFiles: Seq[File], project: ScalaProject, javaMonitor: SubM
         }
     def progress = Maybe.just(scalaProgress)
     def reporter = scalaReporter
-    override def incrementalCompilerOptions = IncOptions.toStringMap(IncOptions.Default)
+    override def incrementalCompilerOptions: java.util.Map[String, String] = {
+      val incOptions = sbt.inc.IncOptions.Default.copy(
+          apiDebug = project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(properties.ScalaPluginSettings.apiDiff.name)),
+          apiDumpDirectory = None)
+      sbt.inc.IncOptions.toStringMap(incOptions)
+    }
   }
 
   def options = new Options {

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
@@ -29,7 +29,13 @@ object IDESettings {
   }
 
   def buildManagerSettings: List[Box] =
-    List(Box("Build manager", List(buildManager, compileOrder, stopBuildOnErrors, debugIncremental, withVersionClasspathValidator)))
+    List(Box("Build manager",
+      List(buildManager,
+        compileOrder,
+        stopBuildOnErrors,
+        debugIncremental,
+        apiDiff,
+        withVersionClasspathValidator)))
 }
 
 object ScalaPluginSettings extends Settings {
@@ -39,4 +45,5 @@ object ScalaPluginSettings extends Settings {
   val stopBuildOnErrors = BooleanSetting("-stopBuildOnError", "Stop build if dependent projects have errors.")
   val debugIncremental = BooleanSetting("-debugIncremental", "Explain incremental compilation (sbt builder only)")
   val withVersionClasspathValidator = BooleanSetting("-withVersionClasspathValidator", "Check Scala compatibility of jars in classpath")
+  val apiDiff = BooleanSetting("-apiDiff", "Log type diffs that trigger additional compilation (slows down builder)")
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
@@ -40,6 +40,7 @@ class ScalaCompilerPreferenceInitializer extends AbstractPreferenceInitializer {
       IDESettings.buildManagerSettings.foreach {_.userSettings.foreach(defaultPreference)}
       store.setDefault(convertNameToProperty(ScalaPluginSettings.stopBuildOnErrors.name), true)
       store.setDefault(convertNameToProperty(ScalaPluginSettings.debugIncremental.name), false)
+      store.setDefault(convertNameToProperty(ScalaPluginSettings.apiDiff.name), false)
       store.setDefault(convertNameToProperty(ScalaPluginSettings.withVersionClasspathValidator.name), true)
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <miglayout.version>3.7.4</miglayout.version>
     <log4j.version>1.2.17</log4j.version>
     <mockito.version>1.9.5</mockito.version>
+    <diffutils.version>1.2.1</diffutils.version>
 
     <!-- plugin versions -->
     <tycho.plugin.version>0.18.1</tycho.plugin.version>


### PR DESCRIPTION
The incremental compiler can print diffs that explain
why additional files need recompilation. This commit adds
the diffutil.jar and a user-level option.

Fixed #1001952
