### PR TITLE
Adds decorator extension point to change icons for Scala files

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -1510,4 +1510,17 @@
          <!-- END : do we need these? -->
     </kind>
  </extension>
+ <extension
+       point="org.eclipse.ui.decorators">
+    <decorator
+          class="scala.tools.eclipse.ui.ScalaDecorator"
+          id="scala.tools.eclipse.ui.ScalaDecorator"
+          label="Scala Decorations"
+          state="true"
+          lightweight="true">
+       <description>
+          Shows Scala specific icons
+       </description>
+    </decorator>
+ </extension>
 </plugin>

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaImages.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaImages.scala
@@ -5,48 +5,58 @@
 
 package scala.tools.eclipse
 
-import java.net.MalformedURLException
-import java.net.URL
-
+import org.eclipse.core.runtime.FileLocator
+import org.eclipse.core.runtime.Path
+import org.eclipse.core.runtime.Platform
 import org.eclipse.jface.resource.ImageDescriptor
+import org.osgi.framework.Bundle
 
-object ScalaImages  {
+object ScalaImages {
   val MISSING_ICON = ImageDescriptor.getMissingImageDescriptor
 
-  val SCALA_FILE = create("icons/full/obj16/scu_obj.gif")
-  val SCALA_CLASS_FILE = create("icons/full/obj16/sclassf_obj.gif")
-  val EXCLUDED_SCALA_FILE = create("icons/full/obj16/scu_resource_obj.gif")
+  val SCALA_FILE = fromCoreBundle("/icons/full/obj16/scu_obj.gif")
+  val SCALA_CLASS_FILE = fromCoreBundle("/icons/full/obj16/sclassf_obj.gif")
+  val EXCLUDED_SCALA_FILE = fromCoreBundle("/icons/full/obj16/scu_resource_obj.gif")
 
-  val SCALA_CLASS = create("icons/full/obj16/class_obj.gif")
-  val SCALA_TRAIT = create("icons/full/obj16/trait_obj.gif")
-  val SCALA_OBJECT = create("icons/full/obj16/object_obj.gif")
-  val SCALA_PACKAGE_OBJECT = create("icons/full/obj16/package_object_obj.png")
+  val SCALA_CLASS = fromCoreBundle("/icons/full/obj16/class_obj.gif")
+  val SCALA_TRAIT = fromCoreBundle("/icons/full/obj16/trait_obj.gif")
+  val SCALA_OBJECT = fromCoreBundle("/icons/full/obj16/object_obj.gif")
+  val SCALA_PACKAGE_OBJECT = fromCoreBundle("/icons/full/obj16/package_object_obj.png")
 
-  val PUBLIC_DEF = create("icons/full/obj16/defpub_obj.gif")
-  val PRIVATE_DEF = create("icons/full/obj16/defpri_obj.gif")
-  val PROTECTED_DEF = create("icons/full/obj16/defpro_obj.gif")
+  val PUBLIC_DEF = fromCoreBundle("/icons/full/obj16/defpub_obj.gif")
+  val PRIVATE_DEF = fromCoreBundle("/icons/full/obj16/defpri_obj.gif")
+  val PROTECTED_DEF = fromCoreBundle("/icons/full/obj16/defpro_obj.gif")
 
-  val PUBLIC_VAL = create("icons/full/obj16/valpub_obj.gif")
-  val PROTECTED_VAL = create("icons/full/obj16/valpro_obj.gif")
-  val PRIVATE_VAL = create("icons/full/obj16/valpri_obj.gif")
+  val PUBLIC_VAL = fromCoreBundle("/icons/full/obj16/valpub_obj.gif")
+  val PROTECTED_VAL = fromCoreBundle("/icons/full/obj16/valpro_obj.gif")
+  val PRIVATE_VAL = fromCoreBundle("/icons/full/obj16/valpri_obj.gif")
 
-  val SCALA_TYPE = create("icons/full/obj16/typevariable_obj.gif")
+  val SCALA_TYPE = fromCoreBundle("/icons/full/obj16/typevariable_obj.gif")
 
-  val SCALA_PROJECT_WIZARD = create("icons/full/wizban/newsprj_wiz.png")
+  val SCALA_PROJECT_WIZARD = fromCoreBundle("/icons/full/wizban/newsprj_wiz.png")
 
-  val REFRESH_REPL_TOOLBAR = create("icons/full/etool16/refresh_interpreter.gif")
+  val REFRESH_REPL_TOOLBAR = fromCoreBundle("/icons/full/etool16/refresh_interpreter.gif")
 
-  val NEW_CLASS = create("icons/full/etool16/newclass_wiz.gif")
-  val CORRECTION_RENAME = create("icons/full/obj16/correction_rename.gif")
+  val NEW_CLASS = fromCoreBundle("/icons/full/etool16/newclass_wiz.gif")
+  val CORRECTION_RENAME = fromCoreBundle("/icons/full/obj16/correction_rename.gif")
 
-  private def create(localPath : String) = {
-    try {
-      val pluginInstallURL : URL = ScalaPlugin.plugin.getBundle.getEntry("/")
-      val url = new URL(pluginInstallURL, localPath)
-      ImageDescriptor.createFromURL(url)
-    } catch {
-      case _ : MalformedURLException =>
-        ScalaImages.MISSING_ICON
+  private def fromCoreBundle(path: String): ImageDescriptor =
+    imageDescriptor(ScalaPlugin.plugin.pluginId, path) getOrElse MISSING_ICON
+
+  /**
+   * Creates an `Option` holding an `ImageDescriptor` of an image located in an
+   * arbitrary bundle. The bundle has at least to be resolved and it may not be
+   * stopped. If that is not the case or if the the path to the image is invalid
+   * `None` is returned.
+   */
+  private def imageDescriptor(bundleId: String, path: String): Option[ImageDescriptor] =
+    Option(Platform.getBundle(bundleId)) flatMap { bundle =>
+      val state = bundle.getState()
+      if (state != Bundle.ACTIVE && state != Bundle.STARTING && state != Bundle.RESOLVED)
+        None
+      else {
+        val url = FileLocator.find(bundle, new Path(path), null)
+        Option(url) map ImageDescriptor.createFromURL
+      }
     }
-  }
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaDecorator.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ui/ScalaDecorator.scala
@@ -1,0 +1,32 @@
+package scala.tools.eclipse.ui
+
+import scala.tools.eclipse.ScalaImages
+
+import org.eclipse.core.internal.resources.File
+import org.eclipse.jface.viewers.DecorationContext
+import org.eclipse.jface.viewers.IDecoration
+import org.eclipse.jface.viewers.ILabelProviderListener
+import org.eclipse.jface.viewers.ILightweightLabelDecorator
+
+class ScalaDecorator extends ILightweightLabelDecorator {
+
+  def decorate(elem: Any, decoration: IDecoration): Unit = elem match {
+    case file: File if file.getName().endsWith(".scala") =>
+      decoration.getDecorationContext() match {
+        case dc: DecorationContext =>
+          dc.putProperty(IDecoration.ENABLE_REPLACE, true)
+          decoration.addOverlay(ScalaImages.EXCLUDED_SCALA_FILE, IDecoration.REPLACE)
+        case _ =>
+      }
+    case _ =>
+  }
+
+  def dispose(): Unit = {}
+
+  def isLabelProperty(elem: Any, property: String): Boolean = false
+
+  def addListener(listener: ILabelProviderListener): Unit = {}
+
+  def removeListener(listener: ILabelProviderListener): Unit = {}
+
+}


### PR DESCRIPTION
Scala files which are not on the classpath of a project get displayed
with an icon that is made for Java files. This commit replaces the Java
icon with a different one by using a decorator. Only the large icon is
replaced - smaller ones in the corners are not affected.

The decorator is enabled by default and can be disabled in
"Preferences/General/Appearance/Label Decorations/Scala Decorations"

This change only affects Scala files that are not on the classpath
because internally they are represented with a different object
compared to all other Scala files.

Fixes #1001975
