### PR TITLE
Removed FIXME in `ScalaSourceFile` (Refactoring)

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaSourceFile.scala
@@ -84,12 +84,13 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
    *  the loaded files managed by the presentation compiler.
    */
   override def scheduleReconcile(): Response[Unit] = {
-    // askReload first
-    // FIXME: Here we are calling a deprecated method (i.e., withPresentationCompiler) because the only way I see to fix
-    //        this without changing this method's signature is introducing a `NullResponse` object.
-    val res = scalaProject.withPresentationCompiler { compiler =>
+    val reloaded = scalaProject.presentationCompiler { compiler =>
       compiler.askReload(this, getContents)
-    } ()
+    } getOrElse {
+      val dummy = new Response[Unit]
+      dummy.set(())
+      dummy
+    }
 
     this.reconcile(
         ICompilationUnit.NO_AST,
@@ -97,7 +98,7 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
         null /* use primary owner */,
         null /* no progress monitor */);
 
-    res
+    reloaded
   }
 
   /* getProblems should be reserved for a Java context, @see getProblems */


### PR DESCRIPTION
I thought the only way to get rid of the FIXME was to introduce a
`NullResponse`, which is why I believed it was a good idea to extract a pure
interface from `Response`. As the code demonstrates, it turns out I was wrong in
believing I needed a `NullResponse`.

As a side note, while I think it may still be a good idea to turn `Response`
into a pure interface, I realistically don't see a use-case.  Further, it turns
out that implementing the semantic of a `NullReponse` wouldn't be
straightforward, because the current implementation of `Response` is somewhat
incorrect in my opinion. The issue I see is that a `Response`'s answer shouldn't
change after it is `set`, however this is not enforced in the current
implementation (e.g., one could call `set` and aferward `raise`, and the answer
to `get` would be different depending if it's executed before or after the call
to `raise` - I would consider this a bug). Hence, it currently doesn't make much
sense to turn `Response` into a pure interface.
