### PR TITLE
Do not use system properties to configure incremental compiler.

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
@@ -130,8 +130,6 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
   }
 
   private def runCompiler(sources: Seq[File]) {
-    System.setProperty(Incremental.incDebugProp,
-      project.storage.getString(SettingConverterUtil.convertNameToProperty(ScalaPluginSettings.debugIncremental.name)))
     val inputs = new SbtInputs(sources.toSeq, project, monitor, new SbtProgress, cacheFile, sbtReporter, sbtLogger)
     val analysis =
       try

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/SbtInputs.scala
@@ -44,6 +44,7 @@ class SbtInputs(sourceFiles: Seq[File], project: ScalaProject, javaMonitor: SubM
     override def incrementalCompilerOptions: java.util.Map[String, String] = {
       val incOptions = sbt.inc.IncOptions.Default.copy(
           apiDebug = project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(properties.ScalaPluginSettings.apiDiff.name)),
+          relationsDebug = project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(properties.ScalaPluginSettings.relationsDebug.name)),
           apiDumpDirectory = None)
       sbt.inc.IncOptions.toStringMap(incOptions)
     }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
@@ -33,7 +33,7 @@ object IDESettings {
       List(buildManager,
         compileOrder,
         stopBuildOnErrors,
-        debugIncremental,
+        relationsDebug,
         apiDiff,
         withVersionClasspathValidator)))
 }
@@ -43,7 +43,7 @@ object ScalaPluginSettings extends Settings {
   val compileOrder = ChoiceSetting("-compileorder", "which", "Compilation order",
       List("Mixed", "JavaThenScala", "ScalaThenJava"), "Mixed")
   val stopBuildOnErrors = BooleanSetting("-stopBuildOnError", "Stop build if dependent projects have errors.")
-  val debugIncremental = BooleanSetting("-debugIncremental", "Explain incremental compilation (sbt builder only)")
+  val relationsDebug = BooleanSetting("-relationsDebug", "Log very detailed information about relations, such as dependencies between source files.")
   val withVersionClasspathValidator = BooleanSetting("-withVersionClasspathValidator", "Check Scala compatibility of jars in classpath")
   val apiDiff = BooleanSetting("-apiDiff", "Log type diffs that trigger additional compilation (slows down builder)")
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
@@ -39,7 +39,7 @@ class ScalaCompilerPreferenceInitializer extends AbstractPreferenceInitializer {
       IDESettings.shownSettings(ScalaPlugin.defaultScalaSettings()).foreach {_.userSettings.foreach (defaultPreference)}
       IDESettings.buildManagerSettings.foreach {_.userSettings.foreach(defaultPreference)}
       store.setDefault(convertNameToProperty(ScalaPluginSettings.stopBuildOnErrors.name), true)
-      store.setDefault(convertNameToProperty(ScalaPluginSettings.debugIncremental.name), false)
+      store.setDefault(convertNameToProperty(ScalaPluginSettings.relationsDebug.name), false)
       store.setDefault(convertNameToProperty(ScalaPluginSettings.apiDiff.name), false)
       store.setDefault(convertNameToProperty(ScalaPluginSettings.withVersionClasspathValidator.name), true)
     }


### PR DESCRIPTION
Since sbt 0.13.0 we have an official mechanism for configuring
incremental compiler: IncOptions class. The IDE has been partially migrated
to use that mechanism but one use of old mechanism (that relies on JVM
system properties) was left intact. The `incDebugProp` was used to enable
debugging of relations.

We switch to `IncOptions.relationsDebug` to control debugging of relations
and get rid of manipulating system properties.

This change makes IDE compatible with all sbt 0.13.x versions (including
0.13.2-M1).
