### PR TITLE
Add support for IncOptions.{nameHashing, recompileOnMacroDef} flags

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/buildmanager/sbtintegration/EclipseSbtBuildManager.scala
@@ -28,6 +28,7 @@ import sbt.inc.AnalysisStore
 import sbt.inc.Analysis
 import sbt.inc.FileBasedStore
 import sbt.inc.Incremental
+import sbt.inc.IncOptions
 import sbt.compiler.IC
 import sbt.compiler.CompileFailed
 import org.eclipse.core.resources.IProject
@@ -144,7 +145,9 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
   private def setCached(a: Analysis): Analysis = {
    cached set new SoftReference[Analysis](a); a
   }
-  private[sbtintegration] def latestAnalysis: Analysis = Option(cached.get) flatMap (ref => Option(ref.get)) getOrElse setCached(IC.readAnalysis(cacheFile))
+  // take by-name argument because we need incOptions only when we have a cache miss
+  private[sbtintegration] def latestAnalysis(incOptions: => IncOptions): Analysis =
+    Option(cached.get) flatMap (ref => Option(ref.get)) getOrElse setCached(IC.readAnalysis(cacheFile, incOptions))
 
   private val cachePath = project.underlying.getFile(".cache")
   private def cacheFile = cachePath.getLocation.toFile

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
@@ -35,7 +35,9 @@ object IDESettings {
         stopBuildOnErrors,
         relationsDebug,
         apiDiff,
-        withVersionClasspathValidator)))
+        withVersionClasspathValidator,
+        recompileOnMacroDef,
+        nameHashing)))
 }
 
 object ScalaPluginSettings extends Settings {
@@ -46,4 +48,6 @@ object ScalaPluginSettings extends Settings {
   val relationsDebug = BooleanSetting("-relationsDebug", "Log very detailed information about relations, such as dependencies between source files.")
   val withVersionClasspathValidator = BooleanSetting("-withVersionClasspathValidator", "Check Scala compatibility of jars in classpath")
   val apiDiff = BooleanSetting("-apiDiff", "Log type diffs that trigger additional compilation (slows down builder)")
+  val recompileOnMacroDef = BooleanSetting("-recompileOnMacroDef", "Always recompile all dependencies of a macro def")
+  val nameHashing = BooleanSetting("-nameHashing", "Enable improved (experimental) incremental compilation algorithm")
 }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/ScalaCompilerPreferenceInitializer.scala
@@ -42,6 +42,8 @@ class ScalaCompilerPreferenceInitializer extends AbstractPreferenceInitializer {
       store.setDefault(convertNameToProperty(ScalaPluginSettings.relationsDebug.name), false)
       store.setDefault(convertNameToProperty(ScalaPluginSettings.apiDiff.name), false)
       store.setDefault(convertNameToProperty(ScalaPluginSettings.withVersionClasspathValidator.name), true)
+      store.setDefault(convertNameToProperty(ScalaPluginSettings.recompileOnMacroDef.name), true)
+      store.setDefault(convertNameToProperty(ScalaPluginSettings.nameHashing.name), false)
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
      <scala.library.version>${scala.version}</scala.library.version>
      <version.suffix>2_10</version.suffix>
      <version.tag>local</version.tag>
-     <sbt.version>0.13.0</sbt.version>
+     <sbt.version>0.13.2-M1</sbt.version>
      <sbt.ide.version>${sbt.version}-on-${scala.version}-for-IDE-SNAPSHOT</sbt.ide.version>
 
     <!-- the repos containing the Scala dependencies -->


### PR DESCRIPTION
Add support for new incremental compiler options introduced in sbt 0.13.2-M1:
- `nameHashing` that enables new (experimental) incremental compilation
  algorithm
- `recompileOnMacroDef` that controls the behavior of a heuristic
   that takes care of invalidating of source files that depend on
   macros

Those two options are directly exposed as IDE project settings.

Since those options are available in 0.13.2-M1 only, we bump sbt dependency to that version.

Other than that, I've made two small refactorings:
1. We don't call `IncOptions.copy` anymore but use with\* copying methods
    instead. The reason is that we've made IncOptions to be not a case
    class which makes it easier to maintain binary compatibility of
    IncOptions' API. Generally speaking, default arguments in Scala are
    not compatible with the goal of maintaining binary compatibility.
2. We've switched to a new, overloaded variant of `IC.readAnalysis` that
    takes IncOptions as an argument. The new variant returns the right
    variant of analysis in both cases when name hashing is enabled or
    disabled.

Despite the fact that we switched to the correct variant of `IC.readAnalysis` method a restart of IDE is required after changing the value of nameHashing flag. Normally, one would expect that cleaning given project is enough (that's how it works in sbt itself). However, for some reason it doesn't work in IDE. I believe that some Analysis cache is not cleared correctly when the project is being cleaned. I couldn't figure out the root cause of the problem so for now, a restart of IDE is necessary.
