### PR TITLE
Clean up .classpath files

### DIFF
--- a/org.scala-ide.sdt.core.tests/.classpath
+++ b/org.scala-ide.sdt.core.tests/.classpath
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="target/lib/mockito-all-1.9.5.jar"/>

--- a/org.scala-ide.sdt.core/.classpath
+++ b/org.scala-ide.sdt.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" output="target/classes" path="src"/>
 	<classpathentry kind="lib" path="target/lib/miglayout-3.7.4.jar"/>

--- a/org.scala-ide.sdt.debug.tests/.classpath
+++ b/org.scala-ide.sdt.debug.tests/.classpath
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="target/lib/mockito-all-1.9.5.jar"/>

--- a/org.scala-ide.sdt.debug/.classpath
+++ b/org.scala-ide.sdt.debug/.classpath
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_COMPILER_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.scala-ide.sdt.spy/.classpath
+++ b/org.scala-ide.sdt.spy/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Some .classpath files still contain references to SCALA_CONTAINER and
SCALA_COMPILER_CONTAINER which are not needed anymore. Furthermore
sdt.core explicitly references JavaSE-1.6 as its runtime environment
which shoudn't be included either because this doesn't allow a JRE
independent build.

---

**DO NOT MERGE YET**

I also removed the reference to `org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType` because I couldn't find out what this does. The Javadoc of this class does not give more information. Does someone know what this reference mean?

Furthermore `test-workspace` contain references to JavaSE-1.6 as well. I will append the changes to these files once I found out what `StandardVMType` is doing.
