### PR TITLE
SI-8151 Prepare for removal of -Yself-in-annots

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaMatchLocator.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/javaelements/ScalaMatchLocator.scala
@@ -144,7 +144,7 @@ trait ScalaMatchLocator { self: ScalaPresentationCompiler =>
     // pre.sym[targs]
   case RefinedType(parents, defs) =>
     // parent1 with ... with parentn { defs }
-  case AnnotatedType(annots, tp, selfsym) =>
+  case AnnotatedType(annots, tp) =>
     // tp @annots
           case _ => PatternLocator.INACCURATE_MATCH
         }

--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/Debugger.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/semantichighlighting/classifier/Debugger.scala
@@ -63,9 +63,6 @@ private[classifier] trait SymbolClassificationDebugger { self: SymbolClassificat
 //    }
     for (annotation <- sym.annotations) {
       print(pad(" @-" + annotation, 95))
-      val atp = annotation.atp
-      val sym = atp.selfsym
-      print(pad(" " + sym, 35))
       println()
     }
   }


### PR DESCRIPTION
Upstream, Scala will remove the `selfsym` field from `AnnotatedType`.

This commit removes its uses in Scala IDE:
1. In debug printing code
2. In a commented-out pattern match

Review by @dragos
