### PR TITLE
Fix warning about adapted argument list

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/DebugTargetTerminationTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/scala/tools/eclipse/debug/model/DebugTargetTerminationTest.scala
@@ -74,7 +74,7 @@ object DebugTargetTerminationTest {
             actors foreach { actor => assertThat(actor.toString, actor.getState, is(not(State.Terminated))) }
             actors.foreach(link(_))
             linkedActors = actors
-            reply()
+            reply(())
           case Exit(from, reason) =>
             terminatedLinks += from
             if (linkedActors.forall(terminatedLinks contains _)) {


### PR DESCRIPTION
This warning became an error in 2.11 since scala/scala#3260, when
-Xfuture is enabled.
