### PR TITLE
prevent NPE on classpath problems

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ClasspathManagement.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ClasspathManagement.scala
@@ -401,7 +401,7 @@ trait ClasspathManagement extends HasLogger { self: ScalaProject =>
     val entries = scalaClasspath.userCp
     val errors = mutable.ListBuffer[(Int, String)]()
 
-    for (entry <- entries) {
+    for (entry <- entries if entry ne null) {
       entry.lastSegment() match {
         case IncompatibleVersion(version) =>
           errors += ((IMarker.SEVERITY_ERROR, "%s is cross-compiled with an incompatible version of Scala (%s). In case of errorneous report, this check can be disabled in the compiler preference page.".format(entry.lastSegment, version)))


### PR DESCRIPTION
I hope this fixes the NPE I'm seeing on the Scala compiler project
when I forget to set the SCALA_BASEDIR variable in linked resources.

(It also needs to be set in the "classpath variables" settings panel,
but when you forget that one you get a nice error in the error log.)

```
java.lang.NullPointerException
at scala.tools.eclipse.ClasspathManagement26357anonfun.apply(ClasspathManagement.scala:405)
at scala.tools.eclipse.ClasspathManagement26357anonfun.apply(ClasspathManagement.scala:404)
at scala.collection.immutable.List.foreach(List.scala:302)
at scala.tools.eclipse.ClasspathManagement.validateBinaryVersionsOnClasspath(ClasspathManagement.scala:404)
at scala.tools.eclipse.ClasspathManagement.checkClasspath(ClasspathManagement.scala:299)
at scala.tools.eclipse.ClasspathManagement.isClasspathValid(ClasspathManagement.scala:199)
at scala.tools.eclipse.ScalaProject.isClasspathValid(ScalaProject.scala:93)
at scala.tools.eclipse.ScalaBuilder.build(ScalaBuilder.scala:59)
at org.eclipse.core.internal.events.BuildManager.run(BuildManager.java:733)
```
