### PR TITLE
Add 'Xlint' and 'feature' to the compiler preference site

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/properties/IDESettings.scala
@@ -17,7 +17,7 @@ object IDESettings {
 
     List(
       Box("Standard",
-        List(deprecation, g, optimise, target, unchecked,
+        List(lint, deprecation, feature, g, optimise, target, unchecked,
              pluginOptions, nospecialization, verbose, explaintypes, nowarn)),
       Box("Advanced",
       List(checkInit, Xchecknull, elidebelow,


### PR DESCRIPTION
Both warnings are added to the standard section because
they are some of the most important ones.

Fixes #1002039
