### PR TITLE
Presentation Compiler should not reload managed units while keeping the lock

### DIFF
--- a/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompilerProxy.scala
+++ b/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompilerProxy.scala
@@ -52,6 +52,7 @@ final class ScalaPresentationCompilerProxy(project: ScalaProject) extends HasLog
    */
   def apply[U](op: ScalaPresentationCompiler => U): Option[U] = {
     def obtainPc(): ScalaPresentationCompiler = {
+      var unitsToReload: List[InteractiveCompilationUnit] = Nil
       pcLock.synchronized {
         /* If `restartNextTime` is set to `true`, either initializing or restarting the presentation compiler is enough to fulfill the contract.
          * This also guarantees that if a `askRestart` call happens while `initialize` or `restart` is executed, the presentation compiler will
@@ -63,10 +64,22 @@ final class ScalaPresentationCompilerProxy(project: ScalaProject) extends HasLog
         restartNextTime = false
 
         if (pc eq null) initialize()
-        else if (shouldRestart) restart()
-
-        pc
+        else if (shouldRestart) {
+          // Before restarting, keep track of the compilation units managed by the current presentation compiler
+          unitsToReload = Option(pc).map(_.compilationUnits).getOrElse(Nil)
+          logger.debug("Restarting presentation compiler. The following units will be reloaded: " + unitsToReload)
+          restart()
+        }
       }
+      /* If the pc was restarted, reload all units managed by the old pc.
+       * This is done outside of the synchronized block to prevent deadlocking (see #1002003).
+       *
+       * However, by doing so we are introducing a race-condition: the compilation units that were managed by the former presentation compiler
+       * may not be loaded in the new presentation compiler. This can happen if a concurrent presentation compiler restart request is handled
+       * before the current presentation compiler was given a change to load the `unitsToReload`.
+       */
+      if((pc ne null) && unitsToReload.nonEmpty) pc.askReload(unitsToReload).get
+      pc
     }
 
     Option(obtainPc()) flatMap (pc => Option(op(pc)))
@@ -87,16 +100,12 @@ final class ScalaPresentationCompilerProxy(project: ScalaProject) extends HasLog
     finally isInitializing = false
   }
 
-  /** Shutdown the presentation compiler, and force a re-initialization but asking to reconcile all
-    * compilation units that were serviced by the previous instance of the presentation compiler.
-    */
+  /** Shutdown the presentation compiler, and force a re-initialization. */
   private def restart(): Unit = pcLock.synchronized {
     val oldPc = pc
     shutdown()
     assert(pc eq null, "There must be a race-condition if the presentation compiler instance isn't `null` right after calling `shutdown`.")
-    val units = Option(oldPc).map(_.compilationUnits).getOrElse(Nil)
     initialize()
-    pc.askReload(units).get
   }
 
   /** Shutdown the presentation compiler '''without''' scheduling a reconcile for the opened files.


### PR DESCRIPTION
While restarting the presentation compiler, all units managed by the restarted
presentation compiler are (re)loaded in the new presentation compiler.
However, doing so while holding the `pcLock` can lead to a deadlock, as it can
be observed in the stacktrace reported in the ticket #1002003.

The proposed solution is move the reloading of the compilation units managed by
the restarted presentation compiler _outside_ of the synchronized block. This
prevents the deadlock from happening. Unfortunately, this change also introduces
a new race-condition, as it is now possible that the compilation units loaded in
the restarted presentation compiler may be loaded in the new presentation
compiler, if two restart requests are executed concurrently. This is definitely
an issue, but I don't see how we can fix this problem on our side (my sentiment
is that we may be able to fix the problem by changing the initialization
contract in the presentation compiler).

Related to the above, it is worth noting that a similar race condition can
already happen even without the changes proposed in this commit. For instance,
all requests queued in a presentation compiler can get lost if the presentation
compiler is restarted before the queued requests have been served.

Fix #1002003
Fix #1002007
Fix #1001943
Fix #1001911
Re #1001880
Re #1001875
