### PR TITLE
Reorganize preference pages

### DIFF
--- a/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.core/META-INF/MANIFEST.MF
@@ -99,7 +99,7 @@ Export-Package:
  org.scalaide.core.resources,
  org.scalaide.logging,
  org.scalaide.logging.log4j,
- org.scalaide.logging.ui.properties,
+ org.scalaide.logging.ui.preferences,
  org.scalaide.refactoring.internal,
  org.scalaide.refactoring.internal.method,
  org.scalaide.refactoring.internal.method.ui,

--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -7,47 +7,59 @@
          point="org.eclipse.ui.propertyPages">
       <page
             class="org.scalaide.ui.internal.preferences.CompilerSettings"
-            id="org.scala-ide.sdt.core.properties.compilerPropertyPage"
+            id="org.scalaide.ui.preferences.compiler"
             name="Scala Compiler">
          <filter
                name="nature"
-               value="org.scala-ide.sdt.core.scalanature"/>
+               value="org.scala-ide.sdt.core.scalanature">
+         </filter>
          <enabledWhen>
-         <or> <instanceof value="org.eclipse.jdt.core.IJavaProject"/>
-              <instanceof value="org.eclipse.core.resources.IProject"/>
-         </or>
+            <or>
+               <instanceof
+                     value="org.eclipse.jdt.core.IJavaProject">
+               </instanceof>
+               <instanceof
+                     value="org.eclipse.core.resources.IProject">
+               </instanceof>
+            </or>
          </enabledWhen>
       </page>
-   </extension>
-   <extension
-         point="org.eclipse.ui.propertyPages">
       <page
             class="org.scalaide.ui.internal.preferences.FormatterPreferencePage"
-            id="scala.tools.eclipse.formatter.FormatterPropertyPage"
+            id="org.scalaide.ui.preferences.editor.formatter"
             name="Scala Formatter">
          <filter
                name="nature"
-               value="org.scala-ide.sdt.core.scalanature"/>
+               value="org.scala-ide.sdt.core.scalanature">
+         </filter>
          <enabledWhen>
-         <or> <instanceof value="org.eclipse.jdt.core.IJavaProject"/>
-              <instanceof value="org.eclipse.core.resources.IProject"/>
-         </or>
+            <or>
+               <instanceof
+                     value="org.eclipse.jdt.core.IJavaProject">
+               </instanceof>
+               <instanceof
+                     value="org.eclipse.core.resources.IProject">
+               </instanceof>
+            </or>
          </enabledWhen>
       </page>
-   </extension>
-      <extension
-         point="org.eclipse.ui.propertyPages">
       <page
             class="org.scalaide.ui.internal.preferences.OrganizeImportsPreferencesPage"
-            id="scala.tools.eclipse.properties.OrganizeImportsPreferencesPage"
+            id="org.scalaide.ui.preferences.editor.organizeImports"
             name="Scala Organize Imports">
          <filter
                name="nature"
-               value="org.scala-ide.sdt.core.scalanature"/>
+               value="org.scala-ide.sdt.core.scalanature">
+         </filter>
          <enabledWhen>
-         <or> <instanceof value="org.eclipse.jdt.core.IJavaProject"/>
-              <instanceof value="org.eclipse.core.resources.IProject"/>
-         </or>
+            <or>
+               <instanceof
+                     value="org.eclipse.jdt.core.IJavaProject">
+               </instanceof>
+               <instanceof
+                     value="org.eclipse.core.resources.IProject">
+               </instanceof>
+            </or>
          </enabledWhen>
       </page>
    </extension>
@@ -55,51 +67,51 @@
    <extension point="org.eclipse.ui.preferencePages">
       <page class="org.scalaide.ui.internal.preferences.ScalaPreferences"
             name="Scala"
-            id="org.scala-ide.sdt.core.preferences"/>
-      <page class="org.scalaide.ui.internal.preferences.SyntaxColouringPreferencePage"
-            category="org.scala-ide.sdt.core.preferences"
+            id="org.scalaide.ui.preferences"/>
+      <page class="org.scalaide.ui.internal.preferences.SyntaxColoringPreferencePage"
+            category="org.scalaide.ui.preferences.editor"
             name="Syntax Coloring"
-            id="org.scala-ide.sdt.core.properties.syntaxcolouring.SyntaxColouringPreferencePage"/>
+            id="org.scalaide.ui.preferences.editor.highlighting"/>
       <page
-            category="org.scala-ide.sdt.core.preferences"
+            category="org.scalaide.ui.preferences"
             class="org.scalaide.ui.internal.preferences.CompilerSettings"
-            id="org.scala-ide.sdt.core.preferences.CompilerPreferences"
+            id="org.scalaide.ui.preferences.compiler"
             name="Compiler">
       </page>
       <page
-            category="org.scala-ide.sdt.core.preferences"
+            category="org.scalaide.ui.preferences.editor"
             class="org.scalaide.ui.internal.preferences.FormatterPreferencePage"
-            id="scala.tools.eclipse.formatter.FormatterPreferencePage"
+            id="org.scalaide.ui.preferences.editor.formatter"
             name="Formatter">
       </page>
       <page
-            category="org.scala-ide.sdt.core.preferences"
+            category="org.scalaide.ui.preferences.editor"
             class="org.scalaide.ui.internal.templates.TemplatePreferences"
-            id="org.scala-ide.sdt.core.preferences.Templates"
+            id="org.scalaide.ui.preferences.editor.templates"
             name="Templates">
       </page>
       <page
-            category="org.scala-ide.sdt.core.preferences"
+            category="org.scalaide.ui.preferences.editor"
             class="org.scalaide.ui.internal.preferences.OrganizeImportsPreferencesPage"
-            id="scala.tools.eclipse.properties.OrganizeImportsPreferencesPage"
+            id="org.scalaide.ui.preferences.editor.organizeImports"
             name="Organize Imports">
       </page>
       <page
-            category="org.scala-ide.sdt.core.preferences"
+            category="org.scalaide.ui.preferences.editor"
             class="org.scalaide.ui.internal.preferences.ImplicitsPreferencePage"
-            id="org.scala-ide.sdt.core.properties.Implicits"
+            id="org.scalaide.ui.preferences.editor.implicits"
             name="Implicits">
       </page>
       <page
-            category="org.scala-ide.sdt.core.preferences"
-            class="org.scalaide.logging.ui.properties.LoggingPreferencePage"
-            id="org.scala-ide.sdt.core.properties.Logging"
+            category="org.scalaide.ui.preferences"
+            class="org.scalaide.logging.ui.preferences.LoggingPreferencePage"
+            id="org.scalaide.ui.preferences.logging"
             name="Logging">
       </page>
       <page
-            category="org.scala-ide.sdt.core.preferences"
+            category="org.scalaide.ui.preferences"
             class="org.scalaide.ui.internal.preferences.EditorPreferencePage"
-            id="org.scala-ide.sdt.core.editor"
+            id="org.scalaide.ui.preferences.editor"
             name="Editor">
       </page>      
    </extension>
@@ -746,7 +758,6 @@
    </extension>
 
   <extension
-        id="org.scala-ide.sdt.core.preferences"
         point="org.eclipse.core.runtime.preferences">
      <initializer
            class="org.scalaide.ui.internal.preferences.ColourPreferenceInitializer">
@@ -764,7 +775,7 @@
            class="org.scalaide.ui.internal.preferences.ImplicitsPagePreferenceInitializer">
      </initializer>
      <initializer
-           class="org.scalaide.logging.ui.properties.LoggingPreferencePageInitializer">
+           class="org.scalaide.logging.ui.preferences.LoggingPreferencePageInitializer">
      </initializer>
      <initializer
            class="org.scalaide.ui.internal.preferences.PreferenceInitializer">

--- a/org.scala-ide.sdt.core/src/org/scalaide/logging/LogManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/logging/LogManager.scala
@@ -1,17 +1,12 @@
 package org.scalaide.logging
 
-import org.scalaide.logging.log4j.Log4JFacade
-import org.scalaide.core.ScalaPlugin
-import org.eclipse.jdt.internal.ui.viewsupport.IProblemChangedListener
-import org.eclipse.jface.util.IPropertyChangeListener
 import org.eclipse.jface.util.PropertyChangeEvent
-import org.eclipse.jdt.ui.PreferenceConstants
+import org.scalaide.core.ScalaPlugin
+import org.scalaide.logging.log4j.Log4JFacade
+import org.scalaide.logging.ui.preferences.LoggingPreferenceConstants._
 import org.scalaide.util.internal.eclipse.SWTUtils
-import java.io.File
-import org.eclipse.core.resources.ResourcesPlugin
 
 object LogManager extends Log4JFacade with HasLogger {
-  import ui.properties.LoggingPreferenceConstants._
 
   private def updateLogLevel(event: PropertyChangeEvent): Unit = {
     if (event.getProperty == LogLevel) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/logging/ui/preferences/LoggingPreferenceConstants.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/logging/ui/preferences/LoggingPreferenceConstants.scala
@@ -1,4 +1,4 @@
-package org.scalaide.logging.ui.properties
+package org.scalaide.logging.ui.preferences
 
 private[logging] object LoggingPreferenceConstants {
   private final val Prefix = "scala.tools.eclipse.logging.ui.properties."

--- a/org.scala-ide.sdt.core/src/org/scalaide/logging/ui/preferences/LoggingPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/logging/ui/preferences/LoggingPreferencePage.scala
@@ -1,4 +1,4 @@
-package org.scalaide.logging.ui.properties
+package org.scalaide.logging.ui.preferences
 
 import org.scalaide.logging.Level
 import org.scalaide.logging.LogManager

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SyntaxColoringPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SyntaxColoringPreferencePage.scala
@@ -31,7 +31,7 @@ import org.scalaide.ui.syntax.SyntaxColouringTreeContentAndLabelProvider
 /**
  * @see org.eclipse.jdt.internal.ui.preferences.JavaEditorColoringConfigurationBlock
  */
-class SyntaxColouringPreferencePage extends PreferencePage with IWorkbenchPreferencePage {
+class SyntaxColoringPreferencePage extends PreferencePage with IWorkbenchPreferencePage {
 
   import GridDataHelper._
 

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -57,9 +57,9 @@
    <extension
          point="org.eclipse.ui.preferencePages">
       <page
-            category="org.scala-ide.sdt.core.preferences"
+            category="org.scalaide.ui.preferences"
             class="org.scalaide.debug.internal.preferences.DebuggerPreferences"
-            id="org.scala-ide.sdt.debug.preferences"
+            id="org.scalaide.ui.preferences.debug"
             name="Debug">
       </page>
    </extension>


### PR DESCRIPTION
The new layout contains only the pages Compiler, Debug, Editor and
Logging. All other remaining pages are grouped under the Editor page.

Furthermore, a new consistent name scheme for the preference page ids
is applied. The scheme is as follows:

```
org.scalaide.ui.preferences.<rootlevel-page>.<sublevel-page>
```

SyntaxColouringPreferencePage is renamed to SyntaxColoringPreferencePage
