### PR TITLE
Fix compilation error shown with Xlint

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/CompilationUnit.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/CompilationUnit.scala
@@ -24,7 +24,7 @@ abstract class CompilationUnit(override val workspaceFile: IFile) extends Intera
   /** no-op */
   override def scheduleReconcile(): Response[Unit] = {
     val r = new Response[Unit]
-    r.set()
+    r.set(())
     r
   }
 }


### PR DESCRIPTION
The error was:

```
Adaptation of argument list by inserting () has been removed
```
