### PR TITLE
Make Organize Imports NOT save automatically after edit.

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/EditorHelpers.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/EditorHelpers.scala
@@ -87,7 +87,7 @@ object EditorHelpers {
     }
   }
 
-  def createTextFileChange(file: IFile, fileChanges: List[TextChange]): TextFileChange = {
+  def createTextFileChange(file: IFile, fileChanges: List[TextChange], saveAfter: Boolean = true): TextFileChange = {
     new TextFileChange(file.getName(), file) {
 
       val fileChangeRootEdit = new MultiTextEdit
@@ -96,6 +96,7 @@ object EditorHelpers {
         new ReplaceEdit(change.from, change.to - change.from, change.text)
       } foreach fileChangeRootEdit.addChild
 
+      if (saveAfter) setSaveMode(TextFileChange.LEAVE_DIRTY)
       setEdit(fileChangeRootEdit)
     }
   }
@@ -108,8 +109,9 @@ object EditorHelpers {
    * @param textSelection The currently selected area of the document.
    * @param file The file that we're currently editing (the document alone isn't enough because we need to get an IFile).
    * @param changes The changes that should be applied.
+   * @param saveAfter Whether files should be saved after changes
    */
-  def applyChangesToFileWhileKeepingSelection(document: IDocument, textSelection: ITextSelection, file: AbstractFile, changes: List[TextChange])  {
+  def applyChangesToFileWhileKeepingSelection(document: IDocument, textSelection: ITextSelection, file: AbstractFile, changes: List[TextChange], saveAfter: Boolean = true)  {
 
     def selectionIsInManipulatedRegion(region: IRegion): Boolean = {
       val (regionStart, regionEnd) = {
@@ -122,7 +124,7 @@ object EditorHelpers {
     }
 
     FileUtils.toIFile(file) foreach { f =>
-      createTextFileChange(f, changes).getEdit match {
+      createTextFileChange(f, changes, saveAfter).getEdit match {
         // we know that it is a MultiTextEdit because we created it above
         case edit: MultiTextEdit =>
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImportsAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImportsAction.scala
@@ -124,7 +124,7 @@ class OrganizeImportsAction extends RefactoringAction with RefactoringActionWith
           pm.subTask("Applying the changes.")
           val changes = createChanges(scalaSourceFile, imports, pm)
           val document = editor.getDocumentProvider.getDocument(editor.getEditorInput)
-          EditorHelpers.applyChangesToFileWhileKeepingSelection(document, textSelection, scalaSourceFile.file, changes)
+          EditorHelpers.applyChangesToFileWhileKeepingSelection(document, textSelection, scalaSourceFile.file, changes, false)
           None
         }
       }


### PR DESCRIPTION
Since refactorings are not at the moment 100% bug-free, it seems the right
default to make organize imports leave edited files in a dirty state.

Fixes #1001573
