### PR TITLE
Fix character encoding issue in about.ini

### DIFF
--- a/org.scala-ide.sdt.core/about.ini
+++ b/org.scala-ide.sdt.core/about.ini
@@ -6,5 +6,5 @@ aboutText=The Scala IDE for Eclipse\n\
 The Scala IDE for Eclipse provides an integrated environment for creating Scala programs.\n\
 Visit http://scala-ide.org/\n\n\
 Typesafe Team: Luc Bourlier, Mirco Dotta, Iulian Dragos, Martin Odersky, and Hubert Plocinicak.\n\
-Many thanks to David Bernard, Donna Malayeri, Eric Molitor, Matt Russell, Miles Sabin, Simon Schäfer, Mirko Stocker, Joshua Suereth, Eugene Vigdorchik, and all other contributors.\n\
+Many thanks to David Bernard, Donna Malayeri, Eric Molitor, Matt Russell, Miles Sabin, Simon Sch\u00E4fer, Mirko Stocker, Joshua Suereth, Eugene Vigdorchik, and all other contributors.\n\
 Further thanks to FatCow Web Hosting - http://www.fatcow.com/ - for their icon set Farm-fresh.\n\


### PR DESCRIPTION
This file is interpreted only with ISO 8859-1, which leads to
problems in non Windows environments. Special characters have
to be encoded by Unicode escapes.
