### PR TITLE
Disable javaextdirs setting in Scala projects.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/settings/CompilerSettingsTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/settings/CompilerSettingsTest.scala
@@ -12,6 +12,7 @@ import org.junit.AfterClass
 import org.scalaide.core.EclipseUserSimulator
 import org.scalaide.core.internal.project.ScalaProject
 import org.scalaide.util.internal.eclipse.EclipseUtils
+import scala.tools.nsc.Settings
 
 object CompilerSettingsTest {
   private val simulator = new EclipseUserSimulator
@@ -68,6 +69,20 @@ class CompilerSettingsTest {
     setProjectSettings(CompilerSettings.ADDITIONAL_PARAMS, "-Ylog:typer")
     assertFalse("Settings should not contain additional parameters: " + project.scalacArguments, project.scalacArguments.contains("-language:implicits"))
     assertTrue("Settings should contain additional parameters: " + project.scalacArguments, project.scalacArguments.contains("-Ylog:typer"))
+  }
+
+  @Test
+  def no_javaextdirs() {
+    val scalacArgs = project.scalacArguments
+
+    // We make sure -javaextdirs never picks up the default (runtime) JRE
+    // See ticket #1002072
+    project.presentationCompiler { comp =>
+      val settings = new Settings
+      settings.processArguments(scalacArgs.toList, true)
+      val resolver = new scala.tools.util.PathResolver(settings)
+      assertEquals("Calculated javaextdirs should be empty", "", resolver.Calculated.javaExtDirs.trim)
+    }
   }
 
   private def enableProjectSettings(value: Boolean = true) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -398,7 +398,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
         setting
       }
 
-      val classpathSettings = List(defaultSettings.javabootclasspath, defaultSettings.bootclasspath)
+      val classpathSettings = List(defaultSettings.javabootclasspath, defaultSettings.javaextdirs, defaultSettings.bootclasspath)
 
       (classpathSettings ++ userSettings) map (_.unparse)
     }
@@ -444,10 +444,16 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
     val scalaCp = scalaClasspath // don't need to recompute it each time we use it
 
     settings.javabootclasspath.value = scalaCp.jdkPaths.map(_.toOSString).mkString(pathSeparator)
+    // extdirs are already included in Platform JDK paths
+    // here we disable Scala's default that would pick up the running JVM extdir, resulting in
+    // a mix of classes from the running JVM and configured JDK
+    // (we use a space because an empty string is considered as 'value not set by user')
+    settings.javaextdirs.value = " "
     settings.classpath.value = (scalaCp.userCp ++ scalaCp.scalaLib.toSeq).map(_.toOSString).mkString(pathSeparator)
     scalaCp.scalaLib.foreach(scalaLib => settings.bootclasspath.value = scalaLib.toOSString)
 
     logger.debug("javabootclasspath: " + settings.javabootclasspath.value)
+    logger.debug("javaextdirs: " + settings.javaextdirs.value)
     logger.debug("scalabootclasspath: " + settings.bootclasspath.value)
     logger.debug("user classpath: " + settings.classpath.value)
   }


### PR DESCRIPTION
This setting is appended to the Scala class path. It defaults to the running JDK
extdirs, and that can cause trouble when the project JDK is different from the
JRE used to launch Eclipse.

Fix #1002072
