### PR TITLE
Remove preference store listener on deactivation

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/EditorPainter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/EditorPainter.scala
@@ -45,6 +45,7 @@ abstract class EditorPainter(viewer: ISourceViewer, enablePreference: String) ex
     if (isActive) {
       isActive = false
       widget.removePaintListener(this)
+      store.removePropertyChangeListener(this)
       if (redraw)
         widget.redraw()
     }


### PR DESCRIPTION
The listener would try to redraw a disposed widget on preference changes, even after
the editor was closed.
