### PR TITLE
Cleans up more warts (mostly Option-related)

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/quickassist/ExplicitTypeAssistTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/quickassist/ExplicitTypeAssistTest.scala
@@ -19,7 +19,7 @@ object ExplicitTypeAssistTest {
   var simulator = new EclipseUserSimulator
 
   @BeforeClass
-  def createProject {
+  def createProject() {
     project = simulator.createProjectInWorkspace("assist")
   }
 
@@ -29,7 +29,7 @@ object ExplicitTypeAssistTest {
   }
 
   @AfterClass
-  def deleteProject {
+  def deleteProject() {
     Exception.ignoring(classOf[Exception]) { project.underlying.delete(true, null) }
   }
 

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/OutputFoldersTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/OutputFoldersTest.scala
@@ -95,10 +95,7 @@ class OutputFoldersTest {
     val srcEntries =
       for ((dirPath, inclPats, exclPats, binPath) <- sourceFolders) yield {
         for (path <- Seq(Some(dirPath), Option(binPath)))
-          path match {
-            case Some(path) => ensureFolderExists(project.underlying, path)
-            case None =>
-          }
+          path foreach { (path) => ensureFolderExists(project.underlying, path) }
 
         JavaCore.newSourceEntry(dirPath, inclPats, exclPats, binPath)
       }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/structurebuilder/StructureBuilderTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/structurebuilder/StructureBuilderTest.scala
@@ -115,7 +115,7 @@ class StructureBuilderTest {
             m.getParameterNames().length == m.getParameterTypes().length)
         }
 
-      case _ =>
+      case None =>
         Assert.fail("Could not find type")
     }
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/ScalaPlugin.scala
@@ -211,9 +211,7 @@ class ScalaPlugin extends AbstractUIPlugin with PluginLogConfigurator with IReso
   def getJavaProject(project: IProject) = JavaCore.create(project)
 
   def getScalaProject(project: IProject): ScalaProject = projects.synchronized {
-    projects.get(project) match {
-      case Some(scalaProject) => scalaProject
-      case None =>
+    projects.get(project) getOrElse {
         val scalaProject = ScalaProject(project)
         projects(project) = scalaProject
         scalaProject
@@ -263,11 +261,9 @@ class ScalaPlugin extends AbstractUIPlugin with PluginLogConfigurator with IReso
 
   private def disposeProject(project: IProject): Unit = {
     projects.synchronized {
-      projects.get(project) match {
-        case Some(scalaProject) =>
+      projects.get(project) foreach { (scalaProject) =>
           projects.remove(project)
           scalaProject.dispose()
-        case None =>
       }
     }
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/hyperlink/detector/BaseHyperlinkDetector.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/hyperlink/detector/BaseHyperlinkDetector.scala
@@ -50,7 +50,7 @@ abstract class BaseHyperlinkDetector extends AbstractHyperlinkDetector with HasL
               null
           }
 
-        case _ => null
+        case None => null
       }
     }
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/BuildReporter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/BuildReporter.scala
@@ -52,7 +52,7 @@ abstract class BuildReporter(private[builder] val project0: ScalaProject, settin
                   // the compiler will create PlainFile instances in that case
                   prob += new BuildProblem(severity, msg, pos)
                   BuildProblemMarker.create(i, eclipseSeverity, msg, pos)
-                case _ =>
+                case None =>
                   logger.info("no EclipseResource associated to %s [%s]".format(f.path, f.getClass))
                   prob += new BuildProblem(severity, msg, NoPosition)
                   BuildProblemMarker.create(project0.underlying, eclipseSeverity, msg)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -38,7 +38,7 @@ class SbtInputs(sourceFiles: Seq[File], project: ScalaProject, javaMonitor: SubM
       else
         allProjects.find(_.sourceOutputFolders.map(_._2.getLocation.toFile) contains f) map (_.buildManager) match {
           case Some(sbtManager: EclipseSbtBuildManager) => Maybe.just(sbtManager.latestAnalysis)
-          case _ => Maybe.just(Analysis.Empty)
+          case None => Maybe.just(Analysis.Empty)
         }
     def progress = Maybe.just(scalaProgress)
     def reporter = scalaReporter

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/compiler/ScalaMethodVerifierProvider.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/compiler/ScalaMethodVerifierProvider.scala
@@ -67,12 +67,7 @@ class ScalaMethodVerifierProvider extends IMethodVerifierProvider with HasLogger
 
           logger.debug("Found definition for `%s` in file `%s` of project `%s`".format(abstractMethod, file.getFullPath(), project.getName()))
 
-          ScalaPlugin.plugin.asScalaProject(project) match {
-            case Some(scalaProject) =>
-              isConcreteTraitMethod(abstractMethod, scalaProject)
-
-            case None => false
-          }
+          ScalaPlugin.plugin.asScalaProject(project) exists { isConcreteTraitMethod(abstractMethod, _) }
         }
       }.getOrElse(false)
     }.getOrElse(false)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaClassFileProvider.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaClassFileProvider.scala
@@ -31,7 +31,7 @@ class ScalaClassFileProvider extends IClassFileProvider with HasLogger {
 
     val scalaCF = ScalaClassFileDescriber.isScala(new ByteArrayInputStream(contents)) match {
       case Some(sourcePath) => new ScalaClassFile(parent, name, sourcePath)
-      case _                => null
+      case None                => null
     }
     updateCache(scalaCF ne null)
     scalaCF

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaStructureBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaStructureBuilder.scala
@@ -231,11 +231,10 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
         for ((m, mInfo) <- modules) {
           val c = companionClassOf(m)
           if (c != NoSymbol) {
-            classes.get(c) match {
-              case Some((classElem, classElemInfo)) =>
+            classes.get(c) foreach {
+              case (classElem, classElemInfo) =>
                 addModuleInnerClasses(classElem, classElemInfo, mInfo)
                 addForwarders(classElem, classElemInfo, m.moduleClass)
-              case _ =>
             }
           } else {
             val className = m.nameString
@@ -356,9 +355,7 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
         def addImport(name : String, isWildcard : Boolean) {
           val path = prefix + (if(isWildcard) "" else "." + name)
 
-          val (importContainer, importContainerInfo) = currentImportContainer match {
-            case Some(ci) => ci
-            case None =>
+          val (importContainer, importContainerInfo) = currentImportContainer getOrElse {
               val importContainerElem = JavaElementFactory.createImportContainer(element)
               val importContainerElemInfo = new ImportContainerInfo
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/launching/ScalaLaunchDelegate.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/launching/ScalaLaunchDelegate.scala
@@ -157,7 +157,7 @@ class ScalaLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
         val scalaLibs = resolveClasspath(e, configuration)
         scalaLibs.diff(included)
       case None =>
-        List()
+        Nil
     }
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/ProposalRefactoringActionAdapter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/ProposalRefactoringActionAdapter.scala
@@ -8,9 +8,9 @@ import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.jface.text.IDocument
 
 abstract class ProposalRefactoringActionAdapter(
-    action: ActionAdapter,
-    displayString: String,
-    relevance: Int = RelevanceValues.ProposalRefactoringActionAdapter)
+  action: ActionAdapter,
+  displayString: String,
+  relevance: Int = RelevanceValues.ProposalRefactoringActionAdapter)
   extends BasicCompletionProposal(relevance, displayString) {
 
   override def apply(document: IDocument): Unit = {
@@ -19,15 +19,14 @@ abstract class ProposalRefactoringActionAdapter(
     action.run(null)
   }
 
-  def isValidProposal : Boolean = {
+  def isValidProposal: Boolean = {
     val ra = action match {
       case refactoringAction: RefactoringAction => refactoringAction
-      case renameAction : RenameAction => renameAction.getRenameAction
+      case renameAction: RenameAction => renameAction.getRenameAction
     }
-    ra.createScalaIdeRefactoringForCurrentEditorAndSelection match {
+    ra.createScalaIdeRefactoringForCurrentEditorAndSelection exists {
       // TODO not sure if this null here is very safe
-      case Some(refactoring) => !refactoring.checkInitialConditions(new NullProgressMonitor).hasWarning
-      case None  => false
+      (refactoring) => !refactoring.checkInitialConditions(new NullProgressMonitor).hasWarning
     }
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/createmethod/MissingMemberInfo.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/createmethod/MissingMemberInfo.scala
@@ -133,18 +133,12 @@ object MissingMemberInfo {
           }
         })
       }.flatten
-      optopt.flatten match {
-        case None => Some((Nil, None))
-        case some => some
-      }
+      optopt.flatten.orElse(Some(Nil, None))
     }
 
     val result = for (MethodCallInfo(offset, length, argPosition) <- ScalariformUtils.callingOffsetAndLength(source, offset)) yield {
       getParamsAndReturnType(offset, length, argPosition)
     }
-    result.flatten match {
-      case None => (Nil, None)
-      case Some(tuple) => tuple
-    }
+    result.flatten.getOrElse(Nil,None)
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/resources/EclipseFile.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/resources/EclipseFile.scala
@@ -65,7 +65,7 @@ object EclipseResource extends HasLogger {
           case Some(res) =>
             res.refreshLocal(IResource.DEPTH_ONE, null)
             resourceForPath(path0).map(EclipseResource(_))
-          case _ => None
+          case None => None
         }
     }
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ExtractLocalAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ExtractLocalAction.scala
@@ -64,7 +64,7 @@ class ExtractLocalAction extends RefactoringAction {
             runRefactoring(createWizardForRefactoring(Some(r)), shell)
         }
 
-      case _ => runRefactoring(createWizardForRefactoring(None), shell)
+      case None => runRefactoring(createWizardForRefactoring(None), shell)
     }
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/RefactoringActionWithoutWizard.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/RefactoringActionWithoutWizard.scala
@@ -34,7 +34,7 @@ trait RefactoringActionWithoutWizard extends RefactoringAction {
           } else {
             refactoring.createChange(pm).perform(pm)
           }
-        case _ =>
+        case None =>
           runRefactoring(new ErrorRefactoringWizard("An error occurred while creating the refactoring."), shell)
       }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ScalaIdeRefactoring.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ScalaIdeRefactoring.scala
@@ -162,7 +162,7 @@ abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFil
     result match {
       case Some(refactoringResult) =>
         refactoringResult.left.map(e => refactoringError = Some(e.cause)).fold(_ => Nil, identity)
-      case _ =>
+      case None =>
         refactoringError = Some("An error occurred, please check the log file")
         Nil
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/autoedits/AutoIndentStrategy.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/autoedits/AutoIndentStrategy.scala
@@ -95,13 +95,9 @@ class AutoIndentStrategy(prefStore: IPreferenceStore) extends DefaultIndentLineA
       }
 
     val indent =
-      if (prevLineIndent == curLineIndent)
+      if (prevLineIndent == curLineIndent || textSize(prevLineIndent) < textSize(curLineIndent))
         oneIndent(indentWithTabs, tabSize)
-      else if (textSize(prevLineIndent) < textSize(curLineIndent))
-        oneIndent(indentWithTabs, tabSize)
-      else if (rest != restAfterCaret)
-        oneIndent(indentWithTabs, tabSize)
-      else if (restAfterCaret.trim().nonEmpty)
+      else if (rest != restAfterCaret || restAfterCaret.trim().nonEmpty)
         oneIndent(indentWithTabs, tabSize)
       else
         copyPreviousLineIndent

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/jdt/model/ScalaOverrideIndicatorBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/jdt/model/ScalaOverrideIndicatorBuilder.scala
@@ -28,12 +28,10 @@ case class JavaIndicator(scu: ScalaCompilationUnit,
 
   def open() {
     val tpe0 = JDTUtils.resolveType(scu.newSearchableEnvironment().nameLookup, packageName, typeNames, 0)
-    tpe0 match {
-      case Some(tpe) =>
+    tpe0 foreach { (tpe) =>
         val method = tpe.getMethod(methodName, methodTypeSignatures.toArray)
         if (method.exists)
           JavaUI.openInEditor(method, true, true);
-      case _ =>
     }
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/CompilerSettings.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/CompilerSettings.scala
@@ -211,10 +211,7 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
     additionalParamsWidget = (new AdditionalParametersWidget).addTo(composite)
 
     //Make sure we check enablement of compiler settings here...
-    useProjectSettingsWidget match {
-      case Some(widget) => widget.handleToggle
-      case None         =>
-    }
+    useProjectSettingsWidget.foreach(_.handleToggle())
 
     tabFolder.pack()
     composite
@@ -266,8 +263,7 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
 
   //Make sure apply button isn't available until it should be
   override def isChanged: Boolean = {
-    useProjectSettingsWidget match {
-      case Some(widget) =>
+    useProjectSettingsWidget foreach { (widget) =>
         if (widget.isChanged) {
           return true
         } else {
@@ -276,7 +272,6 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
           if (!widget.isUseEnabled)
             return false
         }
-      case None => //don't need to check
     }
 
     logger.info(eclipseBoxes.exists { box =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/NewApplicationWizard.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/NewApplicationWizard.scala
@@ -89,11 +89,9 @@ class NewApplicationWizard extends BasicNewResourceWizard with HasLogger {
     true
   }
 
-  override def performFinish: Boolean = page.getSelectedPackage match {
-    case None => true
-    case Some(pkg) =>
-      tryExecute(createApplication(page.getApplicationName, pkg)).getOrElse(false)
-  }
+  override def performFinish: Boolean = page.getSelectedPackage forall
+      {(pkg) => tryExecute(createApplication(page.getApplicationName, pkg)).getOrElse(false)}
+
 
   private def openInEditor(file: IFile) = {
     selectAndReveal(file)


### PR DESCRIPTION
- if your pattern-match on option has no guards on the Some, let the other
  case be explicitly None, this will avail you of the totality check.

``` scala
  case Some(x) if (condition) => ...
  case _ => ...
```

 is ok, and so is the case where x is replaced by a refutable pattern. But

``` scala
  case Some(x) => ...
  case _ => ...
```

 is usually more safely written

``` scala
  case Some(x) => ...
  case None => ...
```
- Don't hesitate to use foreach, exists, map, forall, orElse, getOrElse on
  Options
  http://blog.tmorris.net/posts/scalaoption-cheat-sheet/.
