### PR TITLE
Fixes default for project specific compiler settings

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/EclipseSettings.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/EclipseSettings.scala
@@ -28,6 +28,7 @@ trait EclipseSettings {
   object EclipseSetting {
     /** Function to map a Scala compiler setting to an Eclipse plugin setting */
     private def apply(setting: Settings#Setting): EclipseSetting = setting match {
+      case setting: ScalaPluginSettings.BooleanSettingWithDefault => new CheckBoxSettingWithDefault(setting)
       case setting: Settings#BooleanSetting => new CheckBoxSetting(setting)
       case setting: Settings#IntSetting     => new IntegerSetting(setting)
       case setting: Settings#StringSetting =>
@@ -72,9 +73,6 @@ trait EclipseSettings {
 
     def setEnabled(value: Boolean): Unit = {
       control.setEnabled(value)
-      if (!value) {
-        reset
-      }
     }
 
     def addTo(page: Composite) {
@@ -114,6 +112,26 @@ trait EclipseSettings {
     def isChanged = !setting.value.equals(control.getSelection)
 
     def reset() { control.setSelection(false) }
+
+    def apply() { setting.value = control.getSelection }
+  }
+
+  /** Boolean setting controlled by a checkbox, with a custom default value.
+   *  (copy of CheckBoxSetting, with a different reset)
+   */
+  private class CheckBoxSettingWithDefault(setting: ScalaPluginSettings.BooleanSettingWithDefault) extends EclipseSetting(setting) {
+    var control: Button = _
+
+    def createControl(page: Composite) {
+      control = new Button(page, SWT.CHECK)
+      control.setSelection(setting.value)
+      control.addSelectionListener(
+        SelectionListenerSing)
+    }
+
+    def isChanged = !setting.value.equals(control.getSelection)
+
+    def reset() { control.setSelection(setting.default) }
 
     def apply() { setting.value = control.getSelection }
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaCompilerPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaCompilerPreferenceInitializer.scala
@@ -17,19 +17,19 @@ class ScalaCompilerPreferenceInitializer extends AbstractPreferenceInitializer {
   /** Actually initializes preferences */
   def initializeDefaultPreferences() : Unit = {
     Utils.tryExecute {
-      val node = DefaultScope.INSTANCE.getNode(ScalaPlugin.plugin.pluginId)
       val store = new ScopedPreferenceStore(DefaultScope.INSTANCE, ScalaPlugin.plugin.pluginId)
 
       def defaultPreference(s: Settings#Setting) {
         val preferenceName = convertNameToProperty(s.name)
         val default = s match {
+            case bswd : ScalaPluginSettings.BooleanSettingWithDefault => bswd.default.toString()
             case bs : Settings#BooleanSetting => "false"
             case is : Settings#IntSetting => is.default.toString
             case ss : Settings#StringSetting => ss.default
             case ms : Settings#MultiStringSetting => ""
             case cs : Settings#ChoiceSetting => cs.default
           }
-        node.put(preferenceName, default)
+        store.setDefault(preferenceName, default)
       }
 
       IDESettings.shownSettings(ScalaPlugin.defaultScalaSettings()).foreach {_.userSettings.foreach (defaultPreference)}


### PR DESCRIPTION
Don't reset to default values when disabling project specific compiler settings.
Adds support for boolean settings with default values in the compiler settings hierarchy.

Fixes #1002083

I'm not sure of the `BooleanSettingWithDefault` implementation. I had to copy the code from `BooleanSetting`, because it cannot be simply extended it, it is `scala.tools.nsc` private.
I could make it extend `BooleanSetting` if I was to put the code in a `scala.tools.nsc` package, but I don't know if we want to extends compiler packages inside Scala IDE.
