### PR TITLE
Add `override` keyword to some methods

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/containers/ScalaClasspathContainers.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/containers/ScalaClasspathContainers.scala
@@ -18,15 +18,15 @@ import org.scalaide.core.ScalaPlugin
 abstract class ScalaClasspathContainerInitializer(desc : String) extends ClasspathContainerInitializer with HasLogger {
   def entries : Array[IClasspathEntry]
 
-  def initialize(containerPath : IPath, project : IJavaProject) = {
+  override def initialize(containerPath : IPath, project : IJavaProject) = {
     logger.info(s"Initializing classpath container $desc: ${ScalaPlugin.plugin.libClasses}")
     logger.info(s"Initializing classpath container $desc with sources: ${ScalaPlugin.plugin.libSources}")
 
     JavaCore.setClasspathContainer(containerPath, Array(project), Array(new IClasspathContainer {
-      def getPath = containerPath
-      def getClasspathEntries = entries
-      def getDescription = desc+" [" + scala.util.Properties.scalaPropOrElse("version.number", "none")+"]"
-      def getKind = IClasspathContainer.K_SYSTEM
+      override def getPath = containerPath
+      override def getClasspathEntries = entries
+      override def getDescription = desc+" [" + scala.util.Properties.scalaPropOrElse("version.number", "none")+"]"
+      override def getKind = IClasspathContainer.K_SYSTEM
     }), null)
   }
 
@@ -64,13 +64,13 @@ abstract class ScalaClasspathContainerPage(id : String, name : String, title : S
   setDescription(desc)
   setImageDescriptor(JavaPluginImages.DESC_WIZBAN_ADD_LIBRARY)
 
-  def finish() = true
+  override def finish() = true
 
-  def getSelection() : IClasspathEntry = fContainerEntryResult
+  override def getSelection() : IClasspathEntry = fContainerEntryResult
 
-  def setSelection(containerEntry : IClasspathEntry) {}
+  override def setSelection(containerEntry : IClasspathEntry) {}
 
-  def createControl(parent : Composite) {
+  override def createControl(parent : Composite) {
     val composite = new Composite(parent, SWT.NONE)
     setControl(composite)
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunDiagnosticAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunDiagnosticAction.scala
@@ -22,11 +22,11 @@ class RunDiagnosticAction extends IObjectActionDelegate with IWorkbenchWindowAct
     parentWindow = window
   }
 
-  def dispose = { }
+  override def dispose = { }
 
-  def selectionChanged(action: IAction, selection: ISelection) {  }
+  override def selectionChanged(action: IAction, selection: ISelection) {  }
 
-  def run(action: IAction) {
+  override def run(action: IAction) {
     Utils tryExecute {
       action.getId match {
         case RUN_DIAGNOSTICS =>
@@ -42,5 +42,5 @@ class RunDiagnosticAction extends IObjectActionDelegate with IWorkbenchWindowAct
     }
   }
 
-  def setActivePart(action: IAction, targetPart: IWorkbenchPart) { }
+  override def setActivePart(action: IAction, targetPart: IWorkbenchPart) { }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaEditor.scala
@@ -8,7 +8,7 @@ import org.scalaide.core.internal.lexical._
 
 trait ScalaEditor extends IScalaEditor with ISourceViewerEditor with InteractiveCompilationUnitEditor {
 
-  def createDocumentPartitioner = new ScalaDocumentPartitioner
+  override def createDocumentPartitioner = new ScalaDocumentPartitioner
 
 }
 


### PR DESCRIPTION
I can't see these tickets any longer. Sadly I don't know of any linting
tools that could check the entire codebase for the missing `override`,
thus only the three reported classes are fixed and not more.

Fixes #1001938
Fixes #1001937
Fixes #1001936
