### PR TITLE
Better support for auto-completion of identifiers that require backticks

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/completion/CompletionTests.scala
@@ -369,4 +369,32 @@ class CompletionTests {
     }
   }
 
+  @Test
+  def backticks_completion_t1001371() {
+    withCompletions("backticks_completion/BackticksCompletionDemo.scala") {
+      (testNumber, _, proposals) => {
+        def `assert completes with    backticks`(what: String, completion: String) {
+          assertTrue(s"$what should auto-complete WITH backticks.", proposals.exists(_.completion == s"`$completion`"))
+        }
+
+        def `assert completes without backticks`(what: String, completion: String) {
+          assertTrue(s"$what should auto-complete WITHOUT backticks.", proposals.exists(_.completion == completion))
+        }
+
+        testNumber match {
+          case 0 => `assert completes without backticks`("A normal class name", "NormalClassName")
+          case 1 => `assert completes with    backticks`("A non-standard class name", "weird class name")
+          case 2 => `assert completes without backticks`("A weird but valid class name", "abcαβγ_!^©®")
+          case 3 => `assert completes with    backticks`("A non-standard trait name", "misnamed/trait")
+          case 4 => `assert completes with    backticks`("A non-standard object name", "YOLO Obj")
+          case 5 => `assert completes without backticks`("A def with a standard name", "normalDef")
+          case 6 => `assert completes with    backticks`("A def with a non-standard name", "weird/def")
+          case 7 => `assert completes with    backticks`("A field with a non-standard name", "text/plain")
+          case 8 => `assert completes without backticks`("A field with a weird but valid name", "lolcαβγ_!^©®")
+          case 9 => `assert completes with    backticks`("A field with an illegal char in its name", "badchar£2")
+          case 10=> `assert completes with    backticks`("An identifier that is a reserved word", "while")
+        }
+      }
+    }
+  }
 }

--- a/org.scala-ide.sdt.core.tests/test-workspace/completion/src/backticks_completion/BackticksCompletionDemo.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/completion/src/backticks_completion/BackticksCompletionDemo.scala
@@ -1,0 +1,53 @@
+package backticksCompletion
+
+class NormalClassName
+
+class `weird class name`
+
+case class abcαβγ_!^©®(i: Int)
+
+trait `misnamed/trait`
+
+object `YOLO Obj` {
+  /** Members below that are defined with backticks here would be invalid without them, so at completion time,
+   *  they should also be auto-completed with backticks. Conversely, The fields that are not defined with
+   *  backticks should be auto-completed without backticks.
+   */
+
+  def normalDef() {}
+
+  def `weird/def`(name: String) = println(s"Yo, $name!")
+
+  val `text/plain` = "text/plain"
+
+  var lolcαβγ_!^©® = 3
+
+  val `badchar£2` = 1
+
+  val `while` = "reserved word"
+}
+
+object CompletionsDemo {
+  new Nor /*!*/  // Should complete WITHOUT backticks (NormalClassName)
+
+  new we /*!*/   // Should complete WITH backticks (`weird class name`)
+
+  abc /*!*/    // WITHOUT (abcαβγ_!^©®)
+
+  new `weird class name` with mis /*!*/  // WITH (`misnamed/trait`)
+
+  YO /*!*/  // WITH (`YOLO Obj`)
+
+  `YOLO Obj`.nor /*!*/  // WITHOUT
+
+  `YOLO Obj`.wei /*!*/  // WITH
+
+  `YOLO Obj`.tex /*!*/  // WITH
+
+  `YOLO Obj`.lol /*!*/  // WITHOUT
+
+  `YOLO Obj`.badc /*!*/  // WITH
+
+  `YOLO Obj`.whi /*!*/  // WITH
+
+}


### PR DESCRIPTION
Now, identifiers (of classes, traits, defs, fields, packages (and more?)) that would be invalid without back-ticks (including identifiers that are reserved words in scala, say, a method named 'yield' in some java lib) are auto-completed with back-ticks.

This PR is related to ticket [#1001371](https://www.assembla.com/spaces/scala-ide/tickets/1001371#/activity/ticket:). The ticket demands 2 enhancements:
- Auto-completion should add back-ticks for identifiers that would require them.
- Auto-completion suggestions should be made available by the IDE, when the user starts writing the term (to be auto-completed) both with & without a leading back-tick.

This PR does not address the 2nd form of the 2nd enhancement, i.e. auto-completion when the user has already typed a leading back-tick is not supported.
