### PR TITLE
Build support for several versions of Scala

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/TestsSuite.scala
@@ -35,6 +35,7 @@ import org.scalaide.core.sbtbuilder.NestedProjectsTest
 import org.scalaide.core.sbtbuilder.TodoBuilderTest
 import org.scalaide.core.sbtbuilder.DeprecationWarningsTests
 import org.scalaide.core.project.ScalaInstallationTest
+import org.scalaide.core.sbtbuilder.MultiScalaVersionTest
 
 /**
  * To run this class DO NOT FORGET to set the config.ini in the  "configuration" tab.
@@ -77,5 +78,6 @@ import org.scalaide.core.project.ScalaInstallationTest
     classOf[ImportSupportTest],
     classOf[QualifiedNameSupportTest],
     classOf[ScalaWordFinderTest],
-    classOf[ScalaInstallationTest]))
+    classOf[ScalaInstallationTest],
+    classOf[MultiScalaVersionTest]))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/MultiScalaVersionTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/MultiScalaVersionTest.scala
@@ -1,0 +1,87 @@
+package org.scalaide.core.sbtbuilder
+
+import org.junit.{ Test, Assert }
+import org.scalaide.core.testsetup.SDTTestUtils._
+import org.scalaide.core.internal.project.ScalaProject
+import org.eclipse.core.runtime.IPath
+import org.eclipse.jdt.core.JavaCore
+import org.scalaide.core.ScalaPlugin
+import org.scalaide.core.internal.project.ScalaInstallation
+import org.scalaide.util.internal.CompilerUtils.ShortScalaVersion
+import org.scalaide.ui.internal.preferences.CompilerSettings
+import org.eclipse.core.runtime.Path
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.scalaide.util.internal.SettingConverterUtil
+import org.eclipse.core.resources.IMarker
+import scala.tools.nsc.settings.ScalaVersion
+import scala.tools.nsc.settings.SpecificScalaVersion
+import sbt.ScalaInstance
+
+class MultiScalaVersionTest {
+  // this was deprecated in 2.10, and invalid in 2.11
+  // we use this code to show that the project build succeeds, therefore it must be 2.10
+  // This might not be robust enough for 2.12
+  val sourceCode = "case class InvalidCaseClass" // parameter-less case classes forbidden in 2.11
+
+  @Test // Build using the previous version of the Scala library
+  def previousVersionBuildSucceeds() {
+    val Seq(p) = createProjects("prev-version-build")
+    p.projectSpecificStorage.setValue(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE, true)
+    val sourceFile = addFileToProject(p.underlying, "/src/InvalidCaseClass.scala", sourceCode)
+
+    for (installation <- findPreviousScalaInstallation()) {
+      setScalaLibrary(p, installation.libraryJar)
+      val ShortScalaVersion(major, minor) = installation.version
+      p.projectSpecificStorage.setValue(CompilerSettings.ADDITIONAL_PARAMS, s"-Xsource:$major.$minor")
+
+      p.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null)
+      val (_, errors) = getErrorMessages(p.underlying).filter(_._1 == IMarker.SEVERITY_ERROR).unzip
+      Assert.assertEquals(s"No errors expected, but found: $errors", 0, errors.size)
+    }
+  }
+
+  case class DummyInstallation(override val version: ScalaVersion) extends ScalaInstallation {
+    def allJars: Seq[IPath] = ???
+    def compilerJar: IPath = ???
+    def libraryJar: IPath = ???
+    def scalaInstance: ScalaInstance = ???
+  }
+
+  /** shorcut for creating dummy installations. */
+  def di(v: String) = DummyInstallation(ScalaVersion("2.10.0"))
+
+  @Test
+  def bestMatchSimple() {
+    val installations = Seq(di("2.10.0"), di("2.11.0"))
+    val best = ScalaInstallation.findBestMatch(ScalaVersion("2.10.10").asInstanceOf[SpecificScalaVersion], installations)
+    Assert.assertEquals("Find best version", best.version, di("2.10.0").version)
+  }
+
+  @Test
+  def bestMatchOffByOne() {
+    val installations = Seq(di("2.10.0"), di("2.11.0"))
+    val best = ScalaInstallation.findBestMatch(ScalaVersion("2.11.1").asInstanceOf[SpecificScalaVersion], installations)
+    Assert.assertEquals("Find best version", best.version, di("2.11.1").version)
+  }
+
+  @Test
+  def bestMatchLargeMicros() {
+    val installations = Seq(di("2.9.0"), di("2.10.11"))
+    val best = ScalaInstallation.findBestMatch(ScalaVersion("2.10.0").asInstanceOf[SpecificScalaVersion], installations)
+    Assert.assertEquals("Find best version", best.version, di("2.10.0").version)
+  }
+
+  private def findPreviousScalaInstallation(): Option[ScalaInstallation] = {
+    ScalaInstallation.availableInstallations find { installation =>
+      (installation.version, ScalaPlugin.plugin.scalaVer) match {
+        case (ShortScalaVersion(_, minor), ShortScalaVersion(_, pluginMinor)) => minor < pluginMinor
+        case _ => false
+      }
+    }
+  }
+
+  private def setScalaLibrary(p: ScalaProject, lib: IPath): Unit = {
+    val baseClasspath = p.javaProject.getRawClasspath().filter(_.getPath().toPortableString() != ScalaPlugin.plugin.scalaLibId)
+    p.javaProject.setRawClasspath(baseClasspath :+ JavaCore.newLibraryEntry(lib, null, null), null)
+  }
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
@@ -162,6 +162,11 @@ object SDTTestUtils {
     units.flatMap(findProblemMarkers).toList
   }
 
+  def getErrorMessages(project: IProject): Seq[(Int, String)] = {
+    for (m <- project.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE))
+      yield (m.getAttribute(IMarker.SEVERITY).asInstanceOf[Int], m.getAttribute(IMarker.MESSAGE).toString)
+  }
+
   def getErrorMessages(units: ICompilationUnit*): List[String] =
     for (p <- getProblemMarkers(units: _*)) yield p.getAttribute(IMarker.MESSAGE).toString
 
@@ -223,6 +228,7 @@ object SDTTestUtils {
     prj.javaProject.setRawClasspath(existing ++ entries, null)
   }
 
+  /** Create Scala projects, equiped with the Scala nature, Scala library container and a '/src' folder. */
   def createProjects(names: String*): Seq[ScalaProject] =
     names map (n => simulator.createProjectInWorkspace(n, true))
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/ScalaPlugin.scala
@@ -59,6 +59,8 @@ import org.scalaide.ui.internal.diagnostic
 import org.scalaide.util.internal.CompilerUtils
 import org.scalaide.core.internal.builder.zinc.CompilerInterfaceStore
 import org.scalaide.util.internal.eclipse.EclipseUtils
+import org.scalaide.util.internal.FixedSizeCache
+import org.scalaide.core.internal.project.ScalaInstallation
 
 object ScalaPlugin {
   final val IssueTracker = "https://www.assembla.com/spaces/scala-ide/support/tickets"
@@ -213,7 +215,10 @@ class ScalaPlugin extends AbstractUIPlugin with PluginLogConfigurator with IReso
   }
 
   /** The compiler-interface store, located in this plugin configuration area (usually inside the metadata directory */
-  lazy val compilerInterfaceStore = new CompilerInterfaceStore(Platform.getStateLocation(sdtCoreBundle), this)
+  lazy val compilerInterfaceStore: CompilerInterfaceStore = new CompilerInterfaceStore(Platform.getStateLocation(sdtCoreBundle), this)
+
+  /** A LRU cache of class loaders for Scala builders */
+  lazy val classLoaderStore: FixedSizeCache[ScalaInstallation,ClassLoader] = new FixedSizeCache(initSize = 2, maxSize = 3)
 
   def workspaceRoot = ResourcesPlugin.getWorkspace.getRoot
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -478,7 +478,12 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
    */
   lazy val projectSpecificStorage: IPersistentPreferenceStore = {
     val p = new PropertyStore(new ProjectScope(underlying), plugin.pluginId)
-    p.addPropertyChangeListener(new IPropertyChangeListener{ def propertyChange(event: PropertyChangeEvent) = {compatibilityModeCache = Some(getCompatibilityMode()); classpathHasChanged()} })
+    p.addPropertyChangeListener(new IPropertyChangeListener {
+      def propertyChange(event: PropertyChangeEvent) = {
+        compatibilityModeCache = Some(getCompatibilityMode());
+        classpathHasChanged()
+      }
+    })
     p
   }
 
@@ -490,6 +495,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
     if (usesProjectSettings) projectSpecificStorage else ScalaPlugin.prefStore
   }
 
+  @deprecated("This method is not called from anywhere, consider removing in the next release", "4.0.0")
   def isStandardSource(file: IFile, qualifiedName: String): Boolean = {
     val pathString = file.getLocation.toString
     val suffix = qualifiedName.replace(".", "/") + ".scala"

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/FixedSizeCache.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/FixedSizeCache.scala
@@ -1,0 +1,41 @@
+package org.scalaide.util.internal
+
+import java.util.LinkedHashMap
+import java.lang.ref.WeakReference
+
+/** A LRU fixed sized-cache using WeakReferences.
+ *
+ *  The map won't grow past `maxSize`, and on each cache miss it might
+ *  remove the least-recently used entry, if the size of the map grows
+ *  past `maxSize`.
+ *
+ *  This class is based on the Java LinkedHashMap implementation and is thread-safe.
+ */
+class FixedSizeCache[K, V](initSize: Int, maxSize: Int) {
+  private def missed(key: K, orElse: => V): V = {
+    val value = orElse
+    jmap.put(key, new WeakReference(value))
+    value
+  }
+
+  type JEntry = java.util.Map.Entry[K, WeakReference[V]]
+
+  /* This linked map is ordered by access, meaning it removes the LRU entry. */
+  private val jmap = new LinkedHashMap[K, WeakReference[V]](initSize min maxSize, 0.75f, /* accessOrder = */ true) {
+    override def removeEldestEntry(entry: JEntry): Boolean = size() > maxSize
+  }
+
+  /** Return the value associated with K if found in cache, otherwise insert the value
+   *  provided in `orElse`.
+   */
+  def getOrUpdate(key: K)(orElse: => V): V = synchronized {
+    jmap.get(key) match {
+      case null => missed(key, orElse)
+
+      case ref => ref.get() match {
+        case null  => missed(key, orElse)
+        case value => value
+      }
+    }
+  }
+}


### PR DESCRIPTION
This supersedes #695. 

The purpose of this PR is to hook together the Scala builder to the rest of the plugin work around the `-Xsource:2.10` flag:
- projects in _compatibility mode_ that have `-Xsource:2.10` and a 2.10 classpath (including the Scala library) will be built using the 2.10 build compiler (packaged in an additional bundle, with the plugin -- work by @skyluc in #693)
- classloaders are cached per ScalaPlugin instance. The current classloader is re-used in case the installation happens to be the platform (the one running inside Scala IDE). This saves memory and JIT-compilation times (a fresh classloader is "cold", and code needs to be jit-compiled again).

Right now it's cumbersome for users to switch between the two modes. Future work should expose the concept of a Scala installation (much like the JDK/JRE installations for Java) with a clean UI, and allow setting it manually, per project. Furthermore, it should allow to define as many installations as one desires by pointing to a folder or a local maven repository.
