### PR TITLE
Fixes memory test configuration

### DIFF
--- a/org.scala-ide.sdt.core.tests/pom.xml
+++ b/org.scala-ide.sdt.core.tests/pom.xml
@@ -24,10 +24,12 @@
         <dependency>
           <groupId>org.scala-lang</groupId>
           <artifactId>scala-compiler</artifactId>
+          <version>${scala.version}</version>
         </dependency>
         <dependency>
           <groupId>org.scala-lang</groupId>
           <artifactId>scala-reflect</artifactId>
+          <version>${scala.version}</version>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
Because the m2 repos are no more used in this part of the build, the
version for the needed Scala jars are no more pre-set.

The validation build doesn't test this part of the configuration, but it works on my computer :smile:.
