### PR TITLE
Filter -Ymacro-expand from build compiler

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -79,8 +79,16 @@ class SbtInputs(installation: ScalaInstallation,
       }.toArray
     }
 
-    // remove -Xsource arguments (it is relevant only for the presentation compiler)
-    def options = project.scalacArguments.filter(!_.startsWith("-Xsource")).toArray
+    // remove arguments not understood by build compiler
+    def options =
+      if (project.isUsingCompatibilityMode())
+        project.scalacArguments.filter(buildCompilerOption).toArray
+      else
+        project.scalacArguments.toArray
+
+    /** Remove the source-level related arguments */
+    private def buildCompilerOption(arg: String): Boolean =
+      !arg.startsWith("-Xsource") && !(arg == "-Ymacro-expand:none")
 
     def javacOptions = Array() // Not used.
 


### PR DESCRIPTION
Filter both -Xsource and -Ymacro-expand options from the build compiler.

The two options are needed to put the presentation compiler in compatibility
mode, but they should not make it to the build compiler. (2.10 does replies
with `bad option:-Xsource`, for example)

An annoying fix _en-passant_, regarding missed error reporting in compiler initialization.
