### PR TITLE
Fix race condition due to call of `Tree.symbol`

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/semantichighlighting/classifier/SymbolClassification.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/semantichighlighting/classifier/SymbolClassification.scala
@@ -86,7 +86,9 @@ class SymbolClassification(protected val sourceFile: SourceFile, val global: Sca
       var symbolInfos = IndexedSeq.empty[SymbolInfo]
       new Traverser {
         override def traverse(t: Tree): Unit = {
-          if (!progressMonitor.isCanceled() && (t.symbol != NoSymbol || t.isType) && isSourceTree(t)) {
+          def symExists = global.askOption(() => t.symbol != NoSymbol).getOrElse(false)
+
+          if (!progressMonitor.isCanceled() && isSourceTree(t) && (t.hasSymbol || t.isType || symExists)) {
             val ds = findDynamicInfo(t)
             val xs = if (ds.isEmpty) findSymbolInfo(t) else ds.toList
             symbolInfos ++= xs


### PR DESCRIPTION
Fixes #1002132

Not sure if this slows down semantic highlighting too much. Would it make more sense to wrap the entire `Traverser` in an `askOption`?
