### PR TITLE
Showing variable values in hovers when in suspended debug mode

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -3,6 +3,7 @@
 <plugin>
    <extension-point id="reconciliationParticipants" name="Reconcilation Participants" schema="schema/reconciliationParticipants.exsd"/>
    <extension-point id="sourcefileprovider" name="Source file Providers" schema="schema/sourceFileProviders.exsd"/>
+   <extension-point id="scalaHoverDebugOverride" name="Scala Hover Debug Override" schema="schema/scalaHoverDebugOverride.exsd"/>
    <extension
          point="org.eclipse.ui.propertyPages">
       <page

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
@@ -109,6 +109,7 @@ Export-Package:
  org.scalaide.refactoring.internal.source.ui,
  org.scalaide.refactoring.internal.ui,
  org.scalaide.ui.editor,
+ org.scalaide.ui.editor.extensionpoints,
  org.scalaide.ui.internal,
  org.scalaide.ui.internal.actions,
  org.scalaide.ui.internal.actions.hyperlinks,

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
@@ -109,6 +109,7 @@ Export-Package:
  org.scalaide.refactoring.internal.source.ui,
  org.scalaide.refactoring.internal.ui,
  org.scalaide.ui.editor,
+ org.scalaide.ui.editor.extensionpoints,
  org.scalaide.ui.internal,
  org.scalaide.ui.internal.actions,
  org.scalaide.ui.internal.actions.hyperlinks,

--- a/org.scala-ide.sdt.core/schema/scalaHoverDebugOverride.exsd
+++ b/org.scala-ide.sdt.core/schema/scalaHoverDebugOverride.exsd
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.scala-ide.sdt.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.scala-ide.sdt.core" id="scalaHoverDebugOverride" name="Scala Hover Debug Override"/>
+      </appInfo>
+      <documentation>
+         Allows a plugin to supply an alternative logic for creating text hovers for the scala editor. 
+
+Note that the extension point expects to be extended only once, and in case multiple extensions are available, only one will be chosen non-deterministically. This extension point should probably only be used by a debugger plugin, to show variable values (i.e. when the debugger is suspended) upon hover.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <choice>
+            <element ref="overrider"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="overrider">
+      <complexType>
+         <attribute name="hoverFactoryClass" type="string" use="required">
+            <annotation>
+               <documentation>
+                  A factory that creates text hovers to be used in place of the default one.
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.scalaide.ui.editor.extensionpoints.TextHoverFactory"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         The scala-ide.sdt.debug plugin uses this extension point to show variable values in hovers when the debugger is suspended.
+      </documentation>
+   </annotation>
+
+
+
+
+</schema>

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/extensionpoints/ScalaHoverDebugOverrideExtensionPoint.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/extensionpoints/ScalaHoverDebugOverrideExtensionPoint.scala
@@ -1,0 +1,26 @@
+package org.scalaide.ui.editor.extensionpoints
+
+import org.eclipse.core.runtime.Platform
+import org.eclipse.jface.text.ITextHover
+import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
+import org.scalaide.util.internal.Utils
+
+object ScalaHoverDebugOverrideExtensionPoint {
+  final val EXTENSION_POINT_ID = "org.scala-ide.sdt.core.scalaHoverDebugOverride"
+
+  def hoverFor(scu: ScalaCompilationUnit): Option[ITextHover] = extensionHoverFactory map {_ createFor scu}
+
+  private lazy val extensionHoverFactory: Option[TextHoverFactory] = for {
+    // A max of 1 extension is allowed for this extension point. In case more than one is available, only one
+    // will be used, non-deterministically.
+    configElem <- Platform.getExtensionRegistry.getConfigurationElementsFor(EXTENSION_POINT_ID).headOption
+    f <- Utils.tryExecute(configElem.createExecutableExtension("hoverFactoryClass")) collect {case f: TextHoverFactory => f}
+  } yield f
+}
+
+/**
+ * The interface that an extension should implement.
+ */
+trait TextHoverFactory {
+  def createFor(scu: ScalaCompilationUnit): ITextHover
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
@@ -38,6 +38,7 @@ import org.scalaide.core.ScalaPlugin
 import org.scalaide.core.internal.formatter.FormatterPreferences._
 import scalariform.formatter.preferences._
 import org.eclipse.ui.texteditor.ChainedPreferenceStore
+import org.scalaide.ui.editor.extensionpoints.ScalaHoverDebugOverrideExtensionPoint
 
 class ScalaSourceViewerConfiguration(
   javaPreferenceStore: IPreferenceStore,
@@ -139,7 +140,7 @@ class ScalaSourceViewerConfiguration(
 
   override def getTextHover(sv: ISourceViewer, contentType: String, stateMask: Int): ITextHover =
     getCodeAssist match {
-      case Some(scu: ScalaCompilationUnit) => new ScalaHover(scu)
+      case Some(scu: ScalaCompilationUnit) => ScalaHoverDebugOverrideExtensionPoint.hoverFor(scu).getOrElse(new ScalaHover(scu))
       case _                               => new DefaultTextHover(sv)
     }
 

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
@@ -102,7 +102,7 @@ class ScalaDebugTestSession private(launchConfiguration: ILaunchConfiguration) e
     this.synchronized {
       currentStackFrame = stackFrame
       val selection = new StructuredSelection(stackFrame)
-      ScalaDebugger.updateCurrentThread(selection)
+      ScalaDebugger.updateCurrentThreadAndStackFrame(selection)
       state = SUSPENDED
       logger.info("SUSPENDED at: %s:%d".format(stackFrame.getMethodFullName, stackFrame.getLineNumber))
       this.notify

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSuite.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSuite.scala
@@ -10,6 +10,7 @@ import org.scalaide.debug.internal.model.DebugTargetTerminationTest
 import org.scalaide.debug.internal.model.MethodClassifierUnitTest
 import org.scalaide.debug.internal.model.ScalaDebugCacheTest
 import org.scalaide.debug.internal.launching.RemoteConnectorTest
+import org.scalaide.debug.internal.editor.StackFrameVariableOfTreeFinderTest
 
 /**
  * Junit test suite for the Scala debugger.
@@ -31,6 +32,7 @@ import org.scalaide.debug.internal.launching.RemoteConnectorTest
     classOf[DebugTargetTerminationTest],
     classOf[RemoteConnectorTest],
     classOf[ScalaDebugBreakpointTest],
-    classOf[ScalaDebugCacheTest]))
+    classOf[ScalaDebugCacheTest],
+    classOf[StackFrameVariableOfTreeFinderTest]))
 class ScalaDebugTestSuite {
 }

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/editor/StackFrameVariableOfTreeFinderTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/editor/StackFrameVariableOfTreeFinderTest.scala
@@ -1,0 +1,256 @@
+package org.scalaide.debug.internal.editor
+
+import scala.util.Try
+import scala.reflect.internal.util.{Position, OffsetPosition}
+import org.scalaide.debug.internal.ScalaDebugTestSession
+import org.scalaide.debug.internal.ScalaDebugRunningTest
+import org.scalaide.debug.internal.ScalaDebugger
+import org.scalaide.core.testsetup.TestProjectSetup
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
+import org.junit.Test
+import org.junit.Before
+import org.junit.Assert._
+import org.junit.After
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.resources.IncrementalProjectBuilder
+
+object StackFrameVariableOfTreeFinderTest
+extends TestProjectSetup("sfValFinding", bundleName = "org.scala-ide.sdt.debug.tests")
+with ScalaDebugRunningTest {
+  val ScalaClassName = "valfinding.ScalaClass"
+  val OuterClassName = "valfinding.OuterClass"
+  val BaseClassName = "valfinding.BaseClass"
+  val DerivedClassName = "valfinding.DerivedClass"
+  val ExtenderClassName = "valfinding.ExplicitExtenderOfTheTrait"
+  val TheTraitName = "valfinding.TheTrait"
+  val EnclosingTraitName = "valfinding.EnclosingTrait"
+  val ObjectName = "valfinding.Objectt"
+  val ClosureTestClassName = "valfinding.ClosureTest"
+
+  val ScalaClassFile = "ScalaClass.scala"
+  val NestedClassesFile = "NestedClasses.scala"
+  val InheritanceFile = "Inheritance.scala"
+  val EnclosingTraitFile = "EnclosingTrait.scala"
+  val ObjectFieldsFile = "ObjectFields.scala"
+  val ClosuresFile= "Closures.scala"
+}
+
+class StackFrameVariableOfTreeFinderTest {
+  import StackFrameVariableOfTreeFinderTest._
+
+  var testsAreInitialized = false
+
+  @Before
+  def initTests() {
+    if(! testsAreInitialized) {
+      project.underlying.build(IncrementalProjectBuilder.CLEAN_BUILD, new NullProgressMonitor)
+      project.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor)
+      testsAreInitialized = true
+    }
+  }
+
+  def assertFoundValue(atMarker: String, when: String = null, is: Option[String])
+  (implicit cu: ScalaCompilationUnit) {
+    cu.withSourceFile {(src, compiler) =>
+      import compiler.{Try => _, _}
+
+      def treeAtMarker(markerName: String): Tree = {
+        val positions = SDTTestUtils.positionsOf(src.content, s" /*{$markerName}*/")
+        assertEquals(s"Couldn't find exactly one occurence of marker $markerName in ${src.path}.", 1, positions.size)
+        val markerPos = new OffsetPosition(src, positions.head - 1)
+
+        val resp = new Response[Tree]
+        askTypeAt(markerPos, resp)
+        resp.get.left getOrElse (throw new RuntimeException(s"Failed to get the Tree at marker $markerName."))
+      }
+
+      val whenClause = if(when!=null) s"($when) " else ""
+      val foundVariable = StackFrameVariableOfTreeFinder.find(src, compiler, ScalaDebugger.currentStackFrame)(treeAtMarker(atMarker))
+      if(is.isDefined)
+        foundVariable map {v =>
+          val valueStr = Try{v.getValue.getValueString}.getOrElse {
+            throw new AssertionError(s"Failed to '.getValue()' on the found variable at marker '$atMarker'.")}
+          val expected = is.get
+          assertTrue(
+              s"Stack-frame value found at marker '$atMarker' $whenClause was expected to be '$expected'," +
+              s" but is actually $valueStr.",
+              valueStr.matches(s""""$expected"""" + """ \(id=\d+\)"""))
+        } getOrElse fail(s"Failed to find stack-frame value at marker '$atMarker'.")
+      else if(foundVariable.isDefined)
+        fail(s"Expected to find no value at marker '$atMarker' $whenClause, " +
+             s"however the value ${foundVariable.get.getValue.getValueString} was found.")
+    }
+  }
+
+  def withDebugSession(test: ScalaDebugTestSession => Unit) {
+    val session = ScalaDebugTestSession(file("ValFindingDemo.launch"))
+    test(session)
+    session.terminate
+  }
+
+  def scalaCu(filePath: String) =
+    compilationUnit(filePath).asInstanceOf[ScalaCompilationUnit]
+
+  @Test
+  def testClassFields() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(ScalaClassFile)
+
+      session.runToLine(ScalaClassName, 13)
+
+      assertFoundValue(atMarker="class param & field decl",  is=Some("fieldClassParam"))
+      assertFoundValue(atMarker="class param & field usage", is=Some("fieldClassParam"))
+      assertFoundValue(atMarker="non-field class param only used in ctor (decl)",  is=Some("nonFieldClassParam"))
+      assertFoundValue(atMarker="non-field class param only used in ctor (usage)", is=Some("nonFieldClassParam"))
+      assertFoundValue(atMarker="class field decl",  is=Some("classField"))
+      assertFoundValue(atMarker="class field usage", is=Some("classField"))
+      assertFoundValue(atMarker="field with same name of a field", is=None)
+      assertFoundValue(atMarker="similarly named field decl of a class we are not in",  is=None)
+      assertFoundValue(atMarker="similarly named field usage of a class we are not in", is=None)
+    }
+  }
+
+  @Test
+  def testMethodParamsAndLocals() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(ScalaClassFile)
+
+      session.runToLine(ScalaClassName, 17)
+
+      assertFoundValue(atMarker="method param decl",  is=Some("func param"))
+      assertFoundValue(atMarker="method param usage", is=Some("func param"))
+      assertFoundValue(atMarker="similarly named param of a method we are not in", is=None)
+      assertFoundValue(atMarker="method-local variable", "when the variable is not yet assigned", is=None)
+
+      session.stepOver
+
+      assertFoundValue(atMarker="method-local variable", "after the variable is assigned", is=Some("local val"))
+      assertFoundValue(atMarker="similarly named local var of a method we are not in", is=None)
+    }
+  }
+
+  @Test
+  def localVarAccessFromNestedMethods() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(ScalaClassFile)
+
+      session.runToLine(ScalaClassName, 27)
+
+      assertFoundValue(atMarker="nested method param", is=Some("nesteds parameter"))
+      assertFoundValue(atMarker="nested method local", is=Some("nested2Local"))
+      assertFoundValue(atMarker="enclosing nested method local", is=Some("nested1Local"))
+      assertFoundValue(atMarker="root enclosing method local", is=Some("local val"))
+    }
+  }
+
+  @Test
+  def testFieldAccessInNestedClasses() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(NestedClassesFile)
+
+      session.runToLine(OuterClassName, 10)
+
+      assertFoundValue(atMarker="inner class field decl", is=Some("Inner's Field"))
+
+      session.runToLine(OuterClassName, 16)
+
+      assertFoundValue(atMarker="method-local var shadowing field", is=Some("Local Shadower"))
+      assertFoundValue(atMarker="shadowed field accessed with this", is=Some("Inner's Field"))
+      assertFoundValue(atMarker="shadowed field accessed with this with class name", is=Some("Inner's Field"))
+      assertFoundValue(atMarker="shadowed field accessed with this with enclosing class name", is=Some("Outer's Field"))
+      assertFoundValue(atMarker="exclusive field of enclosing class", is=Some("outerExclusiveField"))
+    }
+  }
+
+  @Test
+  def testFieldAccessBaseAndDerivedClasses() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(InheritanceFile)
+
+      session.runToLine(BaseClassName, 7)
+
+      assertFoundValue(atMarker="base class field decl", is=Some("baseField"))
+      assertFoundValue(atMarker="base class field usage", is=Some("baseField"))
+
+      session.runToLine(DerivedClassName, 18)
+
+      assertFoundValue(atMarker="base class field usage from derived class", is=Some("baseField"))
+      assertFoundValue(atMarker="derived class field usage", is=Some("derived field"))
+    }
+  }
+
+  @Test
+  def testTraitFieldAccess() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(InheritanceFile)
+
+      session.runToLine(ExtenderClassName, 34)
+
+      assertFoundValue(atMarker="trait field access from ctor of extender", is=Some("traitFieldd"))
+
+      session.runToLine(ExtenderClassName, 37)
+
+      assertFoundValue(atMarker="trait field access from method of extender", is=Some("traitFieldd"))
+
+      session.runToLine(TheTraitName, 28)
+
+      assertFoundValue(atMarker="trait method param", is=Some("traitFuncParam"))
+      assertFoundValue(atMarker="trait field decl", is=Some("traitFieldd"))
+      assertFoundValue(atMarker="trait field usage from trait", is=Some("traitFieldd"))
+      assertFoundValue(atMarker="private trait field usage from trait", is=Some("privateTraitField"))
+    }
+  }
+
+  @Test
+  def testAccessToFieldsOfEnclosingTraitAndTheEnclosed() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(EnclosingTraitFile)
+
+      session.runToLine(EnclosingTraitName, 10)
+
+      assertFoundValue(atMarker="field decl of class nested in trait", is=Some("nField"))
+      assertFoundValue(atMarker="field usage of class nested in trait", is=Some("nField"))
+      assertFoundValue(atMarker="field of enclosing trait usage", is=Some("tField"))
+    }
+  }
+
+  @Test
+  def testAccessToObjectFields() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(ObjectFieldsFile)
+
+      session.runToLine(ObjectName, 7)
+
+      assertFoundValue(atMarker="object field decl",  is=Some("obj field"))
+      assertFoundValue(atMarker="object field usage", is=Some("obj field"))
+    }
+  }
+
+  @Test
+  def testClosureSupport() {
+    withDebugSession {session =>
+      implicit val cu = scalaCu(ClosuresFile)
+
+      session.runToLine(ClosureTestClassName, 11)
+
+      assertFoundValue(atMarker="closure param decl", is=Some("clParam1"))
+      assertFoundValue(atMarker="closure param usage", is=Some("clParam1"))
+      assertFoundValue(atMarker="captured field of enclosing class", is=Some("captured field"))
+      assertFoundValue(atMarker="captured local variable of enclosing method", is=Some("Local val captured"))
+      assertFoundValue(atMarker="local of another method named similarly to a local of closure", is=None)
+
+      session.runToLine(ClosureTestClassName, 15)
+
+      assertFoundValue(
+          atMarker="local var of closure shadowing local var of enclosing method",
+          "before the variable is assigned to", is=None)
+
+      session.stepOver
+
+      assertFoundValue(
+          atMarker="local var of closure shadowing local var of enclosing method",
+          "after the variable is assigned to", is=Some("shadowed in closure"))
+    }
+  }
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/.classpath
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/.project
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sfValFinding</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/ValFindingDemo.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/ValFindingDemo.launch
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="scala.application">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/sfValFinding/src/*"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="scala.application.new"/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="valfinding.Main"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="sfValFinding"/>
+</launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/Closures.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/Closures.scala
@@ -1,0 +1,23 @@
+package valfinding
+
+class ClosureTest {
+  val fieldC = "captured field"
+
+  def useClosures() {
+    val localValC = "Local val captured"
+    val shadowedInClosure = "This shouldn't be shown"
+
+    List("clParam1", "clParam2", "clParam3").map {closureParam /*{closure param decl}*/ =>
+      closureParam /*{closure param usage}*/
+      fieldC /*{captured field of enclosing class}*/
+      localValC /*{captured local variable of enclosing method}*/
+
+      val shadowedInClosure /*{local var of closure shadowing local var of enclosing method}*/ = "shadowed in closure"
+      shadowedInClosure
+    }
+  }
+
+  def localSimilar {
+    val closureParam /*{local of another method named similarly to a local of closure}*/ = "SSS"
+  }
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/EnclosingTrait.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/EnclosingTrait.scala
@@ -1,0 +1,13 @@
+package valfinding
+
+trait EnclosingTrait {
+  val traitField = "tField"
+
+  new Nestedd
+
+  class Nestedd {
+    val nestedField /*{field decl of class nested in trait}*/ = "nField"
+    nestedField /*{field usage of class nested in trait}*/
+    traitField /*{field of enclosing trait usage}*/
+  }
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/Inheritance.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/Inheritance.scala
@@ -1,0 +1,40 @@
+package valfinding
+
+class BaseClass(baseParam: String) {
+  val baseField /*{base class field decl}*/ = "baseField"
+
+  def baseFunc(bfParam /*{base class method param}*/: String) {
+    baseField /*{base class field usage}*/
+  }
+}
+
+class DerivedClass(derivedParam: Int) extends BaseClass("baseParamFromDerived") /*with TheTrait*/ {
+  val derivedField = "derived field"
+
+  baseFunc("base meth param")
+  derivedFunc("dfParam")
+
+  def derivedFunc(dfParam: String) {
+    baseField /*{base class field usage from derived class}*/
+    derivedField /*{derived class field usage}*/
+  }
+}
+
+trait TheTrait {
+  val traitField /*{trait field decl}*/ = "traitFieldd"
+  private val privateTraitField = "privateTraitField"
+
+  def traitFunc(tfParam /*{trait method param}*/: String = "traitFuncParam") {
+    traitField /*{trait field usage from trait}*/
+    privateTraitField /*{private trait field usage from trait}*/
+  }
+}
+
+class ExplicitExtenderOfTheTrait extends TheTrait {
+  traitField /*{trait field access from ctor of extender}*/
+
+  def fun {
+    traitField /*{trait field access from method of extender}*/
+    traitFunc()
+  }
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/NestedClasses.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/NestedClasses.scala
@@ -1,0 +1,23 @@
+package valfinding
+
+class OuterClass {
+  val outerExclusiveField = "outerExclusiveField"
+  val fff = "Outer's Field"
+
+  class InnerClass {
+    val fff /*{inner class field decl}*/ = "Inner's Field"
+
+    testFields
+
+    def testFields {
+      val fff = "Local Shadower"
+
+      fff /*{method-local var shadowing field}*/                   // Should show "Local Shadower"
+      this.fff /*{shadowed field accessed with this}*/              // Should show "Inner's field"
+      InnerClass.this.fff /*{shadowed field accessed with this with class name}*/    // Should show "Inner's field"
+      OuterClass.this.fff /*{shadowed field accessed with this with enclosing class name}*/   // Should show "Outer's field"
+
+      outerExclusiveField /*{exclusive field of enclosing class}*/
+    }
+  }
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/ObjectFields.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/ObjectFields.scala
@@ -1,0 +1,9 @@
+package valfinding
+
+object Objectt {
+  val field /*{object field decl}*/ = "obj field"
+
+  def f(param: String) {
+    field  /*{object field usage}*/
+  }
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/ScalaClass.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/ScalaClass.scala
@@ -1,0 +1,43 @@
+package valfinding
+
+class ScalaClass(nonFieldClassParamOnlyUsedInCtor /*{non-field class param only used in ctor (decl)}*/ : String, private var fieldClassParam /*{class param & field decl}*/ : String) {
+  fieldClassParam /*{class param & field usage}*/
+  nonFieldClassParamOnlyUsedInCtor /*{non-field class param only used in ctor (usage)}*/
+
+  val classField /*{class field decl}*/ = "classField"
+  classField /*{class field usage}*/
+
+  val cc = CaseC("Case")
+  cc.classField /*{field with same name of a field}*/  // Shouldn't find a value.
+
+  func("func param")
+
+  def func(funcParam /*{method param decl}*/: String) = {
+    funcParam /*{method param usage}*/
+    val localVall /*{method-local variable}*/ = "local val"
+
+    nested1
+
+    def nested1 {
+      val nested1Local = "nested1Local"
+      nested2("nesteds parameter")
+
+      def nested2(nestedMethodParam /*{nested method param}*/: String) {val nested2Local /*{nested method local}*/ = "nested2Local"
+        nested1Local /*{enclosing nested method local}*/
+        localVall /*{root enclosing method local}*/
+      }
+    }
+  }
+
+  def someMethodWeWillNeverStepInto(funcParam /*{similarly named param of a method we are not in}*/: String = "similarly named") {
+    val localVall /*{similarly named local var of a method we are not in}*/ = "Similarly Named"
+  }
+}
+
+class ClassIntoWhichWeWillNeverStep(var fieldClassParam /*{similarly named field decl of a class we are not in}*/: String) {
+  fieldClassParam /*{similarly named field usage of a class we are not in}*/
+}
+
+case class CaseC(classField: String) {
+  val f2: String = classField + " field2"
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/ValFindingDemo.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/sfValFinding/src/ValFindingDemo.scala
@@ -1,0 +1,23 @@
+package valfinding
+
+object Main {
+  val zz = 24
+
+  def main(args: Array[String]): Unit = {
+    val a = new ScalaClass("nonFieldClassParam", "fieldClassParam")
+
+    val outer = new OuterClass
+    val inner = new outer.InnerClass
+
+    val derived = new DerivedClass(47) with TheTrait
+    derived.traitFunc()
+
+    (new ExplicitExtenderOfTheTrait).fun
+
+    new EnclosingTrait{}
+
+    Objectt.f("Obj f param")
+
+    (new ClosureTest).useClosures()
+  }
+}

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -80,4 +80,10 @@
             id="org.scala-ide.sdt.debug.socketListenConnector">
       </vmConnector>
    </extension>
+   <extension
+         point="org.scala-ide.sdt.core.scalaHoverDebugOverride">
+      <overrider
+            hoverFactoryClass="org.scalaide.debug.internal.editor.TextHoverFactory">
+      </overrider>
+   </extension>
 </plugin>

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/editor/TextHoverFactory.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/editor/TextHoverFactory.scala
@@ -1,0 +1,241 @@
+package org.scalaide.debug.internal.editor
+
+import scala.util.Try
+import scala.reflect.internal.util.{Position, RangePosition, OffsetPosition, SourceFile}
+import org.scalaide.util.internal.eclipse.EclipseUtils.PimpedRegion
+import org.scalaide.ui.internal.editor.ScalaHover
+import org.scalaide.ui.editor.extensionpoints.{ TextHoverFactory => TextHoverFactoryInterface }
+import org.scalaide.debug.internal.ScalaDebugger
+import org.scalaide.debug.internal.model.{ScalaThisVariable, ScalaStackFrame}
+import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
+import org.scalaide.core.compiler.ScalaPresentationCompiler
+import org.eclipse.swt.widgets.Shell
+import org.eclipse.jface.text.ITextViewer
+import org.eclipse.jface.text.ITextHoverExtension2
+import org.eclipse.jface.text.ITextHoverExtension
+import org.eclipse.jface.text.ITextHover
+import org.eclipse.jface.text.IRegion
+import org.eclipse.jface.text.IInformationControlExtension2
+import org.eclipse.jface.text.IInformationControlCreator
+import org.eclipse.jface.text.DefaultInformationControl
+import org.eclipse.jdt.internal.debug.ui.ExpressionInformationControlCreator
+import org.eclipse.debug.core.model.IVariable
+
+class TextHoverFactory extends TextHoverFactoryInterface {
+  def createFor(scu: ScalaCompilationUnit): ITextHover = new ScalaHover(scu) with ITextHoverExtension with ITextHoverExtension2 {
+    var stringWasReturnedAtGetHoverInfo2 = false
+
+    override def getHoverInfo2(viewer: ITextViewer, region: IRegion): AnyRef = {
+      icu.withSourceFile{(src, compiler) =>
+        import compiler._
+
+        val resp = new Response[Tree]
+        askTypeAt(region.toRangePos(src), resp)
+
+        stringWasReturnedAtGetHoverInfo2 = false
+
+        for {
+          t <- resp.get.left.toOption
+          stackFrame <- Option(ScalaDebugger.currentStackFrame)
+          variable <- StackFrameVariableOfTreeFinder.find(src, compiler, stackFrame)(t)
+        } yield variable
+      }.flatten getOrElse {
+        stringWasReturnedAtGetHoverInfo2 = true
+        super.getHoverInfo(viewer, region)
+      }
+    }
+
+    override def getHoverControlCreator: IInformationControlCreator =
+      if(stringWasReturnedAtGetHoverInfo2)
+        new IInformationControlCreator {
+          def createInformationControl(parent: Shell) =
+            new StringHandlingInformationControlExtension2(parent)
+        }
+      else  /* An IVariable was returned. */
+        new ExpressionInformationControlCreator
+  }
+
+  class StringHandlingInformationControlExtension2(parent: Shell)
+  extends DefaultInformationControl(parent)
+  with IInformationControlExtension2 {
+    override def setInput(input: AnyRef) {
+      setInformation(input.asInstanceOf[String])
+    }
+  }
+}
+
+
+object StackFrameVariableOfTreeFinder {
+  def find(src: SourceFile, compiler: ScalaPresentationCompiler, stackFrame: ScalaStackFrame)(t: compiler.Tree): Option[IVariable] = {
+    import compiler.{Try => _, _}
+
+    // ---------------- HELPERS ---------------------------------
+    /////////////////////////////////////////////////////////////
+
+    def optSymbol(symbolProducer: => Symbol) =
+      Option(symbolProducer) filterNot(_ == NoSymbol)
+
+    def treeAt(pos: Position) = {
+      val resp = new Response[Tree]
+      askTypeAt(pos, resp)
+      resp.get.left.toOption
+    }
+
+    // StackFrame line numbering is 1-based, while SourceFile line numbering is 0-based. Hence the "- 1".
+    lazy val sfLineNumber = Try{stackFrame.getLineNumber}.filter(_ > 0).map(_ - 1).toOption
+
+    lazy val stackFramePos = sfLineNumber.map {ln =>
+      new OffsetPosition(src, src.skipWhitespace(src.lineToOffset(ln)))
+    }
+
+    def isStackFrameWithin(range: Position) = stackFramePos map {range includes _} getOrElse false
+
+
+    /** Here we use 'template' as an umbrella term to refer to any entity that exposes a 'this'
+     *  variable in the stack frame. This 'this' variable will contain the fields of this template.
+     *  Also if an instance X of a template is enclosed by an instance Y of a template, then Y is
+     *  accessible from X, via the 'outer' field of X.
+     *
+     *  Currently this file considers classes, objects, traits & closures to be templates.
+     *
+     *  Since the stack frame only reveals its line number (and not its position within the line),
+     *  sometimes it is difficult to pinpoint, with certainty, the template that encloses its
+     *  position.
+     *
+     *  This function returns the certainly inner-most template that encloses the line of the stack
+     *  frame. None is returned if we cannot be certain.
+     */
+    def innerMostTemplateCertainlyEnclosingSfPos: Option[Symbol] = sfLineNumber flatMap {sfLine =>
+      val sfPos = src.position(src lineToOffset sfLine)
+      val enclTemplTree = locateIn(parseTree(src), sfPos,
+          t => t.isInstanceOf[ClassDef] || t.isInstanceOf[ModuleDef] || t.isInstanceOf[Function])
+
+      if(enclTemplTree == EmptyTree)
+        None
+      else {
+        val templStartLine = src.offsetToLine(enclTemplTree.pos.start)
+        val templEndLine = src.offsetToLine(enclTemplTree.pos.end)
+        if(sfLine == templStartLine || sfLine == templEndLine)
+          None  // Because in these lines, statements within other templates may exist as well.
+        else
+          treeAt(enclTemplTree.pos) flatMap {t => optSymbol(t.symbol)}
+      }
+    }
+
+    def enclosingTemplOf(s: Symbol) = optSymbol {s enclosingSuchThat {e =>
+      e != s && (e.isClass || e.isTrait || e.isModuleOrModuleClass || e.isAnonymousFunction)}
+    }
+
+    def isFieldAccessibleAtStackFrame(field: Symbol) = optSymbol(field.owner) map {owner =>
+      isStackFrameWithin(owner.pos)
+    } getOrElse false
+
+    def findVariableFromLocalVars(sym: Symbol, disableVarAccessibilityCheck: Boolean = false) = {
+      val isLocalVarAccessibleAtStackFrame = (for {
+        encloser <- optSymbol(sym.enclosingSuchThat{x => x.isMethod || x.isAnonymousFunction})
+      } yield isStackFrameWithin(encloser.pos)) getOrElse false
+
+      if(isLocalVarAccessibleAtStackFrame || disableVarAccessibilityCheck)
+        for {
+          localVars <- Try{stackFrame.getVariables}.toOption
+          foundVar <- localVars.find{_.getName == sym.name.decoded} orElse
+            localVars.find{_.getName.split('$')(0) == sym.name.decoded}  // for variables of enclosing methods
+        } yield foundVar
+      else None
+    }
+
+    def findVariableFromFieldsOf(variable: IVariable, sym: Symbol, varMatcher: IVariable => Boolean = null) = {
+      def stackFrameCompatibleNameOf(sym: Symbol): Name = {  // Based on trial & error. May need more work.
+        var name = sym.name.toTermName
+        if(sym.hasLocalFlag) {
+          // name = name.dropLocal
+          // TODO: The commented line above can be used instead of the one below, when scala 2.10 support is dropped.
+          name = nme dropLocalSuffix name
+        }
+        name.decodedName
+      }
+
+      def cleanBinaryName(name: String) = nme originalName newTermName(name)
+
+      val variableMatcher = if(varMatcher != null)
+        varMatcher
+      else
+        (v: IVariable) => cleanBinaryName(v.getName) == stackFrameCompatibleNameOf(sym)
+
+      for {
+        value <- Try{variable.getValue}.toOption
+        foundFieldVariable <- value.getVariables.find(variableMatcher)
+      } yield foundFieldVariable
+    }
+
+    def thisOfStackFrame = Try{stackFrame.getVariables}.toOption flatMap {sfVars =>
+      sfVars.find(_.isInstanceOf[ScalaThisVariable]) /* doesn't match in traits */ orElse
+        sfVars.find(_.getName == "$this")  // a hack used to access the this when in traits
+    }
+
+    def findVariableFromFieldsOfThis(sym: Symbol, varMatcher: IVariable => Boolean = null) =
+       thisOfStackFrame flatMap {ths => findVariableFromFieldsOf(ths, sym, varMatcher)}
+
+    // ---------------- END OF HELPERS --------------------------
+    /////////////////////////////////////////////////////////////
+
+    Option(t.symbol) flatMap {sym =>
+      val isAVariableOrField = sym.isVal || sym.isVar || sym.isAccessor
+      if(! isAVariableOrField) None
+      else t match {
+        case Select(ths: This, _) =>
+          def tryGetOuter(inner: IVariable) = for {
+            innerVal <- Try{inner.getValue}.toOption
+            outer <- innerVal.getVariables.find(_.getName == "$outer")
+          } yield outer
+
+          (for {
+            sfEnclTempl <- innerMostTemplateCertainlyEnclosingSfPos
+            requestedThisTempl <- Option(ths.symbol)
+            thisOfSf <- thisOfStackFrame
+          } yield {
+
+            // Symbol equality, except if a param is a module & the other its module class, still returns true.
+            def templSymbolsMatch(s1: Symbol, s2: Symbol) =
+              s1 == s2 ||
+              (s1.isModule && (s1.moduleClass == s2)) ||
+              (s2.isModule && (s1 == s2.moduleClass)) ||
+              //
+              // Only in the test case, sometimes two different Symbol objects are created for the same thing,
+              // causing s1 == s2 to be false. The below clause is thus added to make the tests pass.
+              s1.fullLocationString == s2.fullLocationString
+
+            if(templSymbolsMatch(requestedThisTempl, sfEnclTempl))
+              findVariableFromFieldsOfThis(sym) orElse {
+                // Non-field class parameters are sometimes only accessible as local vars.
+                findVariableFromLocalVars(sym, disableVarAccessibilityCheck = true)}
+            else {
+              var currOuter = tryGetOuter(thisOfSf)
+              var currEncl = enclosingTemplOf(sfEnclTempl)
+              while(currOuter.isDefined && currEncl.isDefined && (! templSymbolsMatch(currEncl.get, requestedThisTempl))) {
+                currOuter = tryGetOuter(currOuter.get)
+                currEncl = enclosingTemplOf(currEncl.get)
+              }
+              if(currOuter.isDefined && currEncl.isDefined)
+                findVariableFromFieldsOf(currOuter.get, sym)
+              else None
+            }
+          }).flatten
+        case Select(_, _) => None
+        case _ =>
+          if(sym.isLocal) {
+            findVariableFromLocalVars(sym) orElse
+            //
+            // In closures, local vars of enclosing methods are stored as fields with mangled names.
+            findVariableFromFieldsOfThis(sym, varMatcher = {_.getName.startsWith(sym.decodedName + "$")})
+          } else {
+            if(isFieldAccessibleAtStackFrame(sym))
+              findVariableFromFieldsOfThis(sym) orElse {
+                // Non-field class parameters are sometimes only accessible as local vars.
+                findVariableFromLocalVars(sym, disableVarAccessibilityCheck = true)}
+            else None
+          }
+      }
+    }
+  }
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugModelPresentation.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugModelPresentation.scala
@@ -14,6 +14,8 @@ import org.eclipse.debug.ui.DebugUITools
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility
 import org.eclipse.ui.IEditorInput
 import org.eclipse.jface.viewers.ILabelProviderListener
+import org.eclipse.debug.core.model.IVariable
+import scala.util.Try
 
 /**
  * Utility methods for the ScalaDebugModelPresentation class
@@ -35,6 +37,12 @@ object ScalaDebugModelPresentation {
       case _ =>
         ???
     }
+  }
+
+  def textFor(variable: IVariable): String = {
+    val name = Try{variable.getName} getOrElse "Unavailable Name"
+    val value = Try{variable.getValue} map {computeDetail(_)} getOrElse "Unavailable Value"
+    s"$name = $value"
   }
 
   /** Return the a toString() equivalent for an Array
@@ -125,6 +133,8 @@ class ScalaDebugModelPresentation extends IDebugModelPresentation {
         getScalaThreadText(thread)
       case stackFrame: ScalaStackFrame =>
         getScalaStackFrameText(stackFrame)
+      case variable: IVariable =>
+        ScalaDebugModelPresentation.textFor(variable)
     }
   }
 


### PR DESCRIPTION
Support for showing variable values in hovers when in suspended debug mode.

The hover shows values when hovering over local variables & class fields. Care has been taken for the hover to never show wrong values upon hover (the automated tests test this), although, I cannot rule-out possible bugs.

Some implementation details:
- The sdt.core project now exposes a new extension point (`scalaHoverDebugOverride`) that allows its text hover to be overriden by a plugin. The sdt.debug project provides an extension for this extension point.
- The main logic of this commit is implemented in the `StackFrameVariableOfTreeFinder.find(...)` method. This method takes an ast node (`compiler.Tree`) as input and (if possible) returns the `IVariable` from the stack frame that corresponds to the given ast node.
- Once an `IVariable` is sucessfully found, it is fed to the presentation component that is used internally by the jdt, which presents complex objects in a tree with collapsible sub-trees. Whenever an `IVariable` is not found, the existing implementation of text hover (the one before this commit) is used.
- Some hacks are employed in the implementation (e.g. looking for stack-frame variables that are named `"$this"` or `"$outer"`).
- The `ScalaDebugger` class now also keeps track of the currently selected stack frame.
- A test case exercises the `StackFrameVariableOfTreeFinder.find(...)` function.

Fixes #1001732
