### PR TITLE
Highlight dynamic calls with type parameters

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/semantichighlighting/classifier/DynamicTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/semantichighlighting/classifier/DynamicTest.scala
@@ -105,4 +105,35 @@ class DynamicTest extends AbstractSymbolClassifierTest {
       Map("METH" -> DynamicApplyNamed, "ARG" -> Param))
   }
 
+  @Test
+  def dynamicWithTypeParameter() {
+    checkSymbolClassification("""
+      object X {
+        val d = new D
+        d.field[Int]
+        d.method[Int](10)
+        d.method[Int](value = 10)
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def selectDynamic[A](name: String): A = ???
+        def applyDynamic[A](name: String)(value: Any): A = ???
+        def applyDynamicNamed[A](name: String)(value: (String, Any)): A = ???
+      }
+      """, """
+      object X {
+        val d = new D
+        d.$VAR$[$C$]
+        d.$METH$[$C$](10)
+        d.$DAN $[$C$](10)
+      }
+      import language.dynamics
+      class D extends Dynamic {
+        def selectDynamic[A](name: String): A = ???
+        def applyDynamic[A](name: String)(value: Any): A = ???
+        def applyDynamicNamed[A](name: String)(value: (String, Any)): A = ???
+      }
+      """,
+      Map("METH" -> DynamicApply, "VAR" -> DynamicSelect, "DAN" -> DynamicApplyNamed, "C" -> Class))
+  }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/semantichighlighting/classifier/SafeSymbol.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/semantichighlighting/classifier/SafeSymbol.scala
@@ -64,6 +64,9 @@ private[classifier] trait SafeSymbol extends CompilerAccess with PimpedTrees {
     case Apply(Select(_, DynamicName(sym)), List(name)) =>
       Some(sym -> name.pos)
 
+    case Apply(TypeApply(Select(_, DynamicName(sym)), _), List(name)) =>
+      Some(sym -> name.pos)
+
     case _ =>
       None
   }


### PR DESCRIPTION
`updateDynmaic` is not considered in the tests because type parameters
on the update syntax are invalid.

Fixes #1002162
