### PR TITLE
Revert wrong optimization in 1b83945. Always reset compilers on classpath change

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ClasspathManagement.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ClasspathManagement.scala
@@ -217,12 +217,12 @@ trait ClasspathManagement extends HasLogger { self: ScalaProject =>
     classpathCheckLock.synchronized {
       // mark as in progress
       classpathHasBeenChecked = false
-      val wasValid = classpathValid
       checkClasspath()
-      if (!wasValid && classpathValid) {
-        // no point to reset the compilers on an invalid classpath,
-        // it would not work anyway
-        logger.info("Resetting compilers because the classpath is now valid.")
+      if (classpathValid) {
+        // no point in resetting compilers on an invalid classpath,
+        // it would not work anyway. But we need to reset them if the classpath
+        // was (and still is) valid, because the contents might have changed.
+        logger.info("Resetting compilers due to classpath change.")
         resetCompilers()
       }
     }


### PR DESCRIPTION
Previously we tried to only reset compilers on a transition from an invalid
to a valid class path. That’s wrong, since a change in a valid class path
still needs a reset (the compiler can’t refresh its symbol table any other
way). This lead to spurious errors.
