### PR TITLE
Restore Run Selection In Interpreter functionality

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -1088,7 +1088,7 @@
          name="Toggle Implicits Display"/>
       <command
          categoryId="org.eclipse.debug.ui.category.run"
-         id="scala.tools.eclipse.interpreter.RunSelection"
+         id="org.scalaide.core.handler.RunSelection"
          name="Send Selection to Scala Interpreter"/>
       <command
          categoryId="scala.tools.eclipse.category"
@@ -1186,7 +1186,7 @@
        contextId="scala.tools.eclipse.scalaEditorScope"
        sequence="M1+M2+I"/>
    <key
-       commandId="scala.tools.eclipse.interpreter.RunSelection"
+       commandId="org.scalaide.core.handler.RunSelection"
        schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
        contextId="scala.tools.eclipse.scalaEditorScope"
        sequence="M1+M2+X"/>
@@ -1301,6 +1301,10 @@
           class="org.scalaide.refactoring.internal.MoveConstructorToCompanionObject"
           commandId="org.scalaide.refactoring.MoveConstructorToCompanionObject">
     </handler>
+    <handler
+          class="org.scalaide.ui.internal.actions.RunSelection"
+          commandId="org.scalaide.core.handler.RunSelection">
+    </handler>
  </extension>
  <extension
        point="org.eclipse.ui.menus">
@@ -1334,6 +1338,14 @@
                 icon="icons/indent_guide.png"
                 label="Show Indent Guide"
                 style="toggle">
+          </command>
+          <command
+                commandId="org.scalaide.core.handler.RunSelection"
+                disabledIcon="icons/full/dtool16/run_interpreter.gif"
+                icon="icons/full/etool16/run_interpreter.gif"
+                label="Run Selection in Scala Interpreter"
+                style="push"
+                tooltip="Run Selection in Scala Interpreter">
           </command>
        </toolbar>
     </menuContribution>

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunSelectionAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunSelectionAction.scala
@@ -1,23 +1,18 @@
 package org.scalaide.ui.internal.actions
 
-import org.eclipse.jface.action.IAction
+import org.eclipse.core.commands.AbstractHandler
+import org.eclipse.core.commands.ExecutionEvent
 import org.eclipse.jface.text.ITextSelection
-import org.eclipse.ui.actions.ActionDelegate
-import org.eclipse.ui.texteditor.ITextEditor
-import org.eclipse.ui.IWorkbenchWindow
-import org.eclipse.ui.IWorkbenchWindowActionDelegate
 import org.eclipse.ui.IFileEditorInput
+import org.eclipse.ui.PlatformUI
+import org.eclipse.ui.texteditor.ITextEditor
 import org.scalaide.ui.internal.repl.ReplConsoleView
-import org.scalaide.util.internal.Utils._
+import org.scalaide.util.internal.Utils.WithAsInstanceOfOpt
 
-class RunSelectionAction extends ActionDelegate with IWorkbenchWindowActionDelegate {
-  var workbenchWindow: IWorkbenchWindow = null
+class RunSelection extends AbstractHandler {
 
-  def init(window: IWorkbenchWindow) {
-    workbenchWindow = window
-  }
-
-  override def run(action: IAction) {
+  override def execute(e: ExecutionEvent): AnyRef = {
+    val workbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow()
 
     for (editor <- Option(workbenchWindow.getActivePage.getActiveEditor);
         input <- editor.getEditorInput.asInstanceOfOpt[IFileEditorInput];
@@ -46,5 +41,7 @@ class RunSelectionAction extends ActionDelegate with IWorkbenchWindowActionDeleg
         ReplConsoleView.makeVisible(project,workbenchWindow.getActivePage).evaluate(text)
       }
     }
+
+    null
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/migration/MigrationPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/migration/MigrationPreferenceInitializer.scala
@@ -84,5 +84,6 @@ class MigrationPreferenceInitializer extends AbstractPreferenceInitializer {
     copyKeyBinding("scala.tools.eclipse.refactoring.command.Rename", "org.scalaide.refactoring.Rename")
     copyKeyBinding("scala.tools.eclipse.refactoring.command.ExpandCaseClassBinding", "org.scalaide.refactoring.ExpandCaseClassBinding")
     copyKeyBinding("scala.tools.eclipse.refactoring.commands.quickMenu", "org.scalaide.ui.menu.quickMenu")
+    copyKeyBinding("scala.tools.eclipse.interpreter.RunSelection", "org.scalaide.core.handler.RunSelection")
   }
 }


### PR DESCRIPTION
This functionality was accidentally removed in ae7f8dc, it works now
again.

Instead of the old action API, the new handler API is now used. The
command id has changed as well - the `MigrationPreferenceInitializer`
takes care of it.

Fixes #1002164
