### PR TITLE
Don’t reuse platform classloader when ScalaInstallation matches its version

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -142,7 +142,9 @@ class EclipseSbtBuildManager(val project: ScalaProject, settings0: Settings)
   }
 
   private def runCompiler(sources: Seq[File]) {
-    val inputs = new SbtInputs(findInstallation(project), sources.toSeq, project, monitor, new SbtProgress, tempDirFile, sbtLogger)
+    val scalaInstall = findInstallation(project)
+    logger.info(s"Running compiler using $scalaInstall")
+    val inputs = new SbtInputs(scalaInstall, sources.toSeq, project, monitor, new SbtProgress, tempDirFile, sbtLogger)
     val analysis =
       try
         Some(aggressiveCompile(inputs, sbtLogger))


### PR DESCRIPTION
Remove the optimization that reused the platform class loader when the desired
Scala version matched the one installed in Eclipse. This proved to break due
to OSGi restrictions and the implementation of DelegatingReporter in the
compiler-interface.jar

See #1002175 for details
