### PR TITLE
Redesign of the bug report dialog

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/diagnostic/ReportBugDialog.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/diagnostic/ReportBugDialog.scala
@@ -22,6 +22,12 @@ import org.scalaide.core.internal.project.ScalaInstallation
 
 class ReportBugDialog(shell: Shell) extends Dialog(shell) {
 
+  /** Overwritten in order to set the title text. */
+  override def configureShell(sh: Shell): Unit = {
+    super.configureShell(sh)
+    sh.setText("Bug Reporter")
+  }
+
   protected override def isResizable = true
 
   protected override def createDialogArea(parent: Composite): Control = {
@@ -37,10 +43,15 @@ class ReportBugDialog(shell: Shell) extends Dialog(shell) {
     val messageField = new Text(group1, SWT.READ_ONLY | SWT.MULTI | SWT.BORDER)
     messageField.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL | GridData.HORIZONTAL_ALIGN_FILL))
     messageField.setText(
-        "Scala plugin version: " + ScalaPlugin.plugin.getBundle.getVersion + "\n\n" +
-        "Bundled Scala compiler version: " + ScalaPlugin.plugin.scalaVer.unparse + "\n\n" +
-        "Scala library version:\t" + ScalaInstallation.platformInstallation.version.unparse + "\n" +
-        "Eclipse version: " + Platform.getBundle("org.eclipse.platform").getVersion)
+        s"""|Scala IDE version:
+            |        ${ScalaPlugin.plugin.getBundle.getVersion}
+            |Scala compiler version:
+            |        ${ScalaPlugin.plugin.scalaVer.unparse}
+            |Scala library version:
+            |        ${ScalaInstallation.platformInstallation.version.unparse}
+            |Eclipse version:
+            |        ${Platform.getBundle("org.eclipse.platform").getVersion}
+            |""".stripMargin)
 
     val group2 = new Group(control, SWT.SHADOW_NONE)
     group2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false))
@@ -54,7 +65,7 @@ class ReportBugDialog(shell: Shell) extends Dialog(shell) {
     logFileLink.addListener(SWT.Selection, OpenExternalFile(LogManager.logFile))
 
     val reportBugLink = new Link(group2, SWT.NONE)
-    reportBugLink.setText("and <a href=\"" + ScalaPlugin.IssueTracker + "\">report a bug</a>.")
+    reportBugLink.setText(s""" and <a href="${ScalaPlugin.IssueTracker}">report a bug</a>.""")
     reportBugLink.addListener(SWT.Selection, new LinkListener())
 
     control


### PR DESCRIPTION
- Add title to dialog
- Replace tab with space in version area
- Fix overlapping words in link section
- Reformat version area

Before:
![before](https://cloud.githubusercontent.com/assets/488530/3570995/ff740642-0b57-11e4-9489-577f3fea928e.png)

After:
![after](https://cloud.githubusercontent.com/assets/488530/3570997/029a05a6-0b58-11e4-802e-a1c5a2ed32c5.png)
