### PR TITLE
Treat projects in subfolders correctly in `NewFileWizard`

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/CreateClassProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/CreateClassProposal.scala
@@ -29,7 +29,7 @@ case class CreateClassProposal(className: String, compilationUnit: ICompilationU
     val dialog = new WizardDialog(JavaPlugin.getActiveWorkbenchShell(), wizard)
     dialog.create()
 
-    def file = wizard.page.pathOfCreatedFile
+    def file = wizard.page.createdFile
 
     def existsInDifferentPackage: Boolean = {
       file map { file =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/NewFileWizard.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/NewFileWizard.scala
@@ -89,10 +89,8 @@ trait NewFileWizard extends AnyRef with HasLogger {
   /**
    * Returns the path to the file created by the wizard. Returns `None` as long
    * as the wizard did not yet create a new file.
-   *
-   * '''Note:''' The returned path is absolute to the root of the filesystem
    */
-  def pathOfCreatedFile: Option[IFile] =
+  def createdFile: Option[IFile] =
     Option(file)
 
   def createContents(parent: Composite): Control = {
@@ -271,7 +269,7 @@ trait NewFileWizard extends AnyRef with HasLogger {
       ctx
     }
 
-    val file = m.withInstance(_.createFilePath(selectedFolder, chosenName))
+    val file = m.withInstance(_.create(selectedFolder, chosenName))
     file foreach { f =>
       FileUtils.createFile(f) match {
         case util.Success(_) =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/EmptyFileCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/EmptyFileCreator.scala
@@ -9,7 +9,7 @@ import org.eclipse.core.resources.IResource
  */
 class EmptyFileCreator extends FileCreator {
 
-  override def createFilePath(folder: IFolder, name: String): IFile =
+  override def create(folder: IFolder, name: String): IFile =
     folder.getFile(name)
 
   override def validateName(folder: IFolder, name: String): Validation =

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/FileCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/FileCreator.scala
@@ -65,7 +65,7 @@ trait FileCreator {
    * This method is guaranteed to be called not before [[validateName]] returns
    * a valid state.
    */
-  def createFilePath(folder: IFolder, name: String): IFile
+  def create(folder: IFolder, name: String): IFile
 
   /**
    * Creates a path that is shown when a new file wizard is created. This should

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/ScalaFileCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/ScalaFileCreator.scala
@@ -49,7 +49,7 @@ trait ScalaFileCreator extends FileCreator {
       }
   }
 
-  override def createFilePath(folder: IFolder, name: String): IFile = {
+  override def create(folder: IFolder, name: String): IFile = {
     val filePath = name.replace('.', '/')
     folder.getFile(s"$filePath.scala")
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/ScalaFileCreators.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/ScalaFileCreators.scala
@@ -44,7 +44,7 @@ class PackageObjectCreator extends ScalaFileCreator {
     }
   }
 
-  override def createFilePath(folder: IFolder, name: String): IFile = {
+  override def create(folder: IFolder, name: String): IFile = {
     val filePath = name.replace('.', '/')
     folder.getFile(s"$filePath/package.scala")
   }


### PR DESCRIPTION
Normally a project is located in the root of the workspace, which would
lead to a physical location like '/workspace/project/file'. But it is
totally valid to have a file in a physical location like
'/worskpace/subfolder/project/file'. It is even possible to have source
folders that are linked resources and can therefore be located anywhere
on the file system. In these cases the wizard did not work correctly.

Internally the wizard was based on `IPath` types which was a problem
because they couldn't handle linked resources perfectly well. In case a
linked source folder points to another folder in the workspace, an
`IPath` object did always point to the real file on the file system. If
the path would have pointed to the symlink there would have been no way
to determine its real location.

To overcome this limitation the `IPath` references were replaced by
`IFile`, which abstracts over workspace files and therefore can
correctly recognize symlinks.

Fixes #1002185
