### PR TITLE
Use `Import-Package` instead of `Require-Bundle` for org.eclipse.core.runtime

### DIFF
--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
@@ -12,7 +12,6 @@ Require-Bundle:
  org.eclipse.core.expressions,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,
- org.eclipse.core.runtime,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
  org.eclipse.help,
@@ -50,6 +49,13 @@ Require-Bundle:
  org.eclipse.ui.browser;bundle-version="3.3.0",
  org.eclipse.nebula.widgets.tablecombo;bundle-version="1.0.0"
 Import-Package: 
+ org.eclipse.core.runtime,
+ org.eclipse.core.runtime.content,
+ org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
+ org.eclipse.core.internal.runtime,
+ org.osgi.framework,
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions;apply-aspects:=false,

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
@@ -12,7 +12,6 @@ Require-Bundle:
  org.eclipse.core.expressions,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,
- org.eclipse.core.runtime,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
  org.eclipse.help,
@@ -52,6 +51,13 @@ Require-Bundle:
  org.eclipse.ui.browser;bundle-version="3.3.0",
  org.eclipse.nebula.widgets.tablecombo;bundle-version="1.0.0"
 Import-Package: 
+ org.eclipse.core.runtime,
+ org.eclipse.core.runtime.content,
+ org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
+ org.eclipse.core.internal.runtime,
+ org.osgi.framework,
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions;apply-aspects:=false,

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
@@ -12,7 +12,6 @@ Require-Bundle:
  org.eclipse.core.expressions,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,
- org.eclipse.core.runtime,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
  org.eclipse.help,
@@ -51,6 +50,13 @@ Require-Bundle:
  org.eclipse.ui.browser;bundle-version="3.3.0",
  org.eclipse.nebula.widgets.tablecombo;bundle-version="1.0.0"
 Import-Package: 
+ org.eclipse.core.runtime,
+ org.eclipse.core.runtime.content,
+ org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
+ org.eclipse.core.internal.runtime,
+ org.osgi.framework,
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions;apply-aspects:=false,

--- a/org.scala-ide.sdt.debug/resources/META-INF/MANIFEST-2_10.MF
+++ b/org.scala-ide.sdt.debug/resources/META-INF/MANIFEST-2_10.MF
@@ -12,7 +12,6 @@ Require-Bundle:
  org.eclipse.core.expressions,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,
- org.eclipse.core.runtime,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
  org.eclipse.help,
@@ -51,6 +50,13 @@ Require-Bundle:
  org.scala-ide.sdt.core,
  org.scala-ide.equinox-weaving-launcher;bundle-version="[1.1.0,2.0.0)";resolution:=optional
 Import-Package: 
+ org.eclipse.core.runtime,
+ org.eclipse.core.runtime.content,
+ org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
+ org.eclipse.core.internal.runtime,
+ org.osgi.framework,
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions;apply-aspects:=false,

--- a/org.scala-ide.sdt.debug/resources/META-INF/MANIFEST-2_11.MF
+++ b/org.scala-ide.sdt.debug/resources/META-INF/MANIFEST-2_11.MF
@@ -12,7 +12,6 @@ Require-Bundle:
  org.eclipse.core.expressions,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,
- org.eclipse.core.runtime,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
  org.eclipse.help,
@@ -51,6 +50,13 @@ Require-Bundle:
  org.scala-ide.sdt.core,
  org.scala-ide.equinox-weaving-launcher;bundle-version="[1.1.0,2.0.0)";resolution:=optional
 Import-Package: 
+ org.eclipse.core.runtime,
+ org.eclipse.core.runtime.content,
+ org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
+ org.eclipse.core.internal.runtime,
+ org.osgi.framework,
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions;apply-aspects:=false,

--- a/org.scala-ide.sdt.debug/resources/META-INF/MANIFEST-2_12.MF
+++ b/org.scala-ide.sdt.debug/resources/META-INF/MANIFEST-2_12.MF
@@ -12,7 +12,6 @@ Require-Bundle:
  org.eclipse.core.expressions,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,
- org.eclipse.core.runtime,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
  org.eclipse.help,
@@ -51,6 +50,13 @@ Require-Bundle:
  org.scala-ide.sdt.core,
  org.scala-ide.equinox-weaving-launcher;bundle-version="[1.1.0,2.0.0)";resolution:=optional
 Import-Package: 
+ org.eclipse.core.runtime,
+ org.eclipse.core.runtime.content,
+ org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
+ org.eclipse.core.internal.runtime,
+ org.osgi.framework,
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.builderoptions;apply-aspects:=false,


### PR DESCRIPTION
This should allow Luna installs without conflicts due to “double vision” of
the `javax.bind.ws` package. This workaround was suggested in this Eclipse ticket.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=430458

PS. Even though this is primarily a Luna concern, this works well for Kepler, so I prefer to keep the manifests in sync.
