### PR TITLE
Revert "Unused member warning doesn't highlight whole definition anymore...

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/ScalaPresentationCompiler.scala
@@ -456,7 +456,12 @@ object ScalaPresentationCompiler {
       import prob._
       if (pos.isDefined) {
         val source = pos.source
-        val reducedPos = toSingleLine(pos)
+        val reducedPos =
+          if (pos.isRange)
+            toSingleLine(pos)
+          else
+            new RangePosition(pos.source, pos.point, pos.point, pos.point + ScalaWordFinder.findWord(source.content, pos.start).getLength)
+
         val fileName =
           source.file match {
             case EclipseFile(file) =>


### PR DESCRIPTION
..."

This reverts commit c659afae0c2d27d78b22a18ca1ca3735cb910a4e.

Fixed #1002209
