### PR TITLE
Interrupt Scala builder on resource change

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/BuildMonitor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/BuildMonitor.scala
@@ -1,0 +1,42 @@
+package org.scalaide.core.internal.builder
+
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.NullProgressMonitor
+
+/**
+ * Wrapper for a progress monitor that can access the state of an incremental
+ * builder.
+ */
+class BuildMonitor(m: IProgressMonitor, builder: IncrementalProjectBuilder) extends IProgressMonitor {
+
+  private val underlying = if (m != null) m else new NullProgressMonitor
+
+  override def beginTask(name: String, totalWork: Int): Unit =
+    underlying.beginTask(name, totalWork)
+
+  override def done(): Unit =
+    underlying.done()
+
+  override def internalWorked(work: Double): Unit =
+    underlying.internalWorked(work)
+
+  /**
+   * Returns `true` if either the progress monitor is cancelled or the builder
+   * is interrupted.
+   */
+  override def isCanceled(): Boolean =
+    underlying.isCanceled() || builder.isInterrupted()
+
+  override def setCanceled(value: Boolean): Unit =
+    underlying.setCanceled(value)
+
+  override def setTaskName(name: String): Unit =
+    underlying.setTaskName(name)
+
+  override def subTask(name: String): Unit =
+    underlying.subTask(name)
+
+  override def worked(work: Int): Unit =
+    underlying.worked(work)
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -71,7 +71,7 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
           val removed0 = new HashSet[IFile]
 
           getDelta(project.underlying).accept(new IResourceDeltaVisitor {
-            def visit(delta : IResourceDelta) = {
+            override def visit(delta : IResourceDelta) = {
               delta.getResource match {
                 case file : IFile if plugin.isBuildable(file) && project.sourceFolders.exists(_.isPrefixOf(file.getLocation)) =>
                   delta.getKind match {
@@ -114,7 +114,7 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
       }
     }
 
-    val subMonitor = SubMonitor.convert(monitor, 100).newChild(100, SubMonitor.SUPPRESS_NONE)
+    val subMonitor = SubMonitor.convert(new BuildMonitor(monitor, this), 100).newChild(100, SubMonitor.SUPPRESS_NONE)
     subMonitor.beginTask("Running Scala Builder on " + project.underlying.getName, 100)
 
     val projectsInError = project.transitiveDependencies.filter(p => plugin.getScalaProject(p).buildManager.hasErrors)


### PR DESCRIPTION
Whenever Eclipse is configured to automatically build, an interrupt
event is sent to all builders whenever an resource change happens in the
workspace.

The Scala builder didn't react on such an interrupt event so far - this
changes with this commit.

Beside from aborting the current running build, the build is restarted
after the resource change event is handled.

Fixes #1002229

---

See the discussion on https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/scala-ide-user/VQpZKX0FPLE that led to this PR.
