### PR TITLE
Add *.tmpBin files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/.cache
+**/*.tmpBin
 target/
 org.scala-ide.sdt.core/META-INF/MANIFEST.MF
 org.scala-ide.sdt.update-site/site.xml


### PR DESCRIPTION
These files are created by sbt and they clutter up the `git status`
output until sbt has finished building.
