### PR TITLE
Fix Luna build by using the AJDT dev version of the weaving hook.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <repo.eclipse>${repo.eclipse.luna}</repo.eclipse>
         <repo.ajdt>${repo.ajdt.luna}</repo.ajdt>
         <jdt.core.version.range>[3.10.0,4.0.0)</jdt.core.version.range>
-        <weaving.hook.plugin.version>1.1.0.v20140529-1734</weaving.hook.plugin.version>
+        <weaving.hook.plugin.version>1.1.100.weaving-hook-20140821</weaving.hook.plugin.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
AspecJ has a new release in their /dev update site, with a different
version of the weaving hook. We upgrade to this one to fix our builds.

This is (probably) brought in as a transitive dependency from aspectj.runtime,
and I couldn’t find a way to use the weaving.hook available in the release
Luna repository (there is one there as well).

We might investigate whether we should use the AspectJ release from the
Spring Tool Suite (since that’s the most likely conflict we’ll ever have),
at least until there’s a stable release of AJDT for Luna (none yet).
