### PR TITLE
Switches to package import for the dependency to osgi.service.location

### DIFF
--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
@@ -25,7 +25,6 @@ Require-Bundle:
  org.eclipse.jface.text,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ltk.ui.refactoring,
- org.eclipse.osgi,
  org.eclipse.search,
  org.eclipse.text,
  org.eclipse.ui,
@@ -52,6 +51,7 @@ Require-Bundle:
  org.eclipse.e4.ui.workbench;bundle-version="1.0.2",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.0.1"
 Import-Package: 
+ org.eclipse.osgi.service.datalocation,
  org.eclipse.core.runtime,
  org.eclipse.core.runtime.content,
  org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
@@ -25,7 +25,6 @@ Require-Bundle:
  org.eclipse.jface.text,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ltk.ui.refactoring,
- org.eclipse.osgi,
  org.eclipse.search,
  org.eclipse.text,
  org.eclipse.ui,
@@ -54,6 +53,7 @@ Require-Bundle:
  org.eclipse.e4.ui.workbench;bundle-version="1.0.2",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.0.1"
 Import-Package: 
+ org.eclipse.osgi.service.datalocation,
  org.eclipse.core.runtime,
  org.eclipse.core.runtime.content,
  org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
@@ -25,7 +25,6 @@ Require-Bundle:
  org.eclipse.jface.text,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ltk.ui.refactoring,
- org.eclipse.osgi,
  org.eclipse.search,
  org.eclipse.text,
  org.eclipse.ui,
@@ -53,6 +52,7 @@ Require-Bundle:
  org.eclipse.e4.ui.workbench;bundle-version="1.0.2",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.0.1"
 Import-Package: 
+ org.eclipse.osgi.service.datalocation,
  org.eclipse.core.runtime,
  org.eclipse.core.runtime.content,
  org.eclipse.core.runtime.dynamichelpers;version="[3.4.0,3.5.0)",


### PR DESCRIPTION
The dependency to the bundle org.eclipse.osgi was creating conflict
with the bundle javax.xml.bind (included in Eclipse for JEE).

The problem was reported on the [mailing list](https://groups.google.com/d/msg/scala-ide-user/ZDeZ_rCX5BI/tr-ynGIgcMMJ).
