### PR TITLE
Fixes switching between Scala Installations

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/CompilerSettings.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/CompilerSettings.scala
@@ -466,7 +466,7 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
     def isChanged() = !(currentValue equals initialValue)
 
     override def notify(pub: Publisher[IScalaProjectEvent], event: IScalaProjectEvent): Unit = {
-      event match { case e: ScalaInstallation =>
+      event match { case e: ScalaInstallationChange =>
         // the semantics of the initial value have changed through this backend update
         // it's very important to do this before the Load (platform checks on file IO)
         initialValue = getPreferenceStore().getString(SettingConverterUtil.SCALA_DESIRED_INSTALLATION)
@@ -505,7 +505,7 @@ class CompilerSettings extends PropertyPage with IWorkbenchPreferencePage with E
     getConcernedProject() flatMap (ScalaPlugin().asScalaProject(_)) foreach {_.subscribe(this)}
 
     override def notify(pub: Publisher[IScalaProjectEvent], event: IScalaProjectEvent): Unit = {
-      event match { case e: ScalaInstallation =>
+      event match { case e: ScalaInstallationChange =>
         DisplayThread.asyncExec(doLoad())
         DisplayThread.asyncExec(updateApply())
       }


### PR DESCRIPTION
It was a typo is a match case, introduced during the API refactoring
