### PR TITLE
Fixes problem build disabled after clean

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -41,7 +41,6 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
 
     ensureProject()
     scalaJavaBuilder.clean(monitor)
-    project.buildManager.clean(monitor)
     JDTUtils.refreshPackageExplorer
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ClasspathManagement.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ClasspathManagement.scala
@@ -409,7 +409,7 @@ trait ClasspathManagement extends HasLogger { self: ScalaProject =>
     // the marker manipulation needs to be done in a Job, because it requires
     // a change on the IProject, which is locked for modification during
     // the classpath change notification
-    EclipseUtils.scheduleJob("Update classpath error markers", underlying) { monitor =>
+    EclipseUtils.scheduleJob("Update classpath error markers", underlying, Job.BUILD) { monitor =>
       if (underlying.isOpen()) { // cannot change markers on closed project
         // clean the classpath markers
         underlying.deleteMarkers(SdtConstants.ClasspathProblemMarkerId, true, IResource.DEPTH_ZERO)


### PR DESCRIPTION
Following the merge of #767, doing a clean with `Build Automatically` on, would
not generate any binaries.
The reason was the job scheduled to update the markers after the classpath check (normal after
a clean) was interrupting the build job. The fix is to put both job at the same priority level,
so they don't interrupt each other.
Also fixes the fact that `EclipseBuildManager.clean` was called twice for each project.
