### PR TITLE
Adds missing getOption() synchronization call

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/AbstractNewElementWizardPage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/AbstractNewElementWizardPage.scala
@@ -437,6 +437,7 @@ abstract class AbstractNewElementWizardPage extends NewTypeWizardPage(1, "") wit
       val scalaProject = IScalaPlugin().asScalaProject(parentCU.getJavaProject.getProject).get
 
       scalaProject.presentationCompiler { compiler =>
+        import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
         compiler.asyncExec[Unit] {
           //start control of buffer
           val cb = CodeBuilder(getPackageNameToInject.getOrElse(""), superTypes, buffer, scalaProject.presentationCompiler)
@@ -457,7 +458,7 @@ abstract class AbstractNewElementWizardPage extends NewTypeWizardPage(1, "") wit
 
           //end control of buffer
 
-        }
+        }.getOption()
       }
 
       val cu = createdType.getCompilationUnit


### PR DESCRIPTION
The previous getOption call (old API) was replaced by an asyncExec, it requires
a getOption() (new API) to wait for the execution of the code.
