### PR TITLE
Basic ScalaDoc prettyfications

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/hover/ScalaDocHtmlProducer.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/hover/ScalaDocHtmlProducer.scala
@@ -76,14 +76,14 @@ class ScalaDocHtmlProducer extends HtmlHover {
         <h3>{ header }</h3>
 
     val mainHtml = List(
+      bodyToHtml(comment.body),
+      bodiesToHtml("Example" + (if (comment.example.length > 1) "s" else ""), comment.example),
       bodiesToHtml("Parameters", comment.valueParams.toList.sortBy(_._1).map {
         case (name, body) => Body(Paragraph(Bold(Text(name))) :: body.blocks.toList)
       }),
       bodiesToHtml("Type Parameters", comment.typeParams.toList.sortBy(_._1).map {
         case (name, body) => Body(Paragraph(Bold(Text(name))) :: body.blocks.toList)
       }),
-      bodyToHtml(comment.body),
-      bodiesToHtml("Example" + (if (comment.example.length > 1) "s" else ""), comment.example),
       bodiesToHtml("Version", comment.version.toList),
       bodiesToHtml("Since", comment.since.toList),
       bodiesToHtml("Note", comment.note),


### PR DESCRIPTION
- support for complying with the Scala Hover CSS
- support for display of '@param', '@tparam' elements
