### PR TITLE
Control persistence of PC doc comments.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/leaks/MemoryLeaksTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/leaks/MemoryLeaksTest.scala
@@ -66,6 +66,8 @@ class MemoryLeaksTest extends HasLogger {
     val usedMem = for (i <- 1 to N) yield {
       val src = if (i % 2 == 0) originalTyper else changedTyper
 
+      // reconcile once in a while
+      if (i % 3 == 0) typerUnit.withSourceFile((_, comp) => comp.askReloadManagedUnits())
       val usedMem = withGC {
         typeCheckWith(typerUnit, src)
         typeCheckWith(implicitsUnit, new String(implicitsUnit.getContents))

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -77,7 +77,7 @@ class ScalaPresentationCompiler(name: String, settings: Settings) extends {
 
   override lazy val analyzer = new {
     val global: ScalaPresentationCompiler.this.type = ScalaPresentationCompiler.this
-  } with InteractiveScaladocAnalyzer
+  } with InteractiveScaladocAnalyzer with CommentPreservingTypers
 
   override def forScaladoc = true
 
@@ -256,12 +256,12 @@ class ScalaPresentationCompiler(name: String, settings: Settings) extends {
    *  compiler, it will be from now on.
    */
   def askReload(scu: InteractiveCompilationUnit, content: Array[Char]): Response[Unit] = {
-    withResponse[Unit] { res => askReload(List(scu.sourceFile(content)), res) }
+    withResponse[Unit] { res => clearDocComments(); askReload(List(scu.sourceFile(content)), res) }
   }
 
   /** Atomically load a list of units in the current presentation compiler. */
   def askReload(units: List[InteractiveCompilationUnit]): Response[Unit] = {
-    withResponse[Unit] { res => askReload(units.map(_.sourceFile), res) }
+    withResponse[Unit] { res => clearDocComments(); askReload(units.map(_.sourceFile), res) }
   }
 
   def filesDeleted(units: Seq[InteractiveCompilationUnit]) {


### PR DESCRIPTION
Comments obtained by parsing are cleared at each typer run if `CommentPreservingTypers` isn't mixed in.
- fixes memory leak
- makes Scaladoc slower

It's possible (and easy : add `icUnit.scalaProject.presentationCompiler(_.clearDocComments())` right before [that line](https://github.com/scala-ide/scala-ide/blob/master/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconcilingStrategy.scala#L48)) to reset those comments only at reconciliation, but the memory-leak test doesn't trigger reconciliation (it types all the time).
# 

Tested with :

```
huitseeker➜Scala/scala-ide/org.scala-ide.sdt.build(hotfix/scaladoc-memoryleak✗)» mvn --projects \
../org.scala-ide.sdt.aspects,../org.scala-ide.sdt.core,../org.scala-ide.sdt.core.tests \
-Dscala211.version=2.11.3-SNAPSHOT -P scala-2.11.x,memory-test,eclipse-luna  clean integration-test
```
# 

Edit : i've added a more involved fix as a second commit, which triggers docComment clearing at each reconciliation and make the Memleak test trigger reconciliation. LMK what you think about including it.
