### PR TITLE
Fix deadlock by moving `res.get` outside of synchronized block.

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -131,10 +131,10 @@ class ScalaPresentationCompiler(name: String, _settings: Settings) extends {
         val reloadFiles = reloadees map { case (_, srcFile) => srcFile }
         askReload(reloadFiles, res)
         logger.info(s"Flushed ${reloadees.mkString("", ",", "")}")
-        res.get
       }
       scheduledUnits.clear()
     }
+    res.get
     res
   }
 


### PR DESCRIPTION
Fixed #1002275.

I don't have a reproducible test case, but this should release the hashmap lock that's blocking the PC from making progress in completing `res`.
