### PR TITLE
Harden locate symbol. Sometimes there is no source provider.

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/LocateSymbol.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/LocateSymbol.scala
@@ -85,7 +85,7 @@ trait LocateSymbol { self: ScalaPresentationCompiler =>
         findPath()
 
     findSourceFile.fold(findClassFile()) { f =>
-      SourceFileProviderRegistry.getProvider(f).createFrom(f)
+      Option(SourceFileProviderRegistry.getProvider(f)).flatMap(_.createFrom(f))
     }
   }
 


### PR DESCRIPTION
This used to cause an NPE in the Play plugin when hovering over a Routes
name (it’s source file is Java, and we don’t have a source file provider for Java).

/cc @skyluc @huitseeker
