### PR TITLE
Clear doc comments when fishing reloads.

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -258,12 +258,19 @@ class ScalaPresentationCompiler(name: String, _settings: Settings) extends {
    *  compiler, it will be from now on.
    */
   def askReload(scu: InteractiveCompilationUnit, source: SourceFile): Response[Unit] = {
-    withResponse[Unit] { res => clearDocComments(); askReload(List(source), res) }
+    withResponse[Unit] { res => askReload(List(source), res) }
   }
 
   /** Atomically load a list of units in the current presentation compiler. */
   def askReload(units: List[InteractiveCompilationUnit]): Response[Unit] = {
-    withResponse[Unit] { res => clearDocComments(); askReload(units.map(_.lastSourceMap().sourceFile), res) }
+    withResponse[Unit] { res => askReload(units.map(_.lastSourceMap().sourceFile), res) }
+  }
+
+  /** Make sure we remove the doc comments we accumulated so far. */
+  override def askReload(sources: List[SourceFile], response: Response[Unit]) = {
+    logger.info(s"Clearing doc comments (${cookedDocComments.size} entries)")
+    clearDocComments();
+    super.askReload(sources, response)
   }
 
   def filesDeleted(units: Seq[InteractiveCompilationUnit]) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/diagnostic/ReportBugDialog.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/diagnostic/ReportBugDialog.scala
@@ -19,6 +19,7 @@ import org.scalaide.core.internal.logging.LogManager
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.internal.project.ScalaInstallation.platformInstallation
 import org.scalaide.core.SdtConstants
+import org.scalaide.core.internal.ScalaPlugin
 
 
 class ReportBugDialog(shell: Shell) extends Dialog(shell) {
@@ -43,6 +44,10 @@ class ReportBugDialog(shell: Shell) extends Dialog(shell) {
 
     val messageField = new Text(group1, SWT.READ_ONLY | SWT.MULTI | SWT.BORDER)
     messageField.setLayoutData(new GridData(GridData.GRAB_HORIZONTAL | GridData.HORIZONTAL_ALIGN_FILL))
+
+    val cacheEntries = ScalaPlugin().classLoaderStore.entries
+    val entries = cacheEntries.map(e => s"Compiler v. ${e._1.version.unparse}(${e._1.compiler.classJar})")
+
     messageField.setText(
         s"""|Scala IDE version:
             |        ${IScalaPlugin().getBundle.getVersion}
@@ -52,6 +57,8 @@ class ReportBugDialog(shell: Shell) extends Dialog(shell) {
             |        ${platformInstallation.version.unparse}
             |Eclipse version:
             |        ${Platform.getBundle("org.eclipse.platform").getVersion}
+            |Class loader store: ${cacheEntries.size} entries
+            |        ${entries.mkString("\n\t")}
             |""".stripMargin)
 
     val group2 = new Group(control, SWT.SHADOW_NONE)

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/FixedSizeCache.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/FixedSizeCache.scala
@@ -2,6 +2,7 @@ package org.scalaide.util.internal
 
 import java.util.LinkedHashMap
 import java.lang.ref.WeakReference
+import scala.collection.JavaConverters._
 
 /** A LRU fixed sized-cache using WeakReferences.
  *
@@ -24,6 +25,8 @@ class FixedSizeCache[K, V](initSize: Int, maxSize: Int) {
   private val jmap = new LinkedHashMap[K, WeakReference[V]](initSize min maxSize, 0.75f, /* accessOrder = */ true) {
     override def removeEldestEntry(entry: JEntry): Boolean = size() > maxSize
   }
+
+  def entries: Seq[(K, WeakReference[V])] = jmap.asScala.toSeq
 
   /** Return the value associated with K if found in cache, otherwise insert the value
    *  provided in `orElse`.


### PR DESCRIPTION
Added one more entry to the diagnostic dialog (size of class loader cache).
