### PR TITLE
Fix "expand implicits" quick fixes

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/ExpandingProposalBase.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/ExpandingProposalBase.scala
@@ -15,7 +15,7 @@ class ExpandingProposalBase(msg: String, displayString: String, pos: Position)
    */
   def apply(document: IDocument): Unit = {
     // We extract the replacement string from the marker's message.
-    val ReplacementExtractor = s"(?s).*${ImplicitHighlightingPresenter.DisplayStringSeparator}(.*)".r
+    val ReplacementExtractor = s"(?s)`.*`${ImplicitHighlightingPresenter.DisplayStringSeparator}`(.*?)`?".r
     val ReplacementExtractor(replacement) = msg
     document.replace(pos.getOffset(), pos.getLength(), replacement)
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/ScalaQuickAssistProcessor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickfix/ScalaQuickAssistProcessor.scala
@@ -64,9 +64,9 @@ class ScalaQuickAssistProcessor extends IQuickAssistProcessor with HasLogger {
 }
 
 object ScalaQuickAssistProcessor {
-  private final val ImplicitConversionFound = "(?s)Implicit conversions found: (.*)".r
+  private final val ImplicitConversionFound = "(?s)Implicit conversion found: (.*?):.*?".r
 
-  private final val ImplicitArgFound = "(?s)Implicit arguments found: (.*)".r
+  private final val ImplicitArgFound = "(?s)Implicit arguments found: (.*?)".r
 
   val availableAssists = Seq(
     ExpandCaseClassBindingProposal,


### PR DESCRIPTION
With the introduction of the new HTML hover, the annotation message for
implicit conversions and arguments has changed.

Fixes #1002283

Superseded by #819 (more precisely https://github.com/sschaef/scala-ide/commit/c91cbdbb356492e26e6a177b2358626c662fb774 )
