### PR TITLE
Narrow the return types to API types in tests.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/ClasspathContainersTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/ClasspathContainersTests.scala
@@ -9,7 +9,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.scalaide.core.IScalaPlugin
-import org.scalaide.core.internal.project.ScalaProject
 import org.scalaide.core.IScalaProject
 import org.scalaide.util.internal.CompilerUtils
 import org.scalaide.util.eclipse.EclipseUtils
@@ -19,9 +18,10 @@ import org.eclipse.core.runtime.NullProgressMonitor
 import org.junit.AfterClass
 import org.scalaide.core.SdtConstants
 import org.scalaide.core.testsetup.SDTTestUtils
+import org.scalaide.core.internal.project.ScalaProject
 
 object ClasspathContainersTests {
-  private var projects: List[ScalaProject] = List()
+  private var projects: List[IScalaProject] = List()
 
   @AfterClass
   final def deleteProject(): Unit = {
@@ -36,7 +36,7 @@ class ClasspathContainersTests {
   def getLibraryContainer(project: IScalaProject) = JavaCore.getClasspathContainer(new Path(libraryId), project.javaProject)
 
   def createProject(): ScalaProject = {
-    val project = SDTTestUtils.createProjectInWorkspace(s"compiler-settings${projects.size}", true)
+    val project = SDTTestUtils.internalCreateProjectInWorkspace(s"compiler-settings${projects.size}", true)
     projects = project :: projects
     project
   }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/ClasspathTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/ClasspathTests.scala
@@ -29,6 +29,7 @@ import org.scalaide.util.internal.SettingConverterUtil
 import scala.tools.nsc.settings.SpecificScalaVersion
 import org.scalaide.util.internal.CompilerUtils
 import org.scalaide.core.SdtConstants
+import org.scalaide.core.internal.project.ScalaProject
 
 object ClasspathTests extends TestProjectSetup("classpath") {
 
@@ -71,7 +72,7 @@ class ClasspathTests {
         if classpathEntry.getPath().toPortableString() != "org.scala-ide.sdt.launching.SCALA_CONTAINER")
       yield classpathEntry
 
-  val projectStore = project.projectSpecificStorage
+  val projectStore = internalProject.projectSpecificStorage
 
   private def enableProjectSpecificSettings() = {
     projectStore.setValue(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE, true)

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/DesiredScalaInstallationTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/DesiredScalaInstallationTests.scala
@@ -33,7 +33,7 @@ import org.scalaide.core.SdtConstants
 import org.scalaide.core.testsetup.SDTTestUtils
 
 object DesiredScalaInstallationTests {
-  private var projects: List[ScalaProject] = List()
+  private var projects: List[IScalaProject] = List()
 
     @AfterClass
   final def deleteProject(): Unit = {
@@ -59,7 +59,7 @@ class DesiredScalaInstallationTests {
   def anotherBundle(dsi : LabeledScalaInstallation): Option[LabeledScalaInstallation] = ScalaInstallation.availableBundledInstallations.find { si => si != dsi }
 
   def createProject(): ScalaProject = {
-    val project = SDTTestUtils.createProjectInWorkspace(s"compiler-settings${projects.size}", true)
+    val project = SDTTestUtils.internalCreateProjectInWorkspace(s"compiler-settings${projects.size}", true)
     projects = project :: projects
     project
   }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/DeprecationWarningsTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/DeprecationWarningsTests.scala
@@ -15,12 +15,13 @@ import org.junit.Test
 import scala.language.reflectiveCalls
 import org.scalaide.util.eclipse.FileUtils
 import org.junit.Before
+import org.scalaide.core.internal.project.ScalaProject
 
 object deprecationWarningsProject extends TestProjectSetup("builder-deprecation-warnings") {
 
   def initSettings() {
     // enable deprecation warnings for this project
-    val storage = deprecationWarningsProject.project.projectSpecificStorage.asInstanceOf[PropertyStore]
+    val storage = deprecationWarningsProject.internalProject.projectSpecificStorage.asInstanceOf[PropertyStore]
     storage.setValue(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE, true)
     storage.setValue("deprecation", true)
     storage.setValue("nameHashing", true)

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/MultiScalaVersionTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/MultiScalaVersionTest.scala
@@ -31,17 +31,19 @@ class MultiScalaVersionTest {
 
   @Test // Build using the previous version of the Scala library
   def previousVersionBuildSucceeds() {
-    val Seq(proj) = createProjects("prev-version-build")
+    val Seq(proj) = internalCreateProjects("prev-version-build")
     val p = proj
-    p.projectSpecificStorage.setValue(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE, true)
+    val projectSpecificStorage = p.projectSpecificStorage
+
+    projectSpecificStorage.setValue(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE, true)
 
     for (installation <- findPreviousScalaInstallation()) {
       val choice = ScalaInstallationChoice(installation)
-      p.projectSpecificStorage.setValue(SettingConverterUtil.SCALA_DESIRED_INSTALLATION, choice.toString())
+      projectSpecificStorage.setValue(SettingConverterUtil.SCALA_DESIRED_INSTALLATION, choice.toString())
       Assert.assertEquals(s"Expected to see the desired choice, found ${p.desiredinstallationChoice()}", choice, p.desiredinstallationChoice())
       setScalaLibrary(p, installation.library.classJar)
       val ShortScalaVersion(major, minor) = installation.version
-      p.projectSpecificStorage.setValue(CompilerSettings.ADDITIONAL_PARAMS, s"-Xsource:$major.$minor")
+      projectSpecificStorage.setValue(CompilerSettings.ADDITIONAL_PARAMS, s"-Xsource:$major.$minor")
 
       p.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null)
       val (_, errors) = getErrorMessages(p.underlying).filter(_._1 == IMarker.SEVERITY_ERROR).unzip

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/TestProjectSetup.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/TestProjectSetup.scala
@@ -1,7 +1,6 @@
 package org.scalaide.core.testsetup
 
 import scala.tools.nsc.interactive.Response
-
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.core.runtime.Path
@@ -16,6 +15,7 @@ import org.mockito.Mockito.when
 import org.scalaide.core.compiler.InteractiveCompilationUnit
 import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.IScalaProject
 import org.scalaide.core.internal.project.ScalaProject
 
 /** Base class for setting up tests that depend on a project found in the test-workspace.
@@ -31,8 +31,10 @@ import org.scalaide.core.internal.project.ScalaProject
  *
  */
 class TestProjectSetup(projectName: String, srcRoot: String = "/%s/src/", val bundleName: String = "org.scala-ide.sdt.core.tests") extends ProjectBuilder {
+  private[core] lazy val internalProject: ScalaProject = SDTTestUtils.internalSetupProject(projectName, bundleName)
+
   /** The ScalaProject corresponding to projectName, after copying to the test workspace. */
-  override lazy val project: ScalaProject = SDTTestUtils.setupProject(projectName, bundleName)
+  override lazy val project: IScalaProject = internalProject
 
   /** The package root corresponding to /src inside the project. */
   lazy val srcPackageRoot: IPackageFragmentRoot = {


### PR DESCRIPTION
This should drastically reduce the number of internal “hits” in plugins.
