### PR TITLE
Don’t call `openWhenClosed` if the compilation unit is consistent.

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
@@ -33,7 +33,6 @@ import scala.util.control.Exception
 import org.eclipse.core.runtime.CoreException
 import org.scalaide.core.compiler.ScalaCompilationProblem
 
-
 class ScalaSourceFileProvider extends SourceFileProvider {
   override def createFrom(path: IPath): Option[InteractiveCompilationUnit] =
     ScalaSourceFile.createFromPath(path.toString)
@@ -113,8 +112,12 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
     reconcileFlags : Int,
     problems : JHashMap[_,_],
     monitor : IProgressMonitor) : org.eclipse.jdt.core.dom.CompilationUnit = {
-    val info = createElementInfo.asInstanceOf[OpenableElementInfo]
-    openWhenClosed(info, true, monitor)
+
+    // don't rerun this expensive operation unless necessary
+    if (!isConsistent()) {
+      val info = createElementInfo.asInstanceOf[OpenableElementInfo]
+      openWhenClosed(info, true, monitor)
+    }
     null
   }
 


### PR DESCRIPTION
`openWhenClosed` is expensive: it requires a partial type-check and forcing all
symbols in order to build the structure of the file. It seems to be called
on the UI thread, on every save, twice. This makes the second call a no-op,
and is exactly what the method we’re overriding is doing. This makes it more
responsive, and seems and sane.
