### PR TITLE
Create a build marker when a project is not built due to upstream errors...

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -120,7 +120,8 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
 
     val projectsInError = project.transitiveDependencies.filter(p => IScalaPlugin().getScalaProject(p).buildManager.hasErrors)
     if (stopBuildOnErrors && projectsInError.nonEmpty) {
-      logger.info("Skipped dependent project %s build because of upstream compilation errors in %s".format(project.underlying.getName, projectsInError))
+      project.underlying.deleteMarkers(SdtConstants.ProblemMarkerId, true, IResource.DEPTH_INFINITE)
+      BuildProblemMarker.create(project.underlying, s"Project not built due to errors in dependent project(s) ${projectsInError.map(_.getName).mkString(", ")}")
     } else {
       logger.info("Building project " + project)
       project.build(addedOrUpdated, removed, subMonitor)


### PR DESCRIPTION
....

Fixed #1002320
