### PR TITLE
Handle src/bin folders that are the same as project root folders

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -223,9 +223,13 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
       val outputLocation = if (cpeOutput != null) cpeOutput else javaProject.getOutputLocation
 
       val wsroot = EclipseUtils.workspaceRoot
-      val binPath = wsroot.getFolder(outputLocation) // may not exist
 
-      (source.asInstanceOf[IContainer], binPath)
+      if (source.getProject.getFullPath == outputLocation)
+        (source.asInstanceOf[IContainer], source.asInstanceOf[IContainer])
+      else {
+        val binPath = wsroot.getFolder(outputLocation)
+        (source.asInstanceOf[IContainer], binPath)
+      }
     }
   }
 


### PR DESCRIPTION
It is possible to create source and binary folders that are the same as
the project root folder. The easiest way to do this is to use the "Use
project folder as root folder for sources and class files" option in the
new Scala project wizard.

Scala IDE is unable so far to handle these folders because the Eclipse
API itself seems to be unable to handle these folders. The common
operation to retrieve an IFolder is

```
project.getFolder(path)
```

which throws an exception in case path is the same as the project path.

This commit fixes the problem by not calling the `getFolder` method but
by creating an `IFolder` manually or by reusing the project object
directly.

Fixes #1002332, #1002146

---

Not sure if it is safe to merge this before the final release. Probably it is not harmful because if an exception occurs it is not an behavior change to what currently happens.
