### PR TITLE
Consider project specific formatting settings for auto format

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/saveactions/AutoFormatting.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/saveactions/AutoFormatting.scala
@@ -4,6 +4,7 @@ package saveactions
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.internal.formatter.FormatterPreferences
 import org.scalaide.core.text.Replace
+import org.scalaide.util.internal.eclipse.ProjectUtils
 
 import scalariform.formatter.ScalaFormatter
 import scalariform.utils.TextEdit
@@ -11,7 +12,11 @@ import scalariform.utils.TextEdit
 object AutoFormattingSetting extends SaveActionSetting(
   id = ExtensionSetting.fullyQualifiedName[AutoFormatting],
   name = "Auto formatting",
-  description = "Formats the entire document based on the configuration options in \"Scala > Editor > Formatter\".",
+  description =
+    """|Formats the entire document based on the configuration options in \
+       |"Scala > Editor > Formatter". If project specific formatting is enabled, \
+       |these formatting options are considered instead.
+       |""".stripMargin.replaceAll("\\\\\n", ""),
   codeExample = """|class C {
                    |  def f = {
                    |    val a=0
@@ -27,9 +32,11 @@ trait AutoFormatting extends SaveAction with DocumentSupport {
   override def setting = AutoFormattingSetting
 
   override def perform() = {
-    val formatted = ScalaFormatter.formatAsEdits(
-        document.text,
-        FormatterPreferences.getPreferences(IScalaPlugin().getPreferenceStore()))
+    val prefs = ProjectUtils.resourceOfSelection().map {
+      r => FormatterPreferences.getPreferences(r.getProject)
+    }.getOrElse(FormatterPreferences.getPreferences(IScalaPlugin().getPreferenceStore()))
+
+    val formatted = ScalaFormatter.formatAsEdits(document.text, prefs)
     formatted map { case TextEdit(pos, len, text) => Replace(pos, pos+len, text) }
   }
 }


### PR DESCRIPTION
A fall back to the workspace wide formatting settings happens if the
project settings couldn't be accessed.

Fixes #1002331
