### PR TITLE
Mark a recently flaky test as, erm, Flaky.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/pc/PresentationCompilerDocTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/pc/PresentationCompilerDocTest.scala
@@ -1,5 +1,6 @@
 package org.scalaide.core.pc
 
+import org.scalaide.core.FlakyTest
 import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
 import scala.tools.nsc.doc.base.comment.Comment
 import scala.tools.nsc.interactive.Response
@@ -59,7 +60,7 @@ class PresentationCompilerDocTest {
   }
 
   @Test
-  def inheritedTwoSourcesDoc() {
+  def inheritedTwoSourcesDoc() = FlakyTest.retry("inheritedTwoSourcesDoc", "") {
     val expect: Comment => Boolean = { cmt =>
       existsText(cmt.todo, "implement me")
     }


### PR DESCRIPTION
This one failed three times in PR validation this week. The CI
farm has been pretty crowded with a swathe of scala-js builds,
so that might have flushed out a race condition in this feature.

For now, I have placed the test under the watchful and patient
eye of the FlakyTest retry mechanism.
