### PR TITLE
Add quick assists for spelling mistakes

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -1288,6 +1288,10 @@
           class="org.scalaide.core.internal.quickassist.changecase.ChangeCase"
           id="org.scalaide.core.quickassist.ChangeCase">
     </quickAssist>
+    <quickAssist
+          class="org.scalaide.core.internal.quickassist.FixSpellingMistake"
+          id="org.scalaide.core.quickassist.FixSpellingMistake">
+    </quickAssist>
  </extension>
 
    <extension point="org.eclipse.ui.contexts">

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/FixSpellingMistake.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/FixSpellingMistake.scala
@@ -1,0 +1,19 @@
+package org.scalaide.core.internal.quickassist
+
+import org.eclipse.jdt.internal.ui.text.spelling.WordQuickFixProcessor
+import org.scalaide.core.quickassist.BasicCompletionProposal
+import org.scalaide.core.quickassist.InvocationContext
+import org.scalaide.core.quickassist.QuickAssist
+
+/**
+ * Creates quick assists for spelling mistakes.
+ */
+class FixSpellingMistake extends QuickAssist {
+
+  override def compute(ctx: InvocationContext): Seq[BasicCompletionProposal] = {
+    val jctx = new JavaInvocationContextAdapter(ctx)
+    val p = new WordQuickFixProcessor()
+    p.getCorrections(jctx, jctx.javaProblemLocations).map(JavaProposalAdapter)
+  }
+
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/JavaQuickAssistAdapters.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/JavaQuickAssistAdapters.scala
@@ -1,0 +1,45 @@
+package org.scalaide.core.internal.quickassist
+
+import org.eclipse.jdt.core.ICompilationUnit
+import org.eclipse.jdt.internal.ui.javaeditor.IJavaAnnotation
+import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation
+import org.eclipse.jdt.ui.text.java.IInvocationContext
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
+import org.eclipse.jdt.ui.text.java.IProblemLocation
+import org.eclipse.jface.text.IDocument
+import org.scalaide.core.quickassist.AssistLocation
+import org.scalaide.core.quickassist.BasicCompletionProposal
+import org.scalaide.core.quickassist.InvocationContext
+
+/**
+ * Adapter for [[org.scalaide.core.quickassist.InvocationContext]] that
+ * implements [[org.eclipse.jdt.ui.text.java.IInvocationContext]].
+ */
+final class JavaInvocationContextAdapter(ctx: InvocationContext) extends IInvocationContext {
+  override def getCompilationUnit = ctx.icu.asInstanceOf[ICompilationUnit]
+  override def getSelectionOffset = ctx.selectionStart
+  override def getSelectionLength = ctx.selectionLength
+  override def getASTRoot = null
+  override def getCoveredNode = null
+  override def getCoveringNode = null
+
+  def javaProblemLocations: Array[IProblemLocation] =
+    ctx.problemLocations.collect {
+      case AssistLocation(offset, length, annotation: IJavaAnnotation) =>
+        new ProblemLocation(offset, length, annotation)
+    }.toArray
+}
+
+/**
+ * Adapter for [[org.eclipse.jdt.ui.text.java.IJavaCompletionProposal]] that
+ * implements [[org.scalaide.core.quickassist.BasicCompletionProposal]].
+ */
+final case class JavaProposalAdapter(jcp: IJavaCompletionProposal)
+    extends BasicCompletionProposal(
+      relevance = jcp.getRelevance,
+      displayString = jcp.getDisplayString,
+      image = jcp.getImage) {
+
+  override def apply(document: IDocument): Unit =
+    jcp.apply(document)
+}


### PR DESCRIPTION
After the creation of our own quick assists the Java spelling mistake
quick assists were no longer called. This adds some adapters, which
provide the necessary clutter to call Java quick assists.

Fixes #1002301
