### PR TITLE
Handle src/bin folders that are the same as project root folders

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -223,9 +223,12 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
       val outputLocation = if (cpeOutput != null) cpeOutput else javaProject.getOutputLocation
 
       val wsroot = EclipseUtils.workspaceRoot
-      val binPath = wsroot.getFolder(outputLocation) // may not exist
-
-      (source.asInstanceOf[IContainer], binPath)
+      if (source.getProject.getFullPath == outputLocation)
+        (source.asInstanceOf[IContainer], source.asInstanceOf[IContainer])
+      else {
+        val binPath = wsroot.getFolder(outputLocation)
+        (source.asInstanceOf[IContainer], binPath)
+      }
     }
   }
 


### PR DESCRIPTION
This PR should be the unproblematic part of #850. No tests included because I couldn't find an appropriate test suite and was to lazy to create one.

---

It is possible to create source and binary folders that are the same as
the project root folder. The easiest way to do this is to use the "Use
project folder as root folder for sources and class files" option in the
new Scala project wizard.

Scala IDE is unable so far to handle these folders because the Eclipse
API itself seems to be unable to handle these folders. The common
operation to retrieve an IFolder is

project.getFolder(path)

which throws an exception in case `path` is the same as the path of
`project`.

The problem is fixed by not calling `getFolder` inside of `ScalaProject`
but by reusing an existing reference to the `IContainer` that already
references the correct location on the filesystem.

Fixes #1002146
