### PR TITLE
Support for drop to frame

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
@@ -135,6 +135,7 @@ class ScalaDebugTestSession private(launchConfiguration: ILaunchConfiguration) e
   var state = NOT_LAUNCHED
   var debugTarget: ScalaDebugTarget = null
   var currentStackFrame: ScalaStackFrame = null
+  def currentStackFrames: Seq[ScalaStackFrame] = Option(currentStackFrame).map(_.thread.getScalaStackFrames).getOrElse(Nil)
 
   /**
    * Add a breakpoint at the specified location,
@@ -231,6 +232,17 @@ class ScalaDebugTestSession private(launchConfiguration: ILaunchConfiguration) e
     waitUntilSuspended
 
     assertEquals("Bad state after resumeToCompletion", TERMINATED, state)
+  }
+
+  def dropToFrame(stackFrame: ScalaStackFrame) {
+    assertEquals("Bad state before dropToFrame", SUSPENDED, state)
+
+    setActionRequested
+    stackFrame.dropToFrame()
+
+    waitUntilSuspended
+
+    assertEquals("Bad state after dropToFrame", SUSPENDED, state)
   }
 
   def terminate() {

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugTarget.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugTarget.scala
@@ -370,6 +370,8 @@ abstract class ScalaDebugTarget private (val virtualMachine: VirtualMachine, lau
    */
   private[model] def getScalaThreads: List[ScalaThread] = threads
 
+  private[model] def canPopFrames: Boolean = running && virtualMachine.canPopFrames()
+
 }
 
 private[model] object ScalaDebugTargetActor {

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaStackFrame.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaStackFrame.scala
@@ -1,16 +1,17 @@
 package org.scalaide.debug.internal.model
 
-import scala.collection.JavaConverters.asScalaBufferConverter
-import scala.reflect.NameTransformer
+import com.sun.jdi.AbsentInformationException
+import com.sun.jdi.InvalidStackFrameException
+import com.sun.jdi.Method
+import com.sun.jdi.NativeMethodException
+import com.sun.jdi.StackFrame
+import org.eclipse.debug.core.model.IDropToFrame
 import org.eclipse.debug.core.model.IRegisterGroup
 import org.eclipse.debug.core.model.IStackFrame
 import org.eclipse.debug.core.model.IThread
 import org.eclipse.debug.core.model.IVariable
-import com.sun.jdi.AbsentInformationException
-import com.sun.jdi.Method
-import com.sun.jdi.StackFrame
-import com.sun.jdi.InvalidStackFrameException
-import com.sun.jdi.NativeMethodException
+import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.reflect.NameTransformer
 
 object ScalaStackFrame {
 
@@ -78,7 +79,8 @@ object ScalaStackFrame {
  * This class is NOT thread safe. 'stackFrame' variable can be 're-bound' at any time.
  * Instances have be created through its companion object.
  */
-class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame: StackFrame) extends ScalaDebugElement(thread.getDebugTarget) with IStackFrame {
+class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame: StackFrame)
+  extends ScalaDebugElement(thread.getDebugTarget) with IStackFrame with IDropToFrame {
   import ScalaStackFrame._
 
   // Members declared in org.eclipse.debug.core.model.IStackFrame
@@ -119,7 +121,14 @@ class ScalaStackFrame private (val thread: ScalaThread, @volatile var stackFrame
   override def resume(): Unit = thread.resume()
   override def suspend(): Unit = ???
 
+  // Members declared in org.eclipse.debug.core.model.IDropToFrame
+
+  override def canDropToFrame(): Boolean = thread.canDropToFrame(this)
+  override def dropToFrame(): Unit = thread.dropToFrame(this)
+
   // ---
+
+  def isNative = stackFrame.location().method().isNative()
 
   import org.scalaide.debug.internal.JDIUtil._
   import scala.util.control.Exception


### PR DESCRIPTION
Support for drop to frame button for the Scala IDE debugger. I think, it's not needed to explain what's that, as it's a well-known feature from the Eclipse's debugger for Java.

An implementation is really simple - except some checks whether this operation can be performed it's basically: invoke threadRefrence.popFrames(frame) and stepInto using the stack frame just below this one used when invoking popFrames. The whole UI support is handled by Eclipse as ScalaStackFrame now extends IDropToFrame (Eclipse just does some type casting and then does everything, what we need, when it sees that it got IDropToFrame instance).

Note:
- it can skip some frames as StepInto does this intentionally
- there's no Hot Code Replace (HCR) yet - I'll try to add it soon (I mean it's a separate feature)

Lastly, the below disclaimer is required by the lawyers:

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
