### PR TITLE
scaliform default preferences changed

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/formatter/ScalaFormatterPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/formatter/ScalaFormatterPreferenceInitializer.scala
@@ -11,25 +11,39 @@ class ScalaFormatterPreferenceInitializer extends AbstractPreferenceInitializer 
   import FormatterPreferences._
 
   def initializeDefaultPreferences() {
-    val preferenceStore = IScalaPlugin().getPreferenceStore
+    implicit val preferenceStore = IScalaPlugin().getPreferenceStore
     for (preference <- AllPreferences.preferences) {
       preference match {
+        case DoubleIndentClassDeclaration =>
+          setDefaultBoolean(DoubleIndentClassDeclaration, overrideValue = Some(true))
         case pd: BooleanPreferenceDescriptor =>
-          preferenceStore.setDefault(preference.eclipseKey, pd.defaultValue)
-          preferenceStore.setDefault(preference.oldEclipseKey, pd.defaultValue)
-          if (!preferenceStore.isDefault(preference.oldEclipseKey)) {
-            preferenceStore(pd) = preferenceStore.getBoolean(preference.oldEclipseKey)
-            preferenceStore.setToDefault(preference.oldEclipseKey)
-          }
+          setDefaultBoolean(pd)
         case pd: IntegerPreferenceDescriptor =>
-          preferenceStore.setDefault(preference.eclipseKey, pd.defaultValue)
-          preferenceStore.setDefault(preference.oldEclipseKey, pd.defaultValue)
-          if (!preferenceStore.isDefault(preference.oldEclipseKey)) {
-            preferenceStore(pd) = preferenceStore.getInt(preference.oldEclipseKey)
-            preferenceStore.setToDefault(preference.oldEclipseKey)
-          }
+          setDefaultInt(pd)
       }
     }
 
+  }
+
+  private def setDefaultBoolean(preference: PreferenceDescriptor[Boolean],
+    overrideValue: Option[Boolean] = None)(implicit preferenceStore: IPreferenceStore) = {
+    val defaultValue = overrideValue.getOrElse(preference.defaultValue)
+    preferenceStore.setDefault(preference.eclipseKey, defaultValue)
+    preferenceStore.setDefault(preference.oldEclipseKey, defaultValue)
+    if (!preferenceStore.isDefault(preference.oldEclipseKey)) {
+      preferenceStore(preference) = preferenceStore.getBoolean(preference.oldEclipseKey)
+      preferenceStore.setToDefault(preference.oldEclipseKey)
+    }
+  }
+
+  private def setDefaultInt(preference: PreferenceDescriptor[Int],
+    overrideValue: Option[Int] = None)(implicit preferenceStore: IPreferenceStore) = {
+    val defaultValue = overrideValue.getOrElse(preference.defaultValue)
+    preferenceStore.setDefault(preference.eclipseKey, defaultValue)
+    preferenceStore.setDefault(preference.oldEclipseKey, defaultValue)
+    if (!preferenceStore.isDefault(preference.oldEclipseKey)) {
+      preferenceStore(preference) = preferenceStore.getInt(preference.oldEclipseKey)
+      preferenceStore.setToDefault(preference.oldEclipseKey)
+    }
   }
 }


### PR DESCRIPTION
scaliform.DoubleIndentClassDeclaration preference changed from "false" to "true" according to Scala Style Guide.
https://github.com/mdr/scalariform#doubleindentclassdeclaration

Fixes #1002321
