### PR TITLE
code completion: reduce relevance for non class fields and for java.*, scala.* packages

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionOrderTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionOrderTests.scala
@@ -1,0 +1,53 @@
+package org.scalaide.core.ui.completion
+
+import org.junit.Test
+import org.junit.AfterClass
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.scalaide.ui.internal.preferences.EditorPreferencePage
+import org.scalaide.core.FlakyTest
+
+object CompletionOrderTests extends CompletionTests
+
+class CompletionOrderTests {
+
+  import CompletionOrderTests._
+
+  @Test
+  def completeFieldOnTop() = """
+    package completeFieldOnTop
+    object X extends App {
+      val ClassName = ""
+      def f(name: String) = name
+      f(Class^)
+    }
+  """ becomes """
+    package completeFieldOnTop
+    object X extends App {
+      val ClassName = ""
+      def f(name: String) = name
+      f(ClassName^)
+    }
+  """ after Completion("ClassName",
+      expectedCompletions = Seq("ClassName", "ClassManifest", "Class"),
+      respectOrderOfExpectedCompletions = true)
+
+
+  @Test
+  def completeMethodOnTop() = """
+    package completeMethodOnTop
+    object X extends App {
+      def ClassName = ""
+      def f(name: String) = name
+      f(Class^)
+    }
+  """ becomes """
+    package completeMethodOnTop
+    object X extends App {
+      def ClassName = ""
+      def f(name: String) = name
+      f(ClassName^)
+    }
+  """ after Completion("ClassName: String",
+      expectedCompletions = Seq("ClassName: String", "ClassManifest", "Class"),
+      respectOrderOfExpectedCompletions = true)
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTestSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTestSuite.scala
@@ -8,6 +8,7 @@ import org.junit.runners.Suite
     classOf[CompletionOverwriteTests],
     classOf[AccessibilityTests],
     classOf[StandardCompletionTests],
-    classOf[ParameterCompletionTests]
+    classOf[ParameterCompletionTests],
+    classOf[CompletionOrderTests]
 ))
 class CompletionTestSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTests.scala
@@ -5,6 +5,7 @@ import org.scalaide.core.completion.ScalaCompletions
 import org.scalaide.core.ui.CompilerSupport
 import org.scalaide.core.ui.TextEditTests
 import org.scalaide.util.ScalaWordFinder
+import org.scalaide.core.completion.CompletionProposal
 
 /**
  * This provides a test suite for the code completion functionality.
@@ -34,12 +35,16 @@ abstract class CompletionTests extends TextEditTests with CompilerSupport {
    * @param expectedNumberOfCompletions
    *        The number of completions that are expected to be found. A negative
    *        value means that this option is not considered by the test.
+   * @param respectOrderOfExpectedCompletions
+   *        If `true` then expected completions will be additionally checked to match
+   *        proposal order
    */
   case class Completion(
       completionToApply: String,
       enableOverwrite: Boolean = false,
       expectedCompletions: Seq[String] = Nil,
-      expectedNumberOfCompletions: Int = -1)
+      expectedNumberOfCompletions: Int = -1,
+      respectOrderOfExpectedCompletions: Boolean = false)
         extends Operation {
 
     override def execute() = {
@@ -54,23 +59,40 @@ abstract class CompletionTests extends TextEditTests with CompilerSupport {
         compiler.askLoadedTyped(src, false).get
       }
 
-      val completions = new ScalaCompletions().findCompletions(ScalaWordFinder.findWord(doc, caretOffset), caretOffset, unit)
+      val completions = new ScalaCompletions()
+        .findCompletions(ScalaWordFinder.findWord(doc, caretOffset), caretOffset, unit)
+        .sorted(CompletionProposalOrdering).to[IndexedSeq]
 
-      def findCompletion(rawCompletion: String) =
+      def completionList = completions.map(_.display).mkString("\n")
+
+      def indexOfCompletion(rawCompletion: String) =
         if (!rawCompletion.contains("-"))
-          completions.find(_.display == rawCompletion)
+          completions.indexWhere(_.display == rawCompletion)
         else {
           val Array(completion, qualifier) = rawCompletion.split(" *- *")
-          completions.find(c => c.display == completion && c.displayDetail == qualifier)
+          completions.indexWhere(c => c.display == completion && c.displayDetail == qualifier)
+        }
+
+      def findCompletion(rawCompletion: String): Option[CompletionProposal] =
+        indexOfCompletion(rawCompletion) match {
+          case -1 => None
+          case index => Some(completions.apply(index))
         }
 
       val completion = findCompletion(completionToApply)
 
       val missingCompletions = expectedCompletions.filter(c => findCompletion(c).isEmpty)
       if (missingCompletions.nonEmpty)
-        throw new ComparisonFailure("There are expected completions that do not exist.", missingCompletions.mkString("\n"), "")
+        throw new ComparisonFailure("There are expected completions that do not exist.", missingCompletions.mkString("\n"), completionList)
 
-      def completionList = completions.sortBy(-_.relevance).map(_.display).mkString("\n")
+      if (expectedCompletions.nonEmpty && respectOrderOfExpectedCompletions) {
+        val indexes = expectedCompletions.map(c => indexOfCompletion(c))
+        val sorted = indexes.zip(indexes.tail).forall(i => i._2 - i._1 == 1)
+        if (!sorted)
+          throw new ComparisonFailure(s"The order of completition is wrong", expectedCompletions.mkString("\n"), completionList)
+        if (indexes.head != 0)
+          throw new ComparisonFailure(s"The completition list should start from", expectedCompletions.head, completionList)
+      }
 
       if (expectedNumberOfCompletions >= 0
           && completions.size != expectedNumberOfCompletions) {
@@ -105,4 +127,18 @@ abstract class CompletionTests extends TextEditTests with CompilerSupport {
       unit.scalaProject.presentationCompiler(_.discardCompilationUnit(unit))
     }
   }
+}
+
+/**
+ * This provides a default ordering for completion proposal. The implementation is
+ * based on CompletionProposalComparator that is used in JDT to sort completions
+ */
+private object CompletionProposalOrdering extends Ordering[CompletionProposal] {
+
+  def compare(a: CompletionProposal, b: CompletionProposal) =
+    b.relevance - a.relevance match {
+      case 0 => a.display.compareToIgnoreCase(b.display)
+      case diff => diff
+    }
+
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -410,6 +410,7 @@ class ScalaPresentationCompiler(name: String, _settings: Settings) extends {
     // rudimentary relevance, place own members before inherited ones, and before view-provided ones
     var relevance = 100
     if (!sym.isLocalToBlock) relevance -= 10 // non-local symbols are less relevant than local ones
+    if (!sym.hasGetter) relevance -= 5 // fields are more relevant than non-fields
     if (inherited) relevance -= 10
     if (viaView != NoSymbol) relevance -= 20
     if (sym.hasPackageFlag) relevance -= 30
@@ -420,6 +421,14 @@ class ScalaPresentationCompiler(name: String, _settings: Settings) extends {
       || sym.owner == definitions.ObjectClass) {
       relevance -= 40
     }
+
+    // global symbols are less relevant than local symbols
+    sym.owner.enclosingPackage.fullName match {
+      case "java"  => relevance -= 15
+      case "scala" => relevance -= 10
+      case _ =>
+    }
+
     val casePenalty = if (name.substring(0, prefix.length) != prefix) 50 else 0
     relevance -= casePenalty
 


### PR DESCRIPTION
code completion: reduce relevance for non class fields and for java._, scala._ packages
- Added CompletionOrderTests in CompletionTestSuite for testing completion proposals order
- Added two test related to #1002343
- Fixed relevance algorithm

With this changes order should be:
- Locals
- Fields
- Orders from old algorithm, but symbols from java package take -15 penalty and from scala package take -10 penalty

I decide to penalize java and scala package because it`s symbols (also fields and methods) are less`local` then symbols
from client code.

Fixes #1002343
