### PR TITLE
Revert "Treat files as external dependencies."

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -52,7 +52,7 @@ class SbtInputs(installation: IScalaInstallation,
 
   def analysisMap(f: File): Maybe[Analysis] =
     if (f.isFile)
-      Maybe.nothing[Analysis]()
+      Maybe.just(Analysis.Empty)
     else
       allProjects.find(_.sourceOutputFolders.map(_._2.getLocation().toFile()).toSeq contains f) map (_.buildManager) match {
         case Some(sbtManager: EclipseSbtBuildManager) => Maybe.just(sbtManager.latestAnalysis(incOptions))


### PR DESCRIPTION
Reverts scala-ide/scala-ide#862

Unfortunately this causes infinite build loops with Auto build. I see the following in the log:

```
EclipseSbtBuildManager - Invalidating /Volumes/Thunderbolt_SSD/dragos/Applications/eclipse-luna/plugins/org.scala-lang.scala-library_2.11.5.v20141126-232057-3ac6eabae6.jar: could not find class scala.Int on the classpath.
EclipseSbtBuildManager - Invalidating /Library/Java/JavaVirtualMachines/1.6.0_32-b05-417.jdk/Contents/Classes/classes.jar: could not find class java.lang.Object on the classpath.
```
