### PR TITLE
Add strip margins in string interpolation 

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/MultiLineStringAutoIndentStrategyTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/MultiLineStringAutoIndentStrategyTest.scala
@@ -299,4 +299,84 @@ class MultiLineStringAutoIndentStrategyTest extends AutoEditStrategyTests {
     |  def f = 0
     |}
     |""".mls after newline
+
+  @Test
+  def add_strip_margin_in_string_interpolation() = """
+    |class X {
+    |  val x = 0
+    |  val str = s```|^test $x test```
+    |}
+    |""".mls becomes """
+    |class X {
+    |  val x = 0
+    |  val str = s```|
+    |                |^test $x test```.stripMargin
+    |}
+    |""".mls after (newline, marker = '#')
+
+  @Test
+  def add_strip_margin_in_string_interpolation_with_braces() = """
+    |class X {
+    |  val x = 0
+    |  val str = s```|^test ${x*2} test```
+    |}
+    |""".mls becomes """
+    |class X {
+    |  val x = 0
+    |  val str = s```|
+    |                |^test ${x*2} test```.stripMargin
+    |}
+    |""".mls after (newline, marker = '#')
+
+  @Test
+  def add_strip_margin_in_string_interpolation_with_multiple_lines() = """
+    |class X {
+    |  val x = 0
+    |  val str = s```|test
+    |                |^test $x test```.stripMargin
+    |}
+    |""".mls becomes """
+    |class X {
+    |  val x = 0
+    |  val str = s```|test
+    |                |
+    |                |^test $x test```.stripMargin
+    |}
+    |""".mls after (newline, marker = '#')
+
+  @Test
+  def add_strip_margin_in_string_interpolation_with_multiple_insertions_and_cursor_on_first_line() = """
+    |class X {
+    |  val x = 0
+    |  val str = s```|test $x ^test
+    |                |test $x test
+    |                |$x```.stripMargin
+    |}
+    |""".mls becomes """
+    |class X {
+    |  val x = 0
+    |  val str = s```|test $x #
+    |                |^test
+    |                |test $x test
+    |                |$x```.stripMargin
+    |}
+    |""".mls after (newline, marker = '#')
+
+  @Test
+  def add_strip_margin_in_string_interpolation_with_multiple_insertions() = """
+    |class X {
+    |  val x = 0
+    |  val str = s```|test $x
+    |                |test $x ^test
+    |                |$x```.stripMargin
+    |}
+    |""".mls becomes """
+    |class X {
+    |  val x = 0
+    |  val str = s```|test $x
+    |                |test $x #
+    |                |^test
+    |                |$x```.stripMargin
+    |}
+    |""".mls after (newline, marker = '#')
 }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/TextEditTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/TextEditTests.scala
@@ -61,7 +61,7 @@ abstract class TextEditTests {
     def becomes(expectedOutput: String) = input -> expectedOutput
   }
   final implicit class TestExecutor(testData: (String, String)) {
-    def after(operation: Operation) = test(testData._1, testData._2, operation)
+    def after(operation: Operation, marker: Char = '$') = test(testData._1, testData._2, operation, marker)
   }
 
   /**
@@ -75,21 +75,21 @@ abstract class TextEditTests {
    * before the caret in the input string.
    *
    * Sometimes it can happen that the input or output must contain trailing
-   * white spaces. If this is the case then a $ sign must be set to the position
-   * after the expected number of white spaces.
+   * white spaces. If this is the case then the sign passed to `marker` must be
+   * set to the position after the expected number of white spaces.
    */
-  final def test(input: String, expectedOutput: String, operation: Operation): Unit = {
+  final def test(input: String, expectedOutput: String, operation: Operation, marker: Char = '$'): Unit = {
     require(input.count(_ == '^') == 1, "the cursor in the input isn't set correctly")
     require(expectedOutput.count(_ == '^') == 1, "the cursor in the expected output isn't set correctly")
 
-    val inputWithoutDollarSigns = input.filterNot(_ == '$')
+    val inputWithoutDollarSigns = input.filterNot(_ == marker)
     val caretOffset = inputWithoutDollarSigns.indexOf('^')
     val inputWithoutCursor = inputWithoutDollarSigns.filterNot(_ == '^')
 
     operation.caretOffset = caretOffset
     runTest(inputWithoutCursor, operation)
 
-    val expected = expectedOutput.replaceAll("\\$", "")
+    val expected = expectedOutput.filterNot(_ == marker)
     val actual = new StringBuilder(source).insert(operation.caretOffset, "^").toString()
 
     if (expected != actual) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/autoedits/MultiLineStringAutoIndentStrategy.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/autoedits/MultiLineStringAutoIndentStrategy.scala
@@ -14,45 +14,105 @@ class MultiLineStringAutoIndentStrategy(partitioning: String, prefStore: IPrefer
     val isStripMarginEnabled = prefStore.getBoolean(
       EditorPreferencePage.P_ENABLE_AUTO_STRIP_MARGIN_IN_MULTI_LINE_STRING)
 
+    /** Finds the partition at `offset`. */
+    def partitionAt(offset: Int, preferOpenPartitions: Boolean) =
+      TextUtilities.getPartition(doc, partitioning, offset, preferOpenPartitions)
+
+    /**
+     * Finds the end of the string literal which is at `offset`. This function
+     * is necessary because in case of a string interpolation we have to
+     * traverse multiple partitions in order to get the end position.
+     */
+    def stringInterpolationEnd(offset: Int): Int =
+      if (offset >= doc.getLength)
+        doc.getLength
+      else {
+        val p = partitionAt(offset, preferOpenPartitions = false)
+        val end = p.getOffset+p.getLength
+        if (doc.get(end-3, 3) == "\"\"\"")
+          end
+        else
+          stringInterpolationEnd(end)
+      }
+
+    /**
+     * Finds the start of the string literal which is at `offset`. This function
+     * is necessary because in case of a string interpolation we have to
+     * traverse multiple partitions in order to get the start position.
+     */
+    def stringInterpolationStart(offset: Int): Int =
+      if (offset <= 0)
+        0
+      else {
+        val p = partitionAt(offset, preferOpenPartitions = false)
+        if (p.getLength >= 3 && doc.get(p.getOffset, 3) == "\"\"\"")
+          p.getOffset
+        else
+          stringInterpolationStart(p.getOffset-1)
+      }
+
     def autoIndentAfterNewLine() = {
-      val partition = TextUtilities.getPartition(doc, partitioning, cmd.offset, true)
-      val partitionEnd = partition.getOffset() + partition.getLength()
+      def isTripleQuotes(offset: Int, len: Int) =
+        len >= 3 && doc.get(offset, 3) == "\"\"\""
 
-      val line = doc.getLineOfOffset(cmd.offset)
-      val isFirstLine = line == doc.getLineOfOffset(partition.getOffset())
+      val lineOfCursor = doc.getLineOfOffset(cmd.offset)
+      val (start, end, isFirstLine) = {
+        val p = partitionAt(cmd.offset, preferOpenPartitions = true)
+        val pEnd = p.getOffset+p.getLength
+        val start = stringInterpolationStart(p.getOffset)
 
-      def containsStripMargin = {
+        val isFirstLine =
+          if (isTripleQuotes(p.getOffset, p.getLength))
+            lineOfCursor == doc.getLineOfOffset(p.getOffset())
+          else
+            lineOfCursor == doc.getLineOfOffset(start)
+
+        val end =
+          if (doc.getChar(pEnd-1) == '$')
+            stringInterpolationEnd(pEnd)
+          else
+            pEnd
+
+        (start, end, isFirstLine)
+      }
+
+      def containsStripMargin(offset: Int) = {
         val len = ".stripMargin".length()
-        if (partitionEnd + len >= doc.getLength()) false
-        else doc.get(partitionEnd, len) matches "[ .]stripMargin"
+        if (offset + len >= doc.getLength()) false
+        else doc.get(offset, len) matches "[ .]stripMargin"
       }
 
       def copyIndentOfPreviousLine(additionalIndent: String) = {
-        val indent = indentOfLine(doc, line)
+        val indent = indentOfLine(doc, lineOfCursor)
         cmd.text = s"${cmd.text}$indent$additionalIndent"
       }
 
       def handleFirstLine() = {
         def containsFirstLineStripMargin =
-          doc.getChar(partition.getOffset() + 3) == '|'
+          doc.getChar(start + 3) == '|'
 
         def handleFirstStripMarginLine() = {
           val r = doc.getLineInformationOfOffset(cmd.offset)
-          val lineIndent = indentOfLine(doc, line)
-          val indentCountToBar = partition.getOffset() - r.getOffset() - lineIndent.length + 3
+          val lineIndent = indentOfLine(doc, lineOfCursor)
+
+          val indentCountToBar =
+            if (isTripleQuotes(start, end-start))
+              start - r.getOffset() - lineIndent.length + 3
+            else
+              0
 
           val innerIndent = {
-            val barOffset = partition.getOffset() + 4
+            val barOffset = start + 4
             val wsEnd = findEndOfWhiteSpace(doc, barOffset, r.getOffset() + r.getLength())
             doc.get(barOffset, wsEnd - barOffset)
           }
 
           val indent = s"${cmd.text}$lineIndent${" " * indentCountToBar}|$innerIndent"
-          val isMultiLineStringClosed = partition.getOffset() + partition.getLength() != doc.getLength()
+          val isMultiLineStringClosed = end != doc.getLength()
 
           if (isMultiLineStringClosed) {
-            if (!containsStripMargin)
-              cmd.addCommand(partitionEnd, 0, ".stripMargin", null)
+            if (!containsStripMargin(end))
+              cmd.addCommand(end, 0, ".stripMargin", null)
             cmd.caretOffset = cmd.offset + indent.length()
             cmd.shiftsCaret = false
           }
@@ -69,7 +129,13 @@ class MultiLineStringAutoIndentStrategy(partitioning: String, prefStore: IPrefer
       def handleStripMarginLine() = {
         val r = doc.getLineInformationOfOffset(cmd.offset)
         val (lineIndent, rest, _) = breakLine(doc, cmd.offset)
-        val indentCountToBar = partition.getOffset() - r.getOffset() - lineIndent.length + 3
+
+        val indentCountToBar =
+          if (isTripleQuotes(start, end-start))
+            start - r.getOffset() - lineIndent.length + 3
+          else
+            0
+
         val innerIndent =
           if (!rest.startsWith("|"))
             ""
@@ -85,7 +151,7 @@ class MultiLineStringAutoIndentStrategy(partitioning: String, prefStore: IPrefer
 
       if (isFirstLine)
         handleFirstLine
-      else if (isStripMarginEnabled && containsStripMargin)
+      else if (isStripMarginEnabled && containsStripMargin(end))
         handleStripMarginLine
       else
         copyIndentOfPreviousLine("")


### PR DESCRIPTION
This did not work because the start and end position of the partition
where the cursor is placed was used. This is a problem because string
interpolators are split up into multiple partitions - therefore we have
to traverse the partitions until we found the start and end of the multi
line string literal.

Note that this behavior is still buggy in case someone inserts a multi
line string literal inside of a code block that is already part of a
string interpolation:

    s"""${
      val s = """str"""
      s
    }"""

Fortunately, such code blocks aren't used often, therefore I consider
this as a won't fix until someone opens a ticket..

Fixes #1002145