### PR TITLE
New File Wizard works with projects whose source dir is the root dir

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/NewFileWizard.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/wizards/NewFileWizard.scala
@@ -1,7 +1,7 @@
 package org.scalaide.ui.internal.wizards
 
+import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
-import org.eclipse.core.resources.IFolder
 import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.jface.text.Document
@@ -26,21 +26,19 @@ import org.eclipse.swt.widgets.TableItem
 import org.eclipse.swt.widgets.Text
 import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.ide.IDE
-import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard
 import org.scalaide.core.internal.ScalaPlugin
 import org.scalaide.logging.HasLogger
-import org.scalaide.ui.ScalaImages
 import org.scalaide.ui.internal.templates.ScalaTemplateContext
 import org.scalaide.ui.internal.templates.ScalaTemplateManager
 import org.scalaide.ui.wizards.Invalid
 import org.scalaide.ui.wizards.Valid
 import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.eclipse.FileUtils
+import org.scalaide.util.eclipse.OSGiUtils
 import org.scalaide.util.internal.eclipse.ProjectUtils
 import org.scalaide.util.internal.ui.AutoCompletionOverlay
 import org.scalaide.util.internal.ui.Dialogs
-import org.scalaide.util.eclipse.OSGiUtils
 
 /**
  * Wizard of the Scala IDE to create new files. It can not only create new
@@ -55,7 +53,7 @@ trait NewFileWizard extends AnyRef with HasLogger {
   private var disposables = Seq[{def dispose(): Unit}]()
   /** See [[pathOfCreatedFile]] for the purpose of this variable. */
   private var file: IFile = _
-  private var selectedFolder: IFolder = _
+  private var selectedFolder: IContainer = _
   private val fileCreatorMappings = FileCreatorMapping.mappings
   /** Code completion component for the text field. */
   private var completionOverlay: AutoCompletionOverlay = _
@@ -182,7 +180,10 @@ trait NewFileWizard extends AnyRef with HasLogger {
           else
             srcDirs.head
 
-        setFolderName(root.getFolder(srcDir))
+        if (srcDir != r.getProject.getFullPath)
+          setFolderName(root.getFolder(srcDir))
+        else
+          setFolderName(r.getProject)
       }
 
       val str = if (defaultTypeName.isEmpty) path else path + defaultTypeName
@@ -291,7 +292,7 @@ trait NewFileWizard extends AnyRef with HasLogger {
   }
 
   /** Stores `folder` and shows it in the wizard. */
-  private def setFolderName(folder: IFolder): Unit = {
+  private def setFolderName(folder: IContainer): Unit = {
     selectedFolder = folder
     btProject.setText(selectedFolder.getFullPath().makeRelative().toString())
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/EmptyFileCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/EmptyFileCreator.scala
@@ -1,19 +1,20 @@
 package org.scalaide.ui.wizards
 
+import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
-import org.eclipse.core.resources.IFolder
 import org.eclipse.core.resources.IResource
+import org.eclipse.core.runtime.Path
 
 /**
  * File creator that can only create empty files.
  */
 class EmptyFileCreator extends FileCreator {
 
-  override def create(folder: IFolder, name: String): IFile =
-    folder.getFile(name)
+  override def create(folder: IContainer, name: String): IFile =
+    folder.getFile(new Path(name))
 
-  override def validateName(folder: IFolder, name: String): Validation =
-    if (folder.getFile(name).exists())
+  override def validateName(folder: IContainer, name: String): Validation =
+    if (folder.getFile(new Path(name)).exists())
       Invalid("File already exists")
     else
       Valid
@@ -21,10 +22,10 @@ class EmptyFileCreator extends FileCreator {
   override def initialPath(res: IResource): String =
     ""
 
-  override def completionEntries(folder: IFolder, name: String): Seq[String] =
+  override def completionEntries(folder: IContainer, name: String): Seq[String] =
     Seq()
 
-  override def templateVariables(folder: IFolder, name: String): Map[String, String] =
+  override def templateVariables(folder: IContainer, name: String): Map[String, String] =
     Map()
 
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/FileCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/FileCreator.scala
@@ -1,5 +1,6 @@
 package org.scalaide.ui.wizards
 
+import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IFolder
 import org.eclipse.core.resources.IResource
@@ -26,15 +27,19 @@ case class Invalid(errorMsg: String) extends Validation {
 trait FileCreator {
 
   /**
-   * Returns all the varibles that need to be filled into the associated
-   * template. The Map contains the name of the varibles that are associated
+   * Returns all the variables that need to be filled into the associated
+   * template. The Map contains the name of the variables that are associated
    * with their actual values.
    *
    * This method is called when a new file needs to be created and therefore the
    * template needs to be filled with the variables. Hence, `folder` is the
    * selected folder and `name` the file name that are filled in the wizard.
    */
-  def templateVariables(folder: IFolder, name: String): Map[String, String]
+  def templateVariables(folder: IContainer, name: String): Map[String, String]
+
+  @deprecated("Use the overloaded variant instead", "4.0")
+  final def templateVariables(folder: IFolder, name: String): Map[String, String] =
+    templateVariables(folder: IContainer, name)
 
   /**
    * Finds out if the file name that is inserted into the wizard is valid and
@@ -52,7 +57,11 @@ trait FileCreator {
    * because their implementations don't have to validate them and therefore can
    * crash in unexpected ways.
    */
-  def validateName(folder: IFolder, name: String): Validation
+  def validateName(folder: IContainer, name: String): Validation
+
+  @deprecated("Use the overloaded variant instead", "4.0")
+  final def validateName(folder: IFolder, name: String): Validation =
+    validateName(folder: IContainer, name)
 
   /**
    * Creates the path that points to the location where the wizard should create
@@ -65,7 +74,11 @@ trait FileCreator {
    * This method is guaranteed to be called not before [[validateName]] returns
    * a valid state.
    */
-  def create(folder: IFolder, name: String): IFile
+  def create(folder: IContainer, name: String): IFile
+
+  @deprecated("Use the overloaded variant instead", "4.0")
+  final def create(folder: IFolder, name: String): IFile =
+    create(folder: IContainer, name)
 
   /**
    * Creates a path that is shown when a new file wizard is created. This should
@@ -82,7 +95,11 @@ trait FileCreator {
    * typed, therefore it needs to contain all the information an user expects to
    * see.
    */
-  def completionEntries(folder: IFolder, name: String): Seq[String]
+  def completionEntries(folder: IContainer, name: String): Seq[String]
+
+  @deprecated("Use the overloaded variant instead", "4.0")
+  final def completionEntries(folder: IFolder, name: String): Seq[String] =
+    completionEntries(folder: IContainer, name)
 
   /**
    * When the new file wizard is created this controls if in case of an invalid

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/ScalaFileCreators.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/wizards/ScalaFileCreators.scala
@@ -1,10 +1,10 @@
 package org.scalaide.ui.wizards
 
-import org.eclipse.core.resources.IFolder
-import org.eclipse.core.resources.ResourcesPlugin
-import org.eclipse.core.runtime.IPath
-import org.scalaide.util.internal.Commons
+import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.IPath
+import org.eclipse.core.runtime.Path
+import org.scalaide.util.internal.Commons
 
 class ClassCreator extends ScalaFileCreator
 
@@ -36,7 +36,7 @@ class PackageObjectCreator extends ScalaFileCreator {
       case Some(e) => Left(Invalid(e))
       case _       => Right { f =>
         val fileName = fullyQualifiedType.replace('.', '/') + "/package.scala"
-        if (f.getFile(fileName).exists())
+        if (f.getFile(new Path(fileName)).exists())
           Invalid("File already exists")
         else
           Valid
@@ -44,9 +44,9 @@ class PackageObjectCreator extends ScalaFileCreator {
     }
   }
 
-  override def create(folder: IFolder, name: String): IFile = {
+  override def create(folder: IContainer, name: String): IFile = {
     val filePath = name.replace('.', '/')
-    folder.getFile(s"$filePath/package.scala")
+    folder.getFile(new Path(s"$filePath/package.scala"))
   }
 }
 


### PR DESCRIPTION
It is not possible to create an instance of `IFolder` from a project path.
However, this behavior is required to create a file in a source dir that
is the same as a project dir. Therefore we switched from `IFolder` to
`IContainer` in the traits `NewFileWizard` and `FileCreator`.

Fixes #1002332

---

Follow-up of #850 and #858
