### PR TITLE
Fix double-newline bug in Scala templates

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -49,7 +49,7 @@ import org.scalaide.util.internal.eclipse.TextSelectionTest
 import org.scalaide.util.eclipse.RegionUtilsTest
 import org.scalaide.core.pc.DeclarationPrinterTest
 import org.scalaide.core.compiler.NamePrinterTest
-import org.scalaide.core.ui.TestScalaTemplateContext
+import org.scalaide.core.ui.ScalaTemplateContextTest
 
 @RunWith(classOf[Suite])
 @Suite.SuiteClasses(
@@ -103,6 +103,6 @@ import org.scalaide.core.ui.TestScalaTemplateContext
     classOf[RegionUtilsTest],
     classOf[DeclarationPrinterTest],
     classOf[NamePrinterTest],
-    classOf[TestScalaTemplateContext]
+    classOf[ScalaTemplateContextTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -49,6 +49,7 @@ import org.scalaide.util.internal.eclipse.TextSelectionTest
 import org.scalaide.util.eclipse.RegionUtilsTest
 import org.scalaide.core.pc.DeclarationPrinterTest
 import org.scalaide.core.compiler.NamePrinterTest
+import org.scalaide.core.ui.TestScalaTemplateContext
 
 @RunWith(classOf[Suite])
 @Suite.SuiteClasses(
@@ -101,6 +102,7 @@ import org.scalaide.core.compiler.NamePrinterTest
     classOf[TextSelectionTest],
     classOf[RegionUtilsTest],
     classOf[DeclarationPrinterTest],
-    classOf[NamePrinterTest]
+    classOf[NamePrinterTest],
+    classOf[TestScalaTemplateContext]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/ScalaTemplateContextTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/ScalaTemplateContextTest.scala
@@ -13,7 +13,7 @@ import org.scalaide.core.SdtConstants
 import org.junit.Assert
 
 @RunWith(classOf[JUnit4ClassRunner])
-class TestScalaTemplateContext {
+class ScalaTemplateContextTest {
 
   val CARET = "_|_"
   

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/ScalaTemplateContextTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/ScalaTemplateContextTest.scala
@@ -16,25 +16,25 @@ import org.junit.Assert
 class ScalaTemplateContextTest {
 
   val CARET = "_|_"
-  
+
   def runTest( textSoFar: String, template : String, expectedResult : String ) : Unit = {
-    
+
     val document = new Document(textSoFar.replace(CARET, ""))
     val contextType = new ScalaTemplateContextType
     contextType.setId( SdtConstants.PluginId + ".templates" )
-    
+
     val context = new ScalaTemplateContext(contextType, document, textSoFar.indexOf(CARET), document.getLength)
-    
+
     val templateObject = new Template("Test Template", "", contextType.getId, template)
-    
+
     val buffer = context.evaluate(templateObject)
-    
+
     Assert.assertEquals( expectedResult, buffer.getString )
   }
-  
+
   @Test
   def basicTest() {
-    val textSoFar = 
+    val textSoFar =
       "class TestOuterClass { \n" +
       "  " + CARET + "\n" +
       "}"
@@ -42,10 +42,10 @@ class ScalaTemplateContextTest {
     val expectedResult = template
     runTest( textSoFar, template, expectedResult )
   }
-  
+
   @Test
   def testMultilineTemplateWithLinuxLineEndings() {
-    val textSoFar = 
+    val textSoFar =
       "class TestOuterClass { \n" +
       "  " + CARET + "\n" +
       "}"
@@ -53,10 +53,10 @@ class ScalaTemplateContextTest {
     val expectedResult = "/**\n   *\n   *\n   */"
     runTest( textSoFar, template, expectedResult )
   }
-  
+
   @Test
   def testMultilineTemplateWithCarriageReturnLineEndings() {
-    val textSoFar = 
+    val textSoFar =
       "class TestOuterClass { \n" +
       "  " + CARET + "\n" +
       "}"
@@ -64,10 +64,10 @@ class ScalaTemplateContextTest {
     val expectedResult = "/**\r   *\r   *\r   */"
     runTest( textSoFar, template, expectedResult )
   }
-  
+
   @Test
   def testMultilineTemplateWithWindowsLineEndings() {
-    val textSoFar = 
+    val textSoFar =
       "class TestOuterClass { \n" +
       "  " + CARET + "\n" +
       "}"

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/TestScalaTemplateContext.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/TestScalaTemplateContext.scala
@@ -1,0 +1,78 @@
+package org.scalaide.core.ui
+
+import org.junit.runner.RunWith
+import org.junit.internal.runners.JUnit4ClassRunner
+import org.eclipse.jface.text.Document
+import org.eclipse.jface.text.templates.TemplateContextType
+import org.scalaide.ui.internal.templates.ScalaTemplateCompletionProcessor
+import org.scalaide.ui.internal.templates.ScalaTemplateContextType
+import org.scalaide.ui.internal.templates.ScalaTemplateContext
+import org.eclipse.jface.text.templates.Template
+import org.junit.Test
+import org.scalaide.core.SdtConstants
+import org.junit.Assert
+
+@RunWith(classOf[JUnit4ClassRunner])
+class TestScalaTemplateContext {
+
+  val CARET = "_|_"
+  
+  def runTest( textSoFar: String, template : String, expectedResult : String ) : Unit = {
+    
+    val document = new Document(textSoFar.replace(CARET, ""))
+    val contextType = new ScalaTemplateContextType
+    contextType.setId( SdtConstants.PluginId + ".templates" )
+    
+    val context = new ScalaTemplateContext(contextType, document, textSoFar.indexOf(CARET), document.getLength)
+    
+    val templateObject = new Template("Test Template", "", contextType.getId, template)
+    
+    val buffer = context.evaluate(templateObject)
+    
+    Assert.assertEquals( expectedResult, buffer.getString )
+  }
+  
+  @Test
+  def basicTest() {
+    val textSoFar = 
+      "class TestOuterClass { \n" +
+      "  " + CARET + "\n" +
+      "}"
+    val template = "case class Test()"
+    val expectedResult = template
+    runTest( textSoFar, template, expectedResult )
+  }
+  
+  @Test
+  def testMultilineTemplateWithLinuxLineEndings() {
+    val textSoFar = 
+      "class TestOuterClass { \n" +
+      "  " + CARET + "\n" +
+      "}"
+    val template = "/**\n *\n *\n */"
+    val expectedResult = "/**\n   *\n   *\n   */"
+    runTest( textSoFar, template, expectedResult )
+  }
+  
+  @Test
+  def testMultilineTemplateWithCarriageReturnLineEndings() {
+    val textSoFar = 
+      "class TestOuterClass { \n" +
+      "  " + CARET + "\n" +
+      "}"
+    val template = "/**\r *\r *\r */"
+    val expectedResult = "/**\r   *\r   *\r   */"
+    runTest( textSoFar, template, expectedResult )
+  }
+  
+  @Test
+  def testMultilineTemplateWithWindowsLineEndings() {
+    val textSoFar = 
+      "class TestOuterClass { \n" +
+      "  " + CARET + "\n" +
+      "}"
+    val template = "/**\r\n *\r\n *\r\n */"
+    val expectedResult = "/**\r\n   *\r\n   *\r\n   */"
+    runTest( textSoFar, template, expectedResult )
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/templates/ScalaTemplateContext.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/templates/ScalaTemplateContext.scala
@@ -23,14 +23,15 @@ class ScalaTemplateContext(contextType: TemplateContextType, document: IDocument
     val text = buffer.getString()
     val legalLineEnds = document.getLegalLineDelimiters()
 
-    val (breakOffsets, lineEnds) = (for (m <- legalLineEnds.mkString("|").r.findAllMatchIn(text).toList) yield {
+    val regexStr = legalLineEnds.sortBy( s => -s.length ).mkString("|")
+    val (breakOffsets, lineEnds) = (for (m <- regexStr.r.findAllMatchIn(text).toList) yield {
       (m.start, m.matched)
     }) unzip
 
     val actualLineEnd = lineEnds.headOption.getOrElse(document.getLineDelimiter(document.getLineOfOffset(offset)))
 
     // the template might use any legal line ending
-    val result = text.split(legalLineEnds.mkString("|")).mkString(actualLineEnd + indentation)
+    val result = text.split(regexStr).mkString(actualLineEnd + indentation)
 
     def newOffset(x: Int): Int = {
       x + breakOffsets.takeWhile(x >).size * indentation.length


### PR DESCRIPTION
This should fix ticket #1002303. I've also added some basic tests for the ScalaTemplateContext class since it didn't have any before.