### PR TITLE
Do not pass DocDef with underlying ClassDef to Namers.standardEnterSym

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScaladocGlobalCompatibilityTrait.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScaladocGlobalCompatibilityTrait.scala
@@ -7,6 +7,18 @@ import scala.tools.nsc.symtab.BrowsingLoaders
 
 trait InteractiveScaladocAnalyzer extends interactive.InteractiveAnalyzer with ScaladocAnalyzer {
     val global : Global
+    import global._
+
+    /** Overridden to fix #1002367. */
+    override def newNamer(context: Context) = new Namer(context) with InteractiveNamer {
+      override def standardEnterSym(t: Tree): Context = t match {
+        case DocDef(_, defn) =>
+          super.standardEnterSym(defn)
+        case t =>
+          super.standardEnterSym(t)
+      }
+    }
+
     override def newTyper(context: Context) = new Typer(context) with InteractiveTyper with ScaladocTyper {
       override def canAdaptConstantTypeToLiteral = false
     }


### PR DESCRIPTION
`standardEnterSym` internally uses the following code:

    tree.symbol match {
      case NoSymbol => try dispatch() catch typeErrorHandler(tree, this.context)
      case sym      => enterExistingSym(sym, tree)
    }

where tree is a `DocDef` with an underlying `ClassDef`. Because `symbol`
on `DocDef` is forwarded to the underlying tree, we would pass a symbol
that doesn't match its original tree to `enterExistingSym`, which later
would result in an `ClassCastException`.

Fixes #1002367

---
I'm not sure if this is the right location to fix this bug. Should it be done in `Namers.standardEnterSym` directly?

Review by @huitseeker would be nice.