### PR TITLE
Bump version to new Scala 2.11.6 development version, including xml and

### DIFF
--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
@@ -43,7 +43,7 @@ Require-Bundle:
  org.scala-lang.scala-reflect;bundle-version="[2.11,2.12)",
  org.scala-lang.scala-compiler;bundle-version="[2.11,2.12)",
  org.scala-refactoring.library,
- org.scala-lang.modules.scala-xml;bundle-version="[1.0.2,1.0.2]",
+ org.scala-lang.modules.scala-xml;bundle-version="[1.0.2,1.0.10]",
  org.scala-ide.sbt.full.library;bundle-version="[0.13,0.14)",
  org.scala-ide.sbt.compiler.interface;bundle-version="[0.13,0.14)",
  org.scala-ide.scala210.jars,

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
@@ -43,7 +43,7 @@ Require-Bundle:
  org.scala-lang.scala-reflect;bundle-version="[2.12,2.13)",
  org.scala-lang.scala-compiler;bundle-version="[2.12,2.13)",
  org.scala-refactoring.library,
- org.scala-lang.modules.scala-xml;bundle-version="[1.0.2,1.0.2]",
+ org.scala-lang.modules.scala-xml;bundle-version="[1.0.2,1.0.10]",
  org.scala-ide.sbt.full.library;bundle-version="[0.13,0.14)",
  org.scala-ide.sbt.compiler.interface;bundle-version="[0.13,0.14)",
  scalariform,

--- a/pom.xml
+++ b/pom.xml
@@ -62,16 +62,16 @@
     <!-- Scala 2.10.x -->
     <scala210.version>2.10.5-SNAPSHOT</scala210.version>
     <!-- Scala 2.11.x -->
-    <scala211.version>2.11.5-SNAPSHOT</scala211.version>
+    <scala211.version>2.11.6-SNAPSHOT</scala211.version>
     <scala211.binary.version>2.11</scala211.binary.version>
-    <scala211.scala-xml.version>1.0.2</scala211.scala-xml.version>
-    <scala211.scala-parser-combinators.version>1.0.1</scala211.scala-parser-combinators.version>
+    <scala211.scala-xml.version>1.0.3</scala211.scala-xml.version>
+    <scala211.scala-parser-combinators.version>1.0.3</scala211.scala-parser-combinators.version>
     <scala211.scala-swing.version>1.0.1</scala211.scala-swing.version>
     <!-- Scala 2.12.x -->
     <scala212.version>2.12.0-SNAPSHOT</scala212.version>
     <scala212.binary.version>2.11</scala212.binary.version>
-    <scala212.scala-xml.version>1.0.2</scala212.scala-xml.version>
-    <scala212.scala-parser-combinators.version>1.0.1</scala212.scala-parser-combinators.version>
+    <scala212.scala-xml.version>1.0.3</scala212.scala-xml.version>
+    <scala212.scala-parser-combinators.version>1.0.3</scala212.scala-parser-combinators.version>
     <scala212.scala-swing.version>1.0.1</scala212.scala-swing.version>
 
     <!-- dependencies repos, can be overwritten by profiles -->


### PR DESCRIPTION
parser combinator dependencies.