### PR TITLE
Fix NPE in semantic highlighting job

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/InteractiveCompilationUnitEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/InteractiveCompilationUnitEditor.scala
@@ -3,5 +3,6 @@ package org.scalaide.ui.editor
 import org.scalaide.core.compiler.InteractiveCompilationUnit
 
 trait InteractiveCompilationUnitEditor extends DecoratedInteractiveEditor {
+  /** Returns `null` if the editor is closed. */
   def getInteractiveCompilationUnit(): InteractiveCompilationUnit
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/semantichighlighting/Presenter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/semantichighlighting/Presenter.scala
@@ -116,7 +116,7 @@ class Presenter(
     }
 
     private def performSemanticHighlighting(monitor: IProgressMonitor): IStatus = {
-      editor.getInteractiveCompilationUnit.withSourceFile { (sourceFile, compiler) =>
+      Option(editor.getInteractiveCompilationUnit).flatMap(_.withSourceFile { (sourceFile, compiler) =>
         logger.debug("performing semantic highlighting on " + sourceFile.file.name)
         positionsTracker.startComputingNewPositions()
         val symbolInfos =
@@ -143,7 +143,7 @@ class Presenter(
           } else Status.OK_STATUS
         }
         else Status.OK_STATUS
-      } getOrElse (Status.OK_STATUS)
+      }) getOrElse (Status.OK_STATUS)
     }
 
     private def runPositionsUpdateInUiThread(newPositions: Array[Position], damagedRegion: IRegion): Unit =


### PR DESCRIPTION
In case the editor is closed, no interactive compilation unit can be
retrieved and null is returned. This bug occurred while stepping through
multiple files in the debugger.

Fixes #1002386