### PR TITLE
Enable retry for a seemingly flaky test.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/ui/internal/editor/decorators/bynameparams/CallByNameParamAtCreationPresenterTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/ui/internal/editor/decorators/bynameparams/CallByNameParamAtCreationPresenterTest.scala
@@ -9,6 +9,7 @@ import org.scalaide.CompilerSupportTests
 import org.scalaide.core.semantichighlighting.classifier.RegionParser
 import org.scalaide.core.semantichighlighting.classifier.RegionParser.EmbeddedSubstr
 import CallByNameParamAtCreationPresenterTest.mkScalaCompilationUnit
+import org.scalaide.core.FlakyTest
 
 object CallByNameParamAtCreationPresenterTest extends CompilerSupportTests
 
@@ -164,7 +165,7 @@ class CallByNameParamAtCreationPresenterTest {
   }
 
   @Test
-  def testWithMultiplePartiallyAppliedFunctions() {
+  def testWithMultiplePartiallyAppliedFunctions() = FlakyTest.retry("testWithMultiplePartiallyAppliedFunctions", "") {
     testWithSingleLineCfg("""
       object X {
         def f(i1: Int)(i2: => Int)(i3: => Int) = i1 * i2 * i3


### PR DESCRIPTION
Failed a few times recently in Scala PR validation:

  https://github.com/scala/scala/pull/4354
  https://github.com/scala/scala/pull/4357