### PR TITLE
Add command extension to restart presentation compiler with shortcut

### DIFF
--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -1034,6 +1034,13 @@
       description="Debug Scala JUnit Test"
       id="org.eclipse.shortcut.scala.junit.debug"
       name="Debug Scala JUnit Test" />
+    <command
+          categoryId="scala.tools.eclipse.category"
+          defaultHandler="org.scalaide.ui.internal.actions.RestartPresentationCompilerAction"
+          description="Restarts the Presentation Compiler of the Scala project that belongs to the active selection"
+          id="org.scala-ide.sdt.core.restartScalaPresentationCompiler"
+          name="Restart Scala Presentation Compiler">
+    </command>
   </extension>
 
   <extension point="org.eclipse.ui.bindings">

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/AbstractPopupAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/AbstractPopupAction.scala
@@ -1,19 +1,37 @@
 package org.scalaide.ui.internal.actions
 
+import org.eclipse.core.commands.AbstractHandler
+import org.eclipse.core.commands.ExecutionEvent
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.IAdaptable
 import org.eclipse.jface.action.IAction
 import org.eclipse.jface.viewers.ISelection
 import org.eclipse.jface.viewers.IStructuredSelection
-import org.eclipse.core.runtime.Platform
 import org.eclipse.ui.IObjectActionDelegate
 import org.eclipse.ui.IWorkbenchPart
 import org.scalaide.util.eclipse.EclipseUtils.RichAdaptable
+import org.scalaide.util.eclipse.EditorUtils
 
-trait AbstractPopupAction extends IObjectActionDelegate {
+/**
+ * This traits contains definitions to handle the invocation of menu entries
+ * that are shown in the "Scala" context menu.
+ *
+ * Extends [[AbstractHandler]] to allow users to call this action by
+ * key bindings.
+ */
+trait AbstractPopupAction extends AbstractHandler with IObjectActionDelegate {
   private var selectionOption: Option[ISelection] = None
 
+  /**
+   * This method is called if either the menu entry is invoked or the handler
+   * (if it exists) is called when an [[IResource]] element is selected.
+   */
   def performAction(project: IProject)
+
+  override def execute(event: ExecutionEvent): AnyRef = {
+    EditorUtils.resourceOfActiveEditor flatMap (r ⇒ Option(r.getProject)) foreach performAction
+    null
+  }
 
   override def selectionChanged(action: IAction, selection: ISelection) { this.selectionOption = Option(selection) }
 


### PR DESCRIPTION
Once the user configures a shortcut for the restart operation, it is
possible to restart the PC of the project that belongs to the active
selection.

No default shortcut provided because it is difficult to find one that is
not already used.

Fixes #1002391