### PR TITLE
Handle single empty line in `RemoveDuplicatedEmptyLines` save action

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/saveactions/RemoveDuplicatedEmptyLinesTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/saveactions/RemoveDuplicatedEmptyLinesTest.scala
@@ -41,4 +41,9 @@ class RemoveDuplicatedEmptyLinesTest extends DocumentSaveActionTests {
     |  }
     |}
     |""".stripMargin after SaveEvent
+
+  @Test
+  def do_not_throw_exception_on_single_empty_line() = """|^
+    |class X""".stripMargin becomes """|^
+    |class X""".stripMargin after SaveEvent
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/saveactions/RemoveDuplicatedEmptyLines.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/saveactions/RemoveDuplicatedEmptyLines.scala
@@ -26,7 +26,7 @@ trait RemoveDuplicatedEmptyLines extends SaveAction with DocumentSupport {
       case (r, _) => r.trimRight(document).length == 0
     }
 
-    val removedLines = emptyLines.sliding(2) flatMap {
+    def removedLines = emptyLines.sliding(2) flatMap {
       case Seq((l1, i1), (l2, i2)) =>
         if (i1+1 == i2)
           Seq(Remove(l1.start, l1.end+1))
@@ -34,6 +34,9 @@ trait RemoveDuplicatedEmptyLines extends SaveAction with DocumentSupport {
           Seq()
     }
 
-    removedLines.toList
+    if (emptyLines.lengthCompare(1) == 0)
+      Nil
+    else
+      removedLines.toList
   }
 }


### PR DESCRIPTION
Seq.sliding(n) returns a seq whose length can be smaller than n if less
than n elements exist.

Fixes #1002400