### PR TITLE
Don't leak `ScalaSourceFileEditors`

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
@@ -214,7 +214,6 @@ class ScalaSourceViewerConfiguration(
 
       val reconciler = new ScalaReconciler(editor, s, isIncremental = false)
       reconciler.setDelay(500)
-      reconciler.install(sourceViewer)
       reconciler.setProgressMonitor(new NullProgressMonitor())
       reconciler
     }.orNull


### PR DESCRIPTION
Calling "install" twice and "uninstall" only once on the reconciler causes listeners not being
removed properly and thereby leaking `ScalaSourceFileEditors`.

See [#1002293](https://www.assembla.com/spaces/scala-ide/tickets/1002293-potential-memory-leaks#/activity/ticket:) for additional information.