### PR TITLE
Fix warnings

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/DeclarationPrinter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/DeclarationPrinter.scala
@@ -164,7 +164,6 @@ abstract class DeclarationPrinter extends HasLogger {
   }
 
   def showFunction(tpe: TypeRef): String = {
-    import tpe._
     import definitions._
 
     val noArgsString = s"${showSymbolName(tpe.sym)}"

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/CompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/CompletionProposal.scala
@@ -20,7 +20,6 @@ object CompletionContext {
   case object InfixMethodContext extends ContextType
 }
 
-
 /** A completion proposal coming from the Scala compiler. This
  *  class holds together data about completion proposals.
  *
@@ -125,7 +124,7 @@ case class CompletionProposal(
   private case object SimpleFunctionType {
     def unapply(fun: String): Option[(String, String)] = {
       fun.split("=>") match {
-        case Array(a, b) if !a.isEmpty => Some(a.trim, b.trim)
+        case Array(a, b) if !a.isEmpty => Some((a.trim, b.trim))
         case _                         => None
       }
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/extensions/SourceFileProviderRegistry.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/extensions/SourceFileProviderRegistry.scala
@@ -29,8 +29,6 @@ object SourceFileProviderRegistry extends HasLogger {
     record.map(_._2).getOrElse(null)
   }
 
-  private def getProvider(extension: String): SourceFileProvider = registry get extension
-
   private def registerProviders() {
     val extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(EXTENSION_POINT)
     if (extensionPoint != null) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -65,7 +65,7 @@ class SbtInputs(installation: IScalaInstallation,
     sbt.inc.IncOptions.Default.
       withApiDebug(apiDebug = project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.apiDiff.name))).
       withRelationsDebug(project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.relationsDebug.name))).
-      withNewClassfileManager(ClassfileManager.transactional(tempDir)).
+      withNewClassfileManager(ClassfileManager.transactional(tempDir, logger)).
       withApiDumpDirectory(None).
       withRecompileOnMacroDef(project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.recompileOnMacroDef.name))).
       withNameHashing(project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.nameHashing.name)))

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/LocateSymbol.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/LocateSymbol.scala
@@ -100,7 +100,7 @@ trait LocateSymbol { self: ScalaPresentationCompiler =>
 
       pos flatMap { p =>
         if (p eq NoPosition) None
-        else Some(cunit, p.point)
+        else Some((cunit, p.point))
       }
     }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaDoc.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaDoc.scala
@@ -49,7 +49,6 @@ trait Scaladoc extends MemberLookupBase with CommentFactoryBase { this: ScalaPre
 
   val TIMEOUT = if (IScalaPlugin().noTimeoutMode) Duration.Inf else 500.millis
 
-
   def parsedDocComment(sym: Symbol, site: Symbol, javaProject:IJavaProject): Option[Comment] = {
     val res =
 
@@ -78,8 +77,6 @@ trait Scaladoc extends MemberLookupBase with CommentFactoryBase { this: ScalaPre
   }
 
   def headerForSymbol(sym:Symbol, tpe: Type): Option[String] = asyncExec{
-    def compose(ss: List[String]): String = ss.filterNot(_.isEmpty).mkString(" ")
-
     def defString(sym: Symbol, tpe: Type): String = {
       // NoType is returned for defining occurrences, in this case we want to display symbol info itself.
       val tpeinfo = if (tpe ne NoType) tpe.widen else sym.info

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -265,7 +265,7 @@ class ScalaPresentationCompiler(name: String, _settings: Settings) extends {
     if (asyncExec { sym.owner.isClass || sym.owner.isFreeType }.getOrElse(false)()) {
       askDocComment(sym, source, site, fragments, response)
     } else {
-      response.set("", "", NoPosition)
+      response.set(("", "", NoPosition))
     }
     response
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/containers/ScalaClasspathContainers.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/containers/ScalaClasspathContainers.scala
@@ -41,7 +41,6 @@ import org.scalaide.util.internal.CompilerUtils.shortString
 import org.scalaide.ui.internal.preferences.CompilerSettings
 import org.scalaide.util.internal.SettingConverterUtil
 import org.scalaide.core.SdtConstants
-import org.scalaide.ui.internal.preferences.PropertyStore
 import org.eclipse.ui.dialogs.PreferencesUtil
 import org.scalaide.core.internal.jdt.util.ScalaClasspathContainerHandler
 
@@ -51,7 +50,6 @@ abstract class ScalaClasspathContainerInitializer(desc: String) extends Classpat
   override def initialize(containerPath: IPath, project: IJavaProject) = {
     val iProject = project.getProject()
 
-    val storage = new PropertyStore(new ProjectScope(iProject), SdtConstants.PluginId)
     val setter = new ClasspathContainerSetter(project)
     val proj =     ScalaPlugin().asScalaProject(iProject)
     val install = proj map (_.effectiveScalaInstallation())
@@ -83,7 +81,6 @@ abstract class ScalaClasspathContainerPage(containerPath: IPath, name: String, o
   with IClasspathContainerPage
   with IClasspathContainerPageExtension
   with ScalaInstallationChoiceUIProviders {
-
 
   private var choiceOfScalaInstallation: ScalaInstallationChoice = null
   protected var scalaProject: Option[ScalaProject] = None

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/semantichighlighting/classifier/SymbolTests.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/semantichighlighting/classifier/SymbolTests.scala
@@ -5,7 +5,6 @@ import scala.reflect.internal.util.RangePosition
 import org.eclipse.jface.text.IRegion
 import scala.reflect.internal.util.SourceFile
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
-import org.scalaide.logging.HasLogger
 import scala.reflect.internal.Flags
 
 private[classifier] trait SymbolTests { self: SymbolClassification =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/saveactions/AddNewLineAtEndOfFileCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/saveactions/AddNewLineAtEndOfFileCreator.scala
@@ -1,7 +1,6 @@
 package org.scalaide.core.internal.extensions.saveactions
 
 import org.scalaide.core.text.Document
-import org.scalaide.extensions.DocumentSupport
 import org.scalaide.extensions.saveactions.AddNewLineAtEndOfFile
 
 object AddNewLineAtEndOfFileCreator {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/saveactions/AutoFormattingCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/saveactions/AutoFormattingCreator.scala
@@ -1,7 +1,6 @@
 package org.scalaide.core.internal.extensions.saveactions
 
 import org.scalaide.core.text.Document
-import org.scalaide.extensions.DocumentSupport
 import org.scalaide.extensions.saveactions.AutoFormatting
 
 object AutoFormattingCreator {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/saveactions/RemoveTrailingWhitespaceCreator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/saveactions/RemoveTrailingWhitespaceCreator.scala
@@ -1,7 +1,6 @@
 package org.scalaide.core.internal.extensions.saveactions
 
 import org.scalaide.core.text.Document
-import org.scalaide.extensions.DocumentSupport
 import org.scalaide.extensions.saveactions.RemoveTrailingWhitespace
 
 object RemoveTrailingWhitespaceCreator {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/hyperlink/ImplicitHyperlinkDetector.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/hyperlink/ImplicitHyperlinkDetector.scala
@@ -4,8 +4,6 @@ import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.hyperlink.IHyperlink
 import org.eclipse.ui.texteditor.ITextEditor
 import org.scalaide.core.compiler.InteractiveCompilationUnit
-import org.scalaide.ui.internal.editor.decorators.implicits.ImplicitConversionAnnotation
-import org.scalaide.util.eclipse.EditorUtils
 
 private class ImplicitHyperlinkDetector extends BaseHyperlinkDetector {
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/JavaElementFactory.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/JavaElementFactory.scala
@@ -6,7 +6,6 @@ import org.eclipse.jdt.internal.core.CompilationUnit
 import org.eclipse.jdt.internal.core.ImportContainer
 import org.eclipse.jdt.internal.core.ImportDeclaration
 import org.eclipse.jdt.internal.core.JavaElement
-import org.eclipse.jdt.internal.core.JavaElementInfo
 import org.eclipse.jdt.internal.core.SourceType
 import org.eclipse.jdt.internal.core.SourceRefElement
 import org.scalaide.util.internal.ReflectionUtils
@@ -16,20 +15,14 @@ object JavaElementFactory extends ReflectionUtils {
   private val icCtor = getDeclaredConstructor(classOf[ImportContainer], classOf[CompilationUnit])
   private val idCtor = getDeclaredConstructor(classOf[ImportDeclaration], classOf[ImportContainer], classOf[String], classOf[Boolean])
   private val parentField = getDeclaredField(classOf[JavaElement], "parent")
-  private val (sreiCtor, pdCtor) =
-    privileged {
-      val sreiCtor0 =
-        Class.forName("org.eclipse.jdt.internal.core.SourceRefElementInfo").
-          getDeclaredConstructor().asInstanceOf[Constructor[AnyRef]]
-      val pdCtor0 =
-        Class.forName("org.eclipse.jdt.internal.core.PackageDeclaration").
-          getDeclaredConstructor(classOf[CompilationUnit], classOf[String]).asInstanceOf[Constructor[AnyRef]]
+  private val pdCtor = privileged {
+    val pdCtor0 =
+      Class.forName("org.eclipse.jdt.internal.core.PackageDeclaration").
+        getDeclaredConstructor(classOf[CompilationUnit], classOf[String]).asInstanceOf[Constructor[AnyRef]]
 
-      sreiCtor0.setAccessible(true)
-      pdCtor0.setAccessible(true)
-
-      (sreiCtor0, pdCtor0)
-    }
+    pdCtor0.setAccessible(true)
+    pdCtor0
+  }
 
   def createSourceType(parent : JavaElement, name : String) =
     stCtor.newInstance(parent, name).asInstanceOf[SourceType]

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaStructureBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaStructureBuilder.scala
@@ -595,9 +595,9 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
         // When done, remove.
         if (sym ne NoSymbol) {
           sym.initialize
-          val getter = sym.getter(sym.owner)
+          val getter = sym.getterIn(sym.owner)
           if (getter hasFlag Flags.ACCESSOR) addDef(getter)
-          val setter = sym.setter(sym.owner)
+          val setter = sym.setterIn(sym.owner)
           if (setter hasFlag Flags.ACCESSOR) addDef(setter)
           addBeanAccessors(sym)
         }
@@ -606,7 +606,7 @@ trait ScalaStructureBuilder extends ScalaAnnotationHelper { pc : ScalaPresentati
       }
 
       def addBeanAccessors(sym: Symbol) {
-        val beanName = nme.localToGetter(sym.name.toTermName).toString.capitalize
+        val beanName = sym.name.dropLocal.toString.capitalize
         val ownerInfo = sym.owner.info
         val accessors = List(ownerInfo.decl(GET append beanName), ownerInfo.decl(IS append beanName), ownerInfo.decl(SET append beanName)).filter(_ ne NoSymbol)
         accessors.foreach(addDef)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/util/LabeledScalaInstallationsSaveHelper.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/util/LabeledScalaInstallationsSaveHelper.scala
@@ -28,7 +28,7 @@ class ContextualizedObjectInputStream(in: InputStream) extends ObjectInputStream
 
   override def resolveClass(desc: ObjectStreamClass) = {
 
-    val res  = Try(Thread.currentThread().getContextClassLoader().loadClass(desc.getName()))
+    val res = Try[Class[_]](Thread.currentThread().getContextClassLoader().loadClass(desc.getName()))
     res match {
       case Success(cl) => cl
       case Failure(thrown) => throw new IllegalAccessException("Something went horribly wrong deserializing")

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/util/LabeledScalaInstallationsSaveHelper.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/util/LabeledScalaInstallationsSaveHelper.scala
@@ -73,16 +73,16 @@ object LabeledScalaInstallationsSaveHelper {
 
   /** A ScalaModule replacement used for object serialization
    */
+  @SerialVersionUID(1001667379327078799L)
   class ScalaModuleReplace(val classJar: IPath, val srcJar: Option[IPath]) extends Serializable {
-    private val serialVersionUID = 1001667379327078799L
     def this(sm: ScalaModule) = this(sm.classJar, sm.sourceJar)
     def getScalaModule() = ScalaModule(classJar, srcJar)
   }
 
   /** A ScalaInstallation replacement used for object serialization
    */
+  @SerialVersionUID(3901667379327078799L)
   class LabeledScalaInstallationReplace(val name: ScalaInstallationLabel, val compilerMod: ScalaModule, val libraryMod: ScalaModule, val extraJarsMods: Seq[ScalaModule]) extends Serializable {
-    private val serialVersionUID = 3901667379327078799L
     def this(ins: LabeledScalaInstallation) = this(ins.label, ins.compiler, ins.library, ins.extraJars)
     def getLabeledScalaInstallation() = new LabeledScalaInstallation() {
       override def label = name
@@ -95,8 +95,8 @@ object LabeledScalaInstallationsSaveHelper {
 
   /** An IPath replacement used for object serialization
    */
+  @SerialVersionUID(-2361259525684491181L)
   class PathReplace(val path: String) extends Serializable {
-    private val serialVersionUID = -2361259525684491181L
     def this(ip: IPath) = this(ip.toPortableString())
     def getPath() = Path.fromPortableString(path)
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/launching/JUnit4TestFinder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/launching/JUnit4TestFinder.scala
@@ -33,7 +33,6 @@ import scala.tools.eclipse.contribution.weaving.jdt.launching.ISearchMethods
 import org.scalaide.logging.HasLogger
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
 
-
 /** A JUnit4 test finder that works for Java and Scala.
  *
  *  We hook this test finder using an internal extension point defined by `org.eclipse.jdt.junit.core`,
@@ -101,7 +100,7 @@ class JUnit4TestFinder extends ITestFinder with ISearchMethods with HasLogger {
           // classes in the empty package are not found in the root mirror
           val sym = if (fqn.lastPos('.') > -1) rootMirror.getClassByName(fqn) else rootMirror.EmptyPackageClass.info.member(fqn)
           sym.annotations
-          sym.info.members.filter(hasTestAnnotation).map(_.originalName.toString).toSet[String]
+          sym.info.members.filter(hasTestAnnotation).map(_.unexpandedName.toString).toSet[String]
         }.getOrElse(emptySet)()
       } getOrElse (emptySet)
     } getOrElse (emptySet)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ClasspathManagement.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ClasspathManagement.scala
@@ -352,7 +352,7 @@ trait ClasspathManagement extends HasLogger { self: ScalaProject =>
     ScalaInstallation.bundledInstallations.map(_.library.classJar) contains library
   }
 
-  private def validateScalaLibrary(fragmentRoots: Seq[ScalaLibrary], canFixInstallationFromScalaLib: Boolean = false): Seq[(Int, String, String)] = {
+  private def validateScalaLibrary(fragmentRoots: Seq[ScalaLibrary], canFixInstallationFromScalaLib: Boolean): Seq[(Int, String, String)] = {
     import org.scalaide.util.internal.CompilerUtils._
 
     def incompatibleScalaLibrary(scalaLib: ScalaLibrary) = scalaLib match {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -537,9 +537,6 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
     }
   }
 
-  @deprecated("removed this cache to avoid sync issues with desired Source level", "4.0.1")
-  private val compatibilityModeCache = null
-
   @deprecated("Don't use or depend on this because it will be removed soon.", since = "4.0.0")
   def defaultOrElse[T]: T = {
     throw InvalidCompilerSettings()

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/changecase/ChangeCaseProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/changecase/ChangeCaseProposal.scala
@@ -4,7 +4,6 @@ package changecase
 import scala.reflect.internal.util.RangePosition
 
 import org.eclipse.jface.text.IDocument
-import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
 import org.scalaide.core.compiler.InteractiveCompilationUnit
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.ui.ScalaImages

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/createmethod/MissingMemberInfo.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/createmethod/MissingMemberInfo.scala
@@ -4,7 +4,6 @@ package createmethod
 import org.eclipse.jdt.core.IJavaElement
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
 import org.scalaide.core.compiler.InteractiveCompilationUnit
-import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
 import org.scalaide.logging.HasLogger
 import org.scalaide.util.internal.scalariform.ArgPosition
 import org.scalaide.util.internal.scalariform.MethodCallInfo
@@ -120,12 +119,12 @@ object MissingMemberInfo {
           }
         }.getOption()
       }.flatten
-      optopt.flatten.orElse(Some(Nil, None))
+      optopt.flatten.orElse(Some((Nil, None)))
     }
 
     val result = for (MethodCallInfo(offset, length, argPosition) <- ScalariformUtils.callingOffsetAndLength(source, offset)) yield {
       getParamsAndReturnType(offset, length, argPosition)
     }
-    result.flatten.getOrElse(Nil,None)
+    result.flatten.getOrElse((Nil,None))
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/extract/ExtractExpressions.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/extract/ExtractExpressions.scala
@@ -26,6 +26,7 @@ class ExtractExpressions extends QuickAssist {
     val proposals = new ArrayBuffer[ExtractionProposal]
 
     icu.withSourceFile { (file, compiler) =>
+      import scala.language.reflectiveCalls
       val refactoring = createRefactoring(compiler, file, selectionStart, selectionEnd)
       var relevance = RelevanceValues.ProposalRefactoringHandlerAdapter - 1
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/LocalNameOccurrences.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/LocalNameOccurrences.scala
@@ -7,6 +7,7 @@ import scala.tools.refactoring.common.InteractiveScalaCompiler
 import org.scalaide.util.eclipse.EditorUtils
 
 case class LocalNameOccurrences(name: String) {
+  import scala.language.reflectiveCalls
   private val os =
     EditorUtils.withCurrentScalaSourceFile { file =>
       file.withSourceFile { (sourceFile, compiler) =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/completion/ScalaCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/completion/ScalaCompletionProposal.scala
@@ -5,7 +5,6 @@ import org.eclipse.jdt.internal.ui.JavaPluginImages
 import org.eclipse.jdt.ui.PreferenceConstants
 import org.eclipse.jface.preference.PreferenceConverter
 import org.eclipse.jface.text.contentassist.ICompletionProposal
-import org.eclipse.jface.text.link._
 import org.eclipse.swt.graphics.Color
 import org.scalaide.core.completion.CompletionProposal
 import org.scalaide.ui.ScalaImages
@@ -27,7 +26,6 @@ object ScalaCompletionProposal {
   val javaInterfaceImage = JavaPluginImages.get(JavaPluginImages.IMG_OBJS_INTERFACE)
   val javaClassImage = JavaPluginImages.get(JavaPluginImages.IMG_OBJS_CLASS)
   val packageImage = JavaPluginImages.get(JavaPluginImages.IMG_OBJS_PACKAGE)
-
 
   /** Wraps a [[CompletionProposa]] returned by the presentation compiler in
    *  an ICompletionProposal usable by the platform.

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/CompilationUnit.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/CompilationUnit.scala
@@ -3,7 +3,6 @@ package org.scalaide.ui.editor
 import scala.reflect.io.AbstractFile
 import org.scalaide.core.compiler.InteractiveCompilationUnit
 import org.scalaide.core.resources.EclipseResource
-import scala.tools.nsc.interactive.Response
 import org.eclipse.core.resources.IFile
 import org.eclipse.jface.text.IDocument
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/SourceCodeEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/SourceCodeEditor.scala
@@ -1,7 +1,5 @@
 package org.scalaide.ui.editor
 
-import org.scalaide.ui.editor.ISourceViewerEditor
-import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
 import org.eclipse.jdt.core.compiler.IProblem
 import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitDocumentProvider.ProblemAnnotation
 import org.eclipse.jface.preference.IPreferenceStore

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/SourceConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/SourceConfiguration.scala
@@ -2,8 +2,6 @@ package org.scalaide.ui.editor
 
 import org.scalaide.core.internal.hyperlink.DeclarationHyperlinkDetector
 import org.scalaide.core.internal.hyperlink.ImplicitHyperlinkDetector
-import org.eclipse.jface.text.hyperlink.IHyperlinkDetectorExtension
-import org.eclipse.jface.text.hyperlink.IHyperlinkDetector
 import org.scalaide.core.internal.hyperlink.ScalaHyperlink
 import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.hyperlink.IHyperlink

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/hover/IScalaHover.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/hover/IScalaHover.scala
@@ -4,7 +4,6 @@ import org.scalaide.logging.HasLogger
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.util.eclipse.OSGiUtils
 import org.scalaide.core.SdtConstants
-import org.scalaide.core.compiler.InteractiveCompilationUnit
 import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
 import org.eclipse.jface.text.ITextHover
 import org.eclipse.jface.text.ITextHoverExtension

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunDiagnosticAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunDiagnosticAction.scala
@@ -5,7 +5,6 @@ import org.eclipse.jface.viewers.ISelection
 import org.eclipse.ui.IObjectActionDelegate
 import org.eclipse.ui.IWorkbenchPart
 import org.eclipse.ui.IWorkbenchWindow
-import org.scalaide.util.Utils
 import org.scalaide.core.internal.logging.LogManager
 import org.eclipse.ui.IWorkbenchWindowActionDelegate
 import org.scalaide.ui.internal.diagnostic

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/ScalaInstallationAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/ScalaInstallationAction.scala
@@ -81,12 +81,11 @@ class ScalaInstallationAction extends IObjectActionDelegate {
 
   //Ask the user to select a build configuration from the selected project.
   private def chooseScalaInstallation(): Option[ScalaInstallationChoice] = {
-    val dialog = new ElementListSelectionDialog(getShell(), labeler) {
-      def getInstallationChoice(): Option[ScalaInstallationChoice] = {
-        val res = getResult()
-        if (res != null && !res.isEmpty) res(0).asInstanceOfOpt[ScalaInstallationChoice]
-        else None
-      }
+    val dialog = new ElementListSelectionDialog(getShell(), labeler)
+    def getInstallationChoice: Option[ScalaInstallationChoice] = {
+      val res = dialog.getResult
+      if (res != null && !res.isEmpty) res(0).asInstanceOfOpt[ScalaInstallationChoice]
+      else None
     }
     val dynamicVersions:List[ScalaInstallationChoice] = List("2.10", "2.11").map((s) => ScalaInstallationChoice(ScalaVersion(s)))
     val fixedVersions: List[ScalaInstallationChoice] = ScalaInstallation.availableInstallations.map((si) => ScalaInstallationChoice(si))
@@ -96,9 +95,10 @@ class ScalaInstallationAction extends IObjectActionDelegate {
     dialog.setMultipleSelection(false)
     val result = dialog.open()
     labeler.dispose()
-    if (result == Window.OK) {
-      dialog.getInstallationChoice()
-    } else None
+    if (result == Window.OK)
+      getInstallationChoice
+    else
+      None
   }
 
   private def getShell() = if (parentWindow == null) SWTUtils.getShell else parentWindow.getShell

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/completion/ScalaCompletionProposalImpl.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/completion/ScalaCompletionProposalImpl.scala
@@ -38,7 +38,6 @@ import org.scalaide.util.internal.Commons
 import org.scalaide.util.ScalaWordFinder
 import org.scalaide.util.eclipse.EditorUtils
 import org.eclipse.jdt.internal.ui.text.java.hover.JavadocHover
-import org.scalaide.ui.editor.hover.ScalaHover
 import org.scalaide.ui.internal.editor.hover.HoverControlCreator
 import org.scalaide.ui.internal.editor.hover.FocusedControlCreator
 import org.scalaide.ui.editor.hover.IScalaHover
@@ -109,7 +108,7 @@ class ScalaCompletionProposalImpl(proposal: CompletionProposal)
   /** Some additional info (like javadoc ...)
    */
   override def getAdditionalProposalInfo(): String = null  // Rather the next method is called.
-  override def getAdditionalProposalInfo(monitor: IProgressMonitor): AnyRef = proposal.documentation() orNull
+  override def getAdditionalProposalInfo(monitor: IProgressMonitor): AnyRef = proposal.documentation().orNull
 
   override def getSelection(d: IDocument): Point = null
   override def apply(d: IDocument) { throw new IllegalStateException("Shouldn't be called") }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
@@ -44,7 +44,6 @@ import org.scalaide.core.internal.hyperlink._
 import org.scalaide.core.internal.formatter.FormatterPreferences._
 import org.scalaide.core.internal.formatter.ScalaFormattingStrategy
 import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
-import org.scalaide.core.internal.lexical._
 import org.scalaide.ui.editor.extensionpoints.ScalaHoverDebugOverrideExtensionPoint
 import org.scalaide.ui.internal.editor.autoedits._
 import org.scalaide.ui.internal.editor.hover.BrowserControlAdditions

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/bynameparams/CallByNameParamAtCreationPresenter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/bynameparams/CallByNameParamAtCreationPresenter.scala
@@ -1,6 +1,5 @@
 package org.scalaide.ui.internal.editor.decorators.bynameparams
 
-import org.scalaide.core.extensions.SemanticHighlightingParticipant
 import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
 import scala.reflect.internal.util.SourceFile
 import org.scalaide.core.compiler.IScalaPresentationCompiler

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/semantichighlighting/TextPresentationHighlighter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/semantichighlighting/TextPresentationHighlighter.scala
@@ -10,7 +10,7 @@ import org.scalaide.core.internal.decorators.semantichighlighting.PositionsTrack
  *
  *  @note This trait is needed for running tests in a headless environment.
  */
-trait TextPresentationHighlighter {
+private[scalaide] trait TextPresentationHighlighter {
   def sourceViewer: ISourceViewer
 
   def initialize(semanticHighlightingJob: Job, positionsTracker: PositionsTracker): Unit

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/FormatterPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/FormatterPreferencePage.scala
@@ -31,7 +31,6 @@ import org.eclipse.ui.editors.text.TextEditor
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.internal.formatter.FormatterPreferences
 import org.scalaide.core.internal.formatter.FormatterPreferences._
-import org.scalaide.util.eclipse.SWTUtils._
 import scalariform.formatter._
 import scalariform.formatter.preferences._
 import org.scalaide.logging.HasLogger

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/HoverPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/HoverPreferencePage.scala
@@ -16,7 +16,6 @@ import org.eclipse.ui.IWorkbenchPreferencePage
 import org.eclipse.ui.dialogs.PreferencesUtil
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.ui.editor.hover.IScalaHover._
-import org.scalaide.util.eclipse.SWTUtils._
 
 /** This class is referenced through plugin.xml */
 class HoverPreferencePage extends PreferencePage with IWorkbenchPreferencePage {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ImplicitsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ImplicitsPreferencePage.scala
@@ -1,6 +1,5 @@
 package org.scalaide.ui.internal.preferences
 
-import org.eclipse.jface.preference._
 import org.eclipse.ui.IWorkbenchPreferencePage
 import org.eclipse.ui.IWorkbench
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/PreviewerFactory.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/PreviewerFactory.scala
@@ -40,7 +40,6 @@ class PreviewerFactory(factoryConfiguration: PreviewerFactoryConfiguration) exte
     val document = new Document
     document.set(initialText)
 
-    import scala.collection.JavaConverters._
     TextUtilities.addDocumentPartitioners(document, asJavaHashMap(factoryConfiguration.getDocumentPartitioners()))
     previewViewer.setDocument(document)
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SaveActionsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SaveActionsPreferencePage.scala
@@ -56,7 +56,7 @@ class SaveActionsPreferencePage extends PreferencePage with IWorkbenchPreference
     timeoutValue = new Text(timeout, SWT.BORDER | SWT.SINGLE)
     timeoutValue.setText(prefStore.getString(SaveActionExtensions.SaveActionTimeoutId))
     timeoutValue.addModifyListener { e: ModifyEvent =>
-      def error = {
+      def error() = {
         setValid(false)
         setErrorMessage(s"Timeout value needs to be >= $MinSaveActionTimeout ms")
       }
@@ -143,7 +143,7 @@ class SaveActionsPreferencePage extends PreferencePage with IWorkbenchPreference
     super.performDefaults
   }
 
-  private def mkTextArea(parent: Composite, lineHeight: Int = 1, initialText: String = "", columnSize: Int = 1): Text = {
+  private def mkTextArea(parent: Composite, lineHeight: Int, initialText: String = "", columnSize: Int): Text = {
     val t = new Text(parent, SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.WRAP | SWT.READ_ONLY)
     t.setText(initialText)
     t.setLayoutData({

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaPreviewerFactory.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaPreviewerFactory.scala
@@ -10,7 +10,6 @@ import org.scalaide.ui.syntax.ScalaSyntaxClasses
 import org.eclipse.jface.preference.IPreferenceStore
 import org.scalaide.ui.internal.editor.decorators.semantichighlighting.HighlightingStyle
 import org.scalaide.ui.internal.editor.decorators.semantichighlighting.Preferences
-import org.eclipse.jface.util.PropertyChangeEvent
 
 class StandardPreviewerFactoryConfiguration extends PreviewerFactoryConfiguration {
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SyntaxColoringPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SyntaxColoringPreferencePage.scala
@@ -61,7 +61,7 @@ class SyntaxColoringPreferencePage extends BaseSyntaxColoringPreferencePage(
     setUpSelectionListener
   }
 
-  private def setUpSelectionListener {
+  private def setUpSelectionListener() = {
     enableSemanticHighlightingCheckBox.addSelectionListener { () =>
       overlayStore.setValue(ENABLE_SEMANTIC_HIGHLIGHTING, enableSemanticHighlightingCheckBox.getSelection)
       extraAccuracyCheckBox.setEnabled(enableSemanticHighlightingCheckBox.getSelection)

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
@@ -39,7 +39,6 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
   strategy: IReconcilingStrategy,
   isIncremental: Boolean) extends MonoReconciler(strategy, isIncremental) with HasLogger {
 
-  @volatile private var editorActive: Boolean = true
   // both these fields are set during `install`, and should be non-null afterwards
   @volatile private var compilerProxy: IPresentationCompilerProxy = _
   @volatile private var activationListener: ActivationListener = _
@@ -49,13 +48,10 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
     override def partActivated(part: IWorkbenchPart): Unit = {
       if (part == editor) {
         forceReconciling()
-        editorActive = true
       }
     }
 
-    override def partDeactivated(part: IWorkbenchPart): Unit = {
-      if (part == editor) editorActive = false
-    }
+    override def partDeactivated(part: IWorkbenchPart): Unit = {}
   }
 
   /** Listen for presentation-compiler restart events. */
@@ -74,19 +70,11 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
   class ActivationListener(control: Control) extends ShellAdapter {
     override def shellActivated(event: ShellEvent): Unit = {
       if (!control.isDisposed() && control.isVisible()) {
-        editorActive = true
         forceReconciling()
       }
     }
 
-    override def shellDeactivated(event: ShellEvent): Unit = {
-      if (!control.isDisposed() && control.getShell == event.getSource)
-        editorActive = false
-    }
-  }
-
-  private def getResource(): IFile = {
-    editor.getInteractiveCompilationUnit().workspaceFile
+    override def shellDeactivated(event: ShellEvent): Unit = {}
   }
 
   override def install(textViewer: ITextViewer): Unit = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconcilingStrategy.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconcilingStrategy.scala
@@ -14,8 +14,6 @@ import org.scalaide.util.Utils._
 
 class ScalaReconcilingStrategy(icuEditor: InteractiveCompilationUnitEditor) extends IReconcilingStrategy with IReconcilingStrategyExtension with HasLogger {
 
-  private var document: IDocument = _
-
   /**
    * The underlying compilation unit, in general implemented by a ScalaSourceFile.
    *
@@ -29,15 +27,12 @@ class ScalaReconcilingStrategy(icuEditor: InteractiveCompilationUnitEditor) exte
   // for which reconciliation of the locally opened editor makes little sense
   // (it's more properly a ScalaClassFileViewer) but we still want to flush
   // scheduled reloads nonetheless
-  private val listeningEditor : Option[IJavaReconcilingListener] =
+  private val listeningEditor: Option[IJavaReconcilingListener] =
     icuEditor.asInstanceOfOpt[IJavaReconcilingListener]
 
-  override def setDocument(doc: IDocument) {
-    document = doc
-  }
+  override def setDocument(doc: IDocument) {}
 
-  override def setProgressMonitor(pMonitor : IProgressMonitor) {
-  }
+  override def setProgressMonitor(pMonitor: IProgressMonitor) {}
 
   override def reconcile(dirtyRegion: DirtyRegion, subRegion: IRegion) {
     logger.debug("Incremental reconciliation not implemented.")

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/syntax/preferences/PreviewerFactoryConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/syntax/preferences/PreviewerFactoryConfiguration.scala
@@ -5,7 +5,6 @@ import org.eclipse.jface.util.IPropertyChangeListener
 import org.eclipse.jface.text.source.SourceViewerConfiguration
 import org.eclipse.jface.text.IDocumentPartitioner
 import org.eclipse.jface.text.source.ISourceViewer
-import org.eclipse.jface.util.PropertyChangeEvent
 
 /** Configuration for a previewer, like the one used in syntax coloring preferences page.
  *  It returns the configuration for the source viewer, and the document partitioners to use.

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/FileUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/FileUtils.scala
@@ -3,7 +3,6 @@ package org.scalaide.util.eclipse
 import java.io.ByteArrayInputStream
 import java.io.File
 
-import org.scalaide.util.eclipse.EclipseUtils
 import scala.tools.nsc.io.AbstractFile
 import scala.util.Try
 
@@ -40,23 +39,7 @@ object FileUtils {
     case EclipseResource(file: IFile) => Some(file)
     case abstractFile =>
       val path = Path.fromOSString(abstractFile.path)
-      toIFile(path)
-  }
-
-  @deprecated("Use resourceForPath instead", "4.0.0")
-  private def toIFile(path: IPath): Option[IFile] = {
-    val file = ResourcesPlugin.getWorkspace.getRoot.getFileForLocation(path)
-
-    if (file == null || !file.exists) None
-    else Some(file)
-  }
-
-  private def length(file: IFile) = {
-    val fs = FileBuffers.getFileStoreAtLocation(file.getLocation)
-    if (fs != null)
-      fs.fetchInfo.getLength.toInt
-    else
-      -1
+      resourceForPath(path)
   }
 
   /**
@@ -91,38 +74,6 @@ object FileUtils {
   def hasBuildErrors(file: IResource): Boolean =
     file.findMarkers(SdtConstants.ProblemMarkerId, true, IResource.DEPTH_INFINITE).exists(_.getAttribute(IMarker.SEVERITY) == IMarker.SEVERITY_ERROR)
 
-  private def task(file: IFile, tag: String, msg: String, priority: String, offset: Int, length: Int, line: Int, monitor: IProgressMonitor) = {
-    val mrk = file.createMarker(SdtConstants.TaskMarkerId)
-    val values = new Array[AnyRef](taskMarkerAttributeNames.length)
-
-    val prioNum = priority match {
-      case JavaCore.COMPILER_TASK_PRIORITY_HIGH => IMarker.PRIORITY_HIGH
-      case JavaCore.COMPILER_TASK_PRIORITY_LOW  => IMarker.PRIORITY_LOW
-      case _                                    => IMarker.PRIORITY_NORMAL
-    }
-
-    values(0) = tag + " " + msg
-    values(1) = Integer.valueOf(prioNum)
-    values(2) = Integer.valueOf(IProblem.Task)
-    values(3) = Integer.valueOf(offset)
-    values(4) = Integer.valueOf(offset + length + 1)
-    values(5) = Integer.valueOf(line)
-    values(6) = java.lang.Boolean.valueOf(false)
-    values(7) = JavaBuilder.SOURCE_ID
-    mrk.setAttributes(taskMarkerAttributeNames, values);
-  }
-
-  private val taskMarkerAttributeNames = Array(
-    IMarker.MESSAGE,
-    IMarker.PRIORITY,
-    IJavaModelMarker.ID,
-    IMarker.CHAR_START,
-    IMarker.CHAR_END,
-    IMarker.LINE_NUMBER,
-    IMarker.USER_EDITABLE,
-    IMarker.SOURCE_ID
-  )
-
   /** Delete directory recursively. Does nothing if dir is not a directory. */
   def deleteDir(dir: File): Unit = {
     if (dir.isDirectory()) {
@@ -151,7 +102,7 @@ object FileUtils {
   }
 
   /**
-   * Find a File that matches the given absolute location on the file systme. Since a given
+   * Find a File that matches the given absolute location on the file system. Since a given
    * file might "mounted" under multiple locations in the Eclipse file system, the `prefix`
    * path is used disambiguate.
    */

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/OSGiUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/OSGiUtils.scala
@@ -35,11 +35,6 @@ object OSGiUtils {
     Option(bundle).map(b => Path.fromOSString(FileLocator.getBundleFile(b).getAbsolutePath()))
   }
 
-  private def allPathsInBundle(bundle: Bundle, path: String, filePattern: String): Iterator[IPath] = {
-    import scala.collection.JavaConverters._
-    bundle.findEntries(path, filePattern, false).asScala map urlToPath
-  }
-
   /**
    * Read the content of a file whose `filePath` points to a location in a
    * given `bundleId` and returns them. A [[scala.util.Failure]] is returned if

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/SWTUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/SWTUtils.scala
@@ -18,16 +18,6 @@ object SWTUtils {
 
   import scala.language.implicitConversions
 
-  @deprecated("Use org.scalaide.util.ui.DisplayThread.asyncExec", "3.0.0")
-  private def asyncExec(f: => Unit) {
-    DisplayThread.asyncExec(f)
-  }
-
-  @deprecated("Use org.scalaide.util.ui.DisplayThread.syncExec", "3.0.0")
-  private def syncExec(f: => Unit) {
-    DisplayThread.syncExec(f)
-  }
-
   /** Returns the active workbench window's shell
    *
    *  @return the shell containing this window's controls or `null`

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/FutureUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/FutureUtils.scala
@@ -28,7 +28,7 @@ object FutureUtils {
   /**
    * Adds extensions to the `Future` companion object.
    */
-  implicit class FutureExtensions[A](private val f: Future.type) extends AnyVal {
+  implicit class FutureExtensions(private val f: Future.type) extends AnyVal {
 
     /**
      * Returns a `Future` that is never completed.


### PR DESCRIPTION
Our number of warnings decreased from ~180 to ~110 (at least in my configuration). Half of the remaining warnings belong to deprecations in `sdt.core/plugin.xml`. The remaining ones contain deprecation warnings about the Eclipse API, all sort of warnings in the old wizard and in the indentation engine (which I both didn't fix because I want to kill both of them entirely) and scalac false positives.

This shouldn't introduce any behavior changes.