### PR TITLE
Simplify/fix editor API.

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/InteractiveCompilationUnit.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/InteractiveCompilationUnit.scala
@@ -122,8 +122,20 @@ trait InteractiveCompilationUnit {
   /** Does this unit exist in the workspace? */
   def exists(): Boolean
 
-  /** The Scala project to which this compilation unit belongs. */
+  /** The Scala project to which this compilation unit belongs.
+   *
+   *  @note Do NOT assume `scalaProject.presentationCompiler` is always the right one for this unit
+   */
   def scalaProject: IScalaProject
+
+  /** A presentation compiler that can handle this compilation unit.
+   *
+   * @note This is not always the `scalaProject.presentationCompiler`. For instance, an Sbt
+   *       file editor would use a different instance, since the classpath and source-level
+   *       for Sbt is usually different from the one in the enclosing project.
+   */
+  def presentationCompiler: IPresentationCompilerProxy =
+    scalaProject.presentationCompiler
 
   /** Schedule this unit for reconciliation with the new contents. This by itself won't start
    *  a new type-checking round, instead marks the current unit as *dirty*. At the next reconciliation
@@ -134,7 +146,7 @@ trait InteractiveCompilationUnit {
    *                     may not be Scala. This method takes care of translating the contents to Scala
    */
   def scheduleReconcile(newContents: Array[Char]): Unit = {
-    scalaProject.presentationCompiler { pc =>
+    presentationCompiler { pc =>
       pc.scheduleReload(this, sourceMap(newContents).sourceFile)
     }
   }
@@ -148,7 +160,7 @@ trait InteractiveCompilationUnit {
    *        reconciliation strategy.
    */
   def forceReconcile(): List[ScalaCompilationProblem] = {
-    scalaProject.presentationCompiler(_.flushScheduledReloads())
+    presentationCompiler(_.flushScheduledReloads())
     currentProblems()
   }
 
@@ -161,7 +173,7 @@ trait InteractiveCompilationUnit {
    *  This method should not block.
    */
   def initialReconcile(): Response[Unit] = {
-    val reloaded = scalaProject.presentationCompiler { compiler =>
+    val reloaded = presentationCompiler { compiler =>
       compiler.askReload(this, sourceMap(getContents).sourceFile)
     } getOrElse {
       val dummy = new Response[Unit]
@@ -181,7 +193,7 @@ trait InteractiveCompilationUnit {
   def currentProblems(): List[ScalaCompilationProblem] = {
     import scala.util.control.Exception.failAsValue
 
-    scalaProject.presentationCompiler { pc =>
+    presentationCompiler { pc =>
       val info = lastSourceMap()
       import info._
 
@@ -199,6 +211,6 @@ trait InteractiveCompilationUnit {
    *  @param op The operation to be performed
    */
   def withSourceFile[T](op: (SourceFile, IScalaPresentationCompiler) => T): Option[T] = {
-    scalaProject.presentationCompiler(op(lastSourceMap().sourceFile, _))
+    presentationCompiler(op(lastSourceMap().sourceFile, _))
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ScalaCompletions.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ScalaCompletions.scala
@@ -25,11 +25,21 @@ import org.scalaide.util.internal.Commons
 class ScalaCompletions extends HasLogger {
   import org.eclipse.jface.text.IRegion
 
-  /** Returns the list of possible completions, at the given position in the compilation unit,
-   *  with the given region as completion prefix.
-   */
+  @deprecated("Use getCompletions, which correctly handles units with a different presentation compiler", since = "4.1.0")
   def findCompletions(region: IRegion, position: Int, icu: InteractiveCompilationUnit): List[CompletionProposal] =
     icu.scalaProject.presentationCompiler { compiler =>
+      findCompletion(region, position, icu, compiler)
+    }.getOrElse(Nil)
+
+
+  /** Returns the list of possible completions, at the given position in the compilation unit,
+   *  with the given region as completion prefix.
+   *
+   *  @note This supports compilation units that have a different presentation compiler than the default
+   *        per-project compiler
+   */
+  def getCompletions(region: IRegion, position: Int, icu: InteractiveCompilationUnit): List[CompletionProposal] =
+    icu.presentationCompiler { compiler =>
       findCompletion(region, position, icu, compiler)
     }.getOrElse(Nil)
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/DefaultScalaEditorConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/DefaultScalaEditorConfiguration.scala
@@ -1,0 +1,104 @@
+package org.scalaide.ui.editor
+
+import org.eclipse.jface.text.source.IAnnotationHover
+import org.eclipse.jface.preference.IPreferenceStore
+import org.eclipse.jface.text.reconciler.IReconciler
+import org.eclipse.jface.text.reconciler.MonoReconciler
+import org.eclipse.jface.text.source.DefaultAnnotationHover
+import org.scalaide.core.lexical.ScalaPartitions
+import org.eclipse.jface.text.presentation.PresentationReconciler
+import org.scalaide.core.lexical.ScalaCodeScanners
+import org.eclipse.jface.text.source.SourceViewerConfiguration
+import org.eclipse.jface.text.information.InformationPresenter
+import org.eclipse.jdt.ui.text.IJavaPartitions
+import org.eclipse.jface.text.IDocumentListener
+import org.eclipse.jface.text.source.ISourceViewer
+import org.eclipse.jface.text.IDocument
+import org.scalaide.ui.editor.hover.IScalaHover
+import org.eclipse.jface.text.ITextHover
+import org.scalaide.core.IScalaPlugin
+import org.eclipse.jface.text.DocumentEvent
+import org.eclipse.jface.util.PropertyChangeEvent
+import org.eclipse.jface.text.rules.DefaultDamagerRepairer
+
+/** A default SourceViewerConfiguration class for Scala-based editors.
+ *
+ *  This class can be subclassed. It provides a default configuration including
+ *  reconciliation (errors-as-you-type), hovers and Scala syntax highlighting.
+ *
+ *  The workhorse of this implementation is [[InteractiveCompilationUnit]], which provides
+ *  the mapping between original source and Scala-source.
+ *
+ *  Any method can be overwritten.
+ *
+ *  @note Standard content assist is missing from this configuration, but should be easy to add
+ *        in a subsequent release
+ *
+ *  @since 4.1.0
+ */
+trait DefaultScalaEditorConfiguration extends SourceViewerConfiguration {
+  val javaPreferenceStore: IPreferenceStore
+  val textEditor: InteractiveCompilationUnitEditor
+
+  protected def scalaPreferenceStore: IPreferenceStore = IScalaPlugin().getPreferenceStore
+  private val codeHighlightingScanners = ScalaCodeScanners.codeHighlightingScanners(scalaPreferenceStore, javaPreferenceStore)
+
+  override def getPresentationReconciler(sv: ISourceViewer) = {
+    val reconciler = super.getPresentationReconciler(sv).asInstanceOf[PresentationReconciler]
+
+    for ((partitionType, tokenScanner) <- codeHighlightingScanners) {
+      val dr = new DefaultDamagerRepairer(tokenScanner)
+      reconciler.setDamager(dr, partitionType)
+      reconciler.setRepairer(dr, partitionType)
+    }
+
+    reconciler
+  }
+
+  override def getReconciler(sourceViewer: ISourceViewer): IReconciler = {
+    val reconciler = new MonoReconciler(
+      new ReconcilingStrategy(textEditor, reloader), /*isIncremental = */ false)
+    reconciler.install(sourceViewer)
+    reconciler
+  }
+
+  /** Ask the underlying unit to be scheduled for the next reconciliation round */
+  private object reloader extends IDocumentListener {
+    override def documentChanged(event: DocumentEvent) {
+      textEditor.getInteractiveCompilationUnit().scheduleReconcile(event.getDocument.get.toCharArray)
+    }
+
+    override def documentAboutToBeChanged(event: DocumentEvent) {}
+  }
+
+  override def getTextHover(viewer: ISourceViewer, contentType: String): ITextHover = {
+    IScalaHover(textEditor)
+  }
+
+  override def getConfiguredContentTypes(sourceViewer: ISourceViewer): Array[String] = {
+    Array(IDocument.DEFAULT_CONTENT_TYPE,
+      IJavaPartitions.JAVA_DOC,
+      IJavaPartitions.JAVA_MULTI_LINE_COMMENT,
+      IJavaPartitions.JAVA_SINGLE_LINE_COMMENT,
+      IJavaPartitions.JAVA_STRING,
+      IJavaPartitions.JAVA_CHARACTER,
+      ScalaPartitions.SCALA_MULTI_LINE_STRING)
+  }
+
+  override def getAnnotationHover(viewer: ISourceViewer): IAnnotationHover = {
+    new DefaultAnnotationHover(true)
+  }
+
+  override def getInformationPresenter(sourceViewer: ISourceViewer) = {
+    val p = new InformationPresenter(getInformationControlCreator(sourceViewer))
+    val ip = IScalaHover.hoverInformationProvider(textEditor)
+
+    p.setDocumentPartitioning(getConfiguredDocumentPartitioning(sourceViewer))
+    getConfiguredContentTypes(sourceViewer) foreach (p.setInformationProvider(ip, _))
+    p
+  }
+
+  def propertyChange(event: PropertyChangeEvent) {
+    codeHighlightingScanners.values.foreach(_.adaptToPreferenceChange(event))
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/ReconcilingStrategy.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/ReconcilingStrategy.scala
@@ -9,8 +9,13 @@ import org.scalaide.logging.HasLogger
 import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension
 import org.eclipse.core.runtime.IProgressMonitor
 
-class ReconcilingStrategy(sourceEditor: SourceCodeEditor, documentListener: IDocumentListener) extends IReconcilingStrategy with IReconcilingStrategyExtension with HasLogger {
+class ReconcilingStrategy(sourceEditor: InteractiveCompilationUnitEditor with DecoratedInteractiveEditor,
+    documentListener: IDocumentListener) extends IReconcilingStrategy with IReconcilingStrategyExtension with HasLogger {
   private var document: Option[IDocument] = None
+
+  def this(sourceEditor: SourceCodeEditor, documentListener: IDocumentListener) {
+    this(sourceEditor: InteractiveCompilationUnitEditor with DecoratedInteractiveEditor, documentListener)
+  }
 
   override def setDocument(doc: IDocument) {
     document.foreach(_.removeDocumentListener(documentListener))
@@ -25,7 +30,7 @@ class ReconcilingStrategy(sourceEditor: SourceCodeEditor, documentListener: IDoc
   override def reconcile(partition: IRegion) {
     for (doc <- document) {
       val errors = sourceEditor.getInteractiveCompilationUnit.forceReconcile()
-      sourceEditor.updateErrorAnnotations(errors)
+      sourceEditor.updateErrorAnnotations(errors, null)
     }
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/SourceCodeEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/editor/SourceCodeEditor.scala
@@ -12,6 +12,7 @@ import org.eclipse.jface.text.source.IAnnotationModelExtension2
 import org.eclipse.jface.text.source.ISourceViewer
 import org.eclipse.ui.editors.text.TextEditor
 
+@deprecated("Unnecessary complex class. Use DecoratedInteractiveEditor instead.", since = "4.1.0")
 trait SourceCodeEditor extends ISourceViewerEditor with InteractiveCompilationUnitEditor { self: TextEditor =>
 
   protected type UnderlyingCompilationUnit <: CompilationUnit


### PR DESCRIPTION
This commit should preserve binary compatibility so it can be included in 4.1.

It makes ICUs not assume the project presentation compiler, and this allows a potential Sbt editor to
use its own without needing to overwrite a lot of other methods.