### PR TITLE
old version number and transitive deps

### DIFF
--- a/org.scala-ide.scala210.jars/pom.xml
+++ b/org.scala-ide.scala210.jars/pom.xml
@@ -17,28 +17,33 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala210.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
       <version>${scala210.version}</version>
+      <optional>true</optional>
     </dependency>
     <!-- toolchain, Scala compiler -->
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
       <version>${scala210.version}</version>
+      <optional>true</optional>
     </dependency>
     <!-- modules -->
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-actors</artifactId>
       <version>${scala210.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-swing</artifactId>
       <version>${scala210.version}</version>
+      <optional>true</optional>
     </dependency>
     <!-- sources -->
     <dependency>
@@ -46,12 +51,14 @@
       <artifactId>scala-library</artifactId>
       <version>${scala210.version}</version>
       <classifier>sources</classifier>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
       <version>${scala210.version}</version>
       <classifier>sources</classifier>
+      <optional>true</optional>
     </dependency>
     <!-- toolchain, Scala compiler -->
     <dependency>
@@ -59,6 +66,7 @@
       <artifactId>scala-compiler</artifactId>
       <version>${scala210.version}</version>
       <classifier>sources</classifier>
+      <optional>true</optional>
     </dependency>
     <!-- modules -->
     <dependency>
@@ -66,12 +74,14 @@
       <artifactId>scala-actors</artifactId>
       <version>${scala210.version}</version>
       <classifier>sources</classifier>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-swing</artifactId>
       <version>${scala210.version}</version>
       <classifier>sources</classifier>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
 
     <!-- base versions -->
     <!-- Scala 2.10.x -->
-    <scala210.version>2.10.5-SNAPSHOT</scala210.version>
+    <scala210.version>2.10.5</scala210.version>
     <!-- Scala 2.11.x -->
-    <scala211.version>2.11.6-SNAPSHOT</scala211.version>
+    <scala211.version>2.11.7-SNAPSHOT</scala211.version>
     <scala211.binary.version>2.11</scala211.binary.version>
     <scala211.scala-xml.version>1.0.3</scala211.scala-xml.version>
     <scala211.scala-parser-combinators.version>1.0.3</scala211.scala-parser-combinators.version>


### PR DESCRIPTION
Updates the build with the latest Scala versions.
Removes the transitive dependencies to the dependencies of the Scala 2.10 fat jar. Tycho is making a mess with these when trying to resolve the p2 dependencies, and they are not useful.