### PR TITLE
Make organize imports format consistent with scalariform

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/UserPreferencesFormatting.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/UserPreferencesFormatting.scala
@@ -19,13 +19,7 @@ trait UserPreferencesFormatting {
   trait FormattingOverrides {
     this: Refactoring =>
 
-    override val spacingAroundMultipleImports: String = {
-      for {
-        javaProject <- Option(file.getJavaProject)
-        prefs = FormatterPreferences.getPreferences(javaProject)
-        if  prefs(SpaceInsideParentheses)
-      } yield " "
-    } getOrElse ""
+    override val spacingAroundMultipleImports: String = " "
 
     // TODO: Create more overrides here and in the refactoring library.
   }


### PR DESCRIPTION
We used to pass the IDE's SpaceInsideParentheses setting to scala-refactoring to control the spaces inside the braces of multiple imports, like this:

import a.b.{ c, d }

Unfortunately, in scalariform SpaceInsideParentheses only affects the space around regular parenthesis, and there is no setting for the spaces in imports. So to make the code generated by scala-refactoring consistent with the formatting of scalariform, we always print a space inside multiple imports.

Fixes scala-ide/scala-refactoring#81.