### PR TITLE
Also apply refactoring to files not currently open in the editor

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
@@ -218,6 +218,8 @@ class OrganizeImports extends RefactoringExecutorWithoutWizard {
 
     val refactoring = withCompiler( c => new implementations.OrganizeImports with FormattingOverrides { val global = c })
 
+    override protected def leaveDirty = true
+
     override def checkInitialConditions(pm: IProgressMonitor) = {
       val status = super.checkInitialConditions(pm)
       if(compilationUnitHasProblems) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ScalaIdeRefactoring.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ScalaIdeRefactoring.scala
@@ -75,6 +75,14 @@ abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFil
   def getPages: List[RefactoringWizardPage] = Nil
 
   /**
+   * Set this flag to true if you want changes from this refactoring to be marked as dirty in the editor.
+   *
+   * '''Warning''': Don't set this flag to true for refactorings that might affect files that are not
+   * currently open in the editor, as changes for these files would be lost. See ticket #1002079.
+   */
+  protected def leaveDirty: Boolean = false
+
+  /**
    * Holds the result of preparing this refactoring. We can keep this
    * in a lazy var because it will only be evaluated once.
    */
@@ -140,7 +148,7 @@ abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFil
     textChanges.groupBy(_.sourceFile.file).map {
       case (file, fileChanges) =>
         FileUtils.toIFile(file) map { file =>
-          TextEditUtils.createTextFileChange(file, fileChanges)
+          TextEditUtils.createTextFileChange(file, fileChanges, leaveDirty)
         } getOrElse {
           val msg = "Could not find the corresponding IFile for "+ file.path
           throw new CoreException(new Status(IStatus.ERROR, SdtConstants.PluginId, 0, msg, null))

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/eclipse/TextEditUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/eclipse/TextEditUtils.scala
@@ -27,7 +27,7 @@ object TextEditUtils {
   }
 
   /** Creates a `TextFileChange` which always contains a `MultiTextEdit`. */
-  def createTextFileChange(file: IFile, fileChanges: List[TextChange], saveAfter: Boolean = true): TextFileChange = {
+  def createTextFileChange(file: IFile, fileChanges: List[TextChange], leaveDirty: Boolean): TextFileChange = {
     new TextFileChange(file.getName(), file) {
 
       val fileChangeRootEdit = new MultiTextEdit
@@ -36,7 +36,7 @@ object TextEditUtils {
         new ReplaceEdit(change.from, change.to - change.from, change.text)
       } foreach fileChangeRootEdit.addChild
 
-      if (!saveAfter) setSaveMode(TextFileChange.LEAVE_DIRTY)
+      if (leaveDirty) setSaveMode(TextFileChange.LEAVE_DIRTY)
       else setSaveMode(TextFileChange.KEEP_SAVE_STATE)
 
       setEdit(fileChangeRootEdit)
@@ -55,17 +55,17 @@ object TextEditUtils {
    * @param textSelection The currently selected area of the document.
    * @param file The file that we're currently editing (the document alone isn't enough because we need to get an IFile).
    * @param changes The changes that should be applied.
-   * @param saveAfter Whether files should be saved after changes
+   * @param leaveDirty Whether files should be left dirty after changes
    */
   def applyChangesToFile(
       document: IDocument,
       textSelection: ITextSelection,
       file: AbstractFile,
       changes: List[TextChange],
-      saveAfter: Boolean = true): Option[ITextSelection] = {
+      leaveDirty: Boolean = false): Option[ITextSelection] = {
 
     FileUtils.toIFile(file) map { f =>
-      createTextFileChange(f, changes, saveAfter).getEdit match {
+      createTextFileChange(f, changes, leaveDirty).getEdit match {
         // we know that it is a MultiTextEdit because we created it above
         case edit: MultiTextEdit =>
           applyMultiTextEdit(document, textSelection, edit)

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/eclipse/TextEditUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/eclipse/TextEditUtils.scala
@@ -36,7 +36,9 @@ object TextEditUtils {
         new ReplaceEdit(change.from, change.to - change.from, change.text)
       } foreach fileChangeRootEdit.addChild
 
-      if (saveAfter) setSaveMode(TextFileChange.LEAVE_DIRTY)
+      if (!saveAfter) setSaveMode(TextFileChange.LEAVE_DIRTY)
+      else setSaveMode(TextFileChange.KEEP_SAVE_STATE)
+
       setEdit(fileChangeRootEdit)
     }
   }


### PR DESCRIPTION
`TextFileChange.LEAVE_DIRTY` causes changes to files that are not currently open
in the editor to be silently ignored. `TextFileChange.FORCE_SAVE` seems more appropriate if the flag `saveAfter` is set anyway.

Fixes #1002079