### PR TITLE
Statistics tracker

### DIFF
--- a/org.scala-ide.sdt.core/.classpath
+++ b/org.scala-ide.sdt.core/.classpath
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="lib" path="target/lib/scala-parser-combinators_2.11-1.0.2.jar" sourcepath="target/lib/scala-parser-combinators_2.11-1.0.2-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/scala-pickling_2.11-0.10.0.jar" sourcepath="target/lib/scala-pickling_2.11-0.10.0-sources.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" output="target/classes" path="src"/>

--- a/org.scala-ide.sdt.core/build.properties
+++ b/org.scala-ide.sdt.core/build.properties
@@ -13,4 +13,6 @@ bin.includes = META-INF/,\
                templates/,\
                target/lib/,\
                plugin.properties,\
-               resources/scala-hover.css
+               resources/scala-hover.css,\
+               target/lib/scala-pickling_2.11-0.10.0.jar,\
+               target/lib/scala-parser-combinators_2.11-1.0.2.jar

--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -940,6 +940,9 @@
      <initializer
            class="org.scalaide.ui.internal.preferences.SaveActionsPreferenceInitializer">
      </initializer>
+     <initializer
+           class="org.scalaide.ui.internal.preferences.ScalaPreferenceInitializer">
+     </initializer>
   </extension>
 
   <extension point="org.eclipse.core.expressions.propertyTesters">

--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -147,6 +147,12 @@
             id="org.scalaide.ui.preferences.editor.saveactions"
             name="Save Actions">
       </page>
+      <page
+            category="org.scalaide.ui.preferences"
+            class="org.scalaide.ui.internal.preferences.StatisticsPreferencePage"
+            id="org.scalaide.ui.preferences.statistics"
+            name="Statistics">
+      </page>
    </extension>
 
   <extension point="org.eclipse.core.contenttype.contentTypes">

--- a/org.scala-ide.sdt.core/pom.xml
+++ b/org.scala-ide.sdt.core/pom.xml
@@ -77,6 +77,24 @@
                   <groupId>com.miglayout</groupId>
                   <artifactId>miglayout</artifactId>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.scala-lang.modules</groupId>
+                  <artifactId>scala-pickling_${scala.minor.version}</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.scala-lang.modules</groupId>
+                  <artifactId>scala-pickling_${scala.minor.version}</artifactId>
+                  <classifier>sources</classifier>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.scala-lang.modules</groupId>
+                  <artifactId>scala-parser-combinators_${scala.minor.version}</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.scala-lang.modules</groupId>
+                  <artifactId>scala-parser-combinators_${scala.minor.version}</artifactId>
+                  <classifier>sources</classifier>
+                </artifactItem>
               </artifactItems>
             </configuration>
           </execution>

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_10.MF
@@ -115,6 +115,7 @@ Export-Package:
  org.scalaide.core.internal.quickassist.extract,
  org.scalaide.core.internal.quickassist.inline,
  org.scalaide.core.internal.repl,
+ org.scalaide.core.internal.statistics,
  org.scalaide.core.internal.text,
  org.scalaide.core.lexical,
  org.scalaide.core.quickassist,
@@ -177,7 +178,9 @@ Export-Package:
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,
  target/lib/miglayout-3.7.4.jar,
- target/lib/log4j-1.2.17.jar
+ target/lib/log4j-1.2.17.jar,
+ target/lib/scala-parser-combinators_2.11-1.0.2.jar,
+ target/lib/scala-pickling_2.11-0.10.0.jar
 Eclipse-ExtensibleAPI: 
  true
 

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_11.MF
@@ -115,6 +115,7 @@ Export-Package:
  org.scalaide.core.internal.quickassist.extract,
  org.scalaide.core.internal.quickassist.inline,
  org.scalaide.core.internal.repl,
+ org.scalaide.core.internal.statistics,
  org.scalaide.core.internal.text,
  org.scalaide.core.lexical,
  org.scalaide.core.quickassist,
@@ -177,7 +178,9 @@ Export-Package:
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,
  target/lib/miglayout-3.7.4.jar,
- target/lib/log4j-1.2.17.jar
+ target/lib/log4j-1.2.17.jar,
+ target/lib/scala-parser-combinators_2.11-1.0.2.jar,
+ target/lib/scala-pickling_2.11-0.10.0.jar
 Eclipse-ExtensibleAPI: 
  true
 

--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
@@ -114,6 +114,7 @@ Export-Package:
  org.scalaide.core.internal.quickassist.extract,
  org.scalaide.core.internal.quickassist.inline,
  org.scalaide.core.internal.repl,
+ org.scalaide.core.internal.statistics,
  org.scalaide.core.internal.text,
  org.scalaide.core.lexical,
  org.scalaide.core.quickassist,
@@ -176,7 +177,9 @@ Export-Package:
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,
  target/lib/miglayout-3.7.4.jar,
- target/lib/log4j-1.2.17.jar
+ target/lib/log4j-1.2.17.jar,
+ target/lib/scala-parser-combinators_2.11-1.0.2.jar,
+ target/lib/scala-pickling_2.11-0.10.0.jar
 Eclipse-ExtensibleAPI: 
  true
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/ScalaIdeDataStore.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/ScalaIdeDataStore.scala
@@ -1,0 +1,57 @@
+package org.scalaide.core
+
+import java.io.File
+import java.io.IOException
+
+import org.scalaide.util.eclipse.EclipseUtils
+
+object ScalaIdeDataStore {
+
+  private val userHome = System.getProperty("user.home")
+  private val sep = File.separator
+
+  /**
+   * Preference store id that points to the location of Scala IDEs own Eclipse
+   * independent data store.
+   */
+  final val DataStoreId = "org.scalaide.core.dataStore"
+
+  /**
+   * The default location of the data store. Users can change it in the Scala
+   * preference page. The data store can be shared between multiple Eclipse
+   * instances.
+   */
+  final val DefaultDataStoreLocation = s"$userHome$sep.scalaide"
+
+  /**
+   * The absolute path to the data store.
+   */
+  def dataStoreLocation: String =
+    IScalaPlugin().getPreferenceStore.getString(DataStoreId)
+
+  def statisticsLocation: String =
+    s"$dataStoreLocation${sep}statistics"
+
+  def write[A](location: String)(f: File ⇒ A): Option[A] = {
+    EclipseUtils.withSafeRunner(s"Error while writing to data store file '$location'") {
+      f(validateFile(location))
+    }
+  }
+
+  def read[A](location: String)(f: File ⇒ A): Option[A] = {
+    EclipseUtils.withSafeRunner(s"Error while reading from data store file '$location'") {
+      f(validateFile(location))
+    }
+  }
+
+  private def validateFile(location: String): File = {
+    val file = new File(location)
+    if (!file.exists()) {
+      file.getParentFile.mkdirs()
+      file.createNewFile()
+    }
+    if (file.isDirectory())
+      throw new IOException(s"Path '$location' is not a valid file location.")
+    file
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/ScalaPlugin.scala
@@ -71,6 +71,7 @@ import org.scalaide.ui.internal.editor.ScalaDocumentProvider
 import org.scalaide.core.internal.jdt.model.ScalaClassFile
 import org.eclipse.jdt.core.IClassFile
 import org.scalaide.util.Utils.WithAsInstanceOfOpt
+import org.scalaide.core.internal.statistics.Statistics
 
 object ScalaPlugin {
 
@@ -153,6 +154,10 @@ class ScalaPlugin extends IScalaPlugin with PluginLogConfigurator with IResource
 
   // Scala project instances
   private val projects = new mutable.HashMap[IProject, ScalaProject]
+
+  private lazy val stats = new Statistics
+
+  def statistics = stats
 
   override def scalaCompilationUnit(input: IEditorInput): Option[ScalaCompilationUnit] = {
     def unitOfSourceFile = Option(documentProvider.getWorkingCopy(input).asInstanceOf[ScalaCompilationUnit])

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/AddMethodProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/AddMethodProposal.scala
@@ -6,7 +6,6 @@ import scala.tools.refactoring.common.TextChange
 import scala.tools.refactoring.implementations.AddField
 import scala.tools.refactoring.implementations.AddMethod
 import scala.tools.refactoring.implementations.AddMethodTarget
-
 import org.eclipse.jface.text.IDocument
 import org.eclipse.text.edits.ReplaceEdit
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
@@ -17,8 +16,10 @@ import org.scalaide.core.internal.quickassist.createmethod.TypeParameterList
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.ui.ScalaImages
 import org.scalaide.util.eclipse.EditorUtils
+import org.scalaide.core.internal.statistics.Features.Feature
 
-abstract class AddValOrDefProposal extends BasicCompletionProposal(
+abstract class AddValOrDefProposal(feature: Feature) extends BasicCompletionProposal(
+    feature,
     relevance = 90,
     displayString = "",
     image = ScalaImages.ADD_METHOD_PROPOSAL) {
@@ -29,7 +30,7 @@ abstract class AddValOrDefProposal extends BasicCompletionProposal(
   protected val className: Option[String]
   protected val defName: String
 
-  override def apply(document: IDocument): Unit = {
+  override def applyProposal(document: IDocument): Unit = {
     for {
       icu <- targetSourceFile
       //we must open the editor before doing the refactoring on the compilation unit:

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/CreateClassProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/CreateClassProposal.scala
@@ -9,6 +9,7 @@ import org.eclipse.jface.wizard.WizardDialog
 import org.scalaide.ui.ScalaImages
 import org.scalaide.ui.internal.wizards.NewFileWizardAdapter
 import org.scalaide.core.quickassist.BasicCompletionProposal
+import org.scalaide.core.internal.statistics.Features.CreateClass
 
 /**
  * Opens a `NewFileWizard`, which has the class creator selected on startup. If
@@ -18,11 +19,12 @@ import org.scalaide.core.quickassist.BasicCompletionProposal
  */
 case class CreateClassProposal(className: String, compilationUnit: ICompilationUnit)
   extends BasicCompletionProposal(
+    feature = CreateClass,
     relevance = RelevanceValues.CreateClassProposal,
     displayString = s"Create class '$className'",
     image = ScalaImages.NEW_CLASS.createImage()) {
 
-  override def apply(document: IDocument): Unit = {
+  override def applyProposal(document: IDocument): Unit = {
     val wizard = new NewFileWizardAdapter("org.scalaide.ui.wizards.classCreator", className)
     wizard.init(JavaPlugin.getDefault().getWorkbench(), new StructuredSelection(compilationUnit))
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/FixSpellingMistake.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/FixSpellingMistake.scala
@@ -1,6 +1,7 @@
 package org.scalaide.core.internal.quickassist
 
 import org.eclipse.jdt.internal.ui.text.spelling.WordQuickFixProcessor
+import org.scalaide.core.internal.statistics.Features.FixSpellingMistake
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
 import org.scalaide.core.quickassist.QuickAssist
@@ -14,7 +15,7 @@ class FixSpellingMistake extends QuickAssist {
     val jctx = new JavaInvocationContextAdapter(ctx)
     val p = new WordQuickFixProcessor()
     Option(p.getCorrections(jctx, jctx.javaProblemLocations)).map{cs =>
-      cs.map(JavaProposalAdapter): Seq[BasicCompletionProposal]
+      cs.map(JavaProposalAdapter(FixSpellingMistake, _)): Seq[BasicCompletionProposal]
     }.getOrElse(Seq())
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/FixTypeMismatch.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/FixTypeMismatch.scala
@@ -5,6 +5,7 @@ import org.eclipse.jdt.ui.JavaUI
 import org.eclipse.jface.text.IDocument
 import org.eclipse.ui.texteditor.ITextEditor
 import org.scalaide.core.internal.quickassist.expand.ExpandingProposalBase
+import org.scalaide.core.internal.statistics.Features.FixTypeMismatch
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
 import org.scalaide.core.quickassist.QuickAssist
@@ -36,7 +37,7 @@ class FixTypeMismatch extends QuickAssist {
             // make markers message in form: "... =>replacement"
             val markersMessage = annotationString + ImplicitHighlightingPresenter.DisplayStringSeparator + replacementString
             // construct a proposal with the appropriate location
-            new ExpandingProposalBase(markersMessage, "Transform expression: ", offset, length)
+            new ExpandingProposalBase(FixTypeMismatch, markersMessage, "Transform expression: ", offset, length)
         }
       // no match found for the problem message
       case _ => Nil

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/ImportCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/ImportCompletionProposal.scala
@@ -7,13 +7,15 @@ import org.eclipse.jdt.ui.JavaUI
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.TextUtilities
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
+import org.scalaide.core.internal.statistics.Features.ImportMissingMember
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.logging.HasLogger
 import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.internal.eclipse.TextEditUtils
 
-case class ImportCompletionProposal(val importName: String)
+case class ImportCompletionProposal(importName: String)
     extends BasicCompletionProposal(
+        ImportMissingMember,
         relevance = RelevanceValues.ImportCompletionProposal,
         displayString = s"Import $importName",
         image = JavaUI.getSharedImages().getImage(ISharedImages.IMG_OBJS_IMPDECL))
@@ -24,7 +26,7 @@ case class ImportCompletionProposal(val importName: String)
    *
    * @param document the document into which to insert the proposed completion
    */
-  override def apply(document: IDocument): Unit = {
+  override def applyProposal(document: IDocument): Unit = {
     // First, try to insert with an AST transformation, if that fails, use the (old) method
     try {
       applyByASTTransformation(document)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/JavaQuickAssistAdapters.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/JavaQuickAssistAdapters.scala
@@ -10,6 +10,8 @@ import org.eclipse.jface.text.IDocument
 import org.scalaide.core.quickassist.AssistLocation
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
+import org.scalaide.core.internal.statistics.Features.NotSpecified
+import org.scalaide.core.internal.statistics.Features.Feature
 
 /**
  * Adapter for [[org.scalaide.core.quickassist.InvocationContext]] that
@@ -34,12 +36,13 @@ final class JavaInvocationContextAdapter(ctx: InvocationContext) extends IInvoca
  * Adapter for [[org.eclipse.jdt.ui.text.java.IJavaCompletionProposal]] that
  * implements [[org.scalaide.core.quickassist.BasicCompletionProposal]].
  */
-final case class JavaProposalAdapter(jcp: IJavaCompletionProposal)
+final case class JavaProposalAdapter(override val feature: Feature, jcp: IJavaCompletionProposal)
     extends BasicCompletionProposal(
+      feature = feature,
       relevance = jcp.getRelevance,
       displayString = jcp.getDisplayString,
       image = jcp.getImage) {
 
-  override def apply(document: IDocument): Unit =
+  override def applyProposal(document: IDocument): Unit =
     jcp.apply(document)
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/ProposalRefactoringHandlerAdapter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/ProposalRefactoringHandlerAdapter.scala
@@ -2,18 +2,20 @@ package org.scalaide.core.internal.quickassist
 
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.jface.text.IDocument
+import org.scalaide.core.internal.statistics.Features.Feature
+import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.refactoring.internal.RefactoringExecutor
 import org.scalaide.refactoring.internal.RefactoringHandler
 import org.scalaide.refactoring.internal.rename.Rename
-import org.scalaide.core.quickassist.BasicCompletionProposal
 
 abstract class ProposalRefactoringHandlerAdapter(
+    feature: Feature,
     handler: RefactoringHandler,
     displayString: String,
     relevance: Int = RelevanceValues.ProposalRefactoringHandlerAdapter)
-  extends BasicCompletionProposal(relevance, displayString) {
+  extends BasicCompletionProposal(feature, relevance, displayString) {
 
-  override def apply(document: IDocument): Unit =
+  override def applyProposal(document: IDocument): Unit =
     handler.perform()
 
   def isValidProposal: Boolean = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/QuickAssistHandler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/QuickAssistHandler.scala
@@ -14,6 +14,7 @@ import org.eclipse.jface.text.source.Annotation
 import org.eclipse.ui.IEditorInput
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.statistics.Features.NotSpecified
 import org.scalaide.core.quickassist.AssistLocation
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
@@ -44,8 +45,8 @@ final class QuickAssistHandler extends AbstractHandler {
  * This proposal should be shown when no other proposals are found. If no
  * proposals would be shown, the user wouldn't see a quick assist window at all.
  */
-object NoProposals extends BasicCompletionProposal(0, "No suggestions available") {
-  override def apply(doc: IDocument): Unit = ()
+object NoProposals extends BasicCompletionProposal(NotSpecified, 0, "No suggestions available") {
+  override def applyProposal(doc: IDocument): Unit = ()
 }
 
 object QuickAssistProcessor {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/abstractimpl/AbstractMemberProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/abstractimpl/AbstractMemberProposal.scala
@@ -1,32 +1,32 @@
 package org.scalaide.core.internal.quickassist.abstractimpl
 
-import scala.tools.nsc.interactive.Global
 import scala.tools.refactoring.implementations.AddMethodTarget
 
-import org.scalaide.core.compiler.InteractiveCompilationUnit
 import org.scalaide.core.compiler.IScalaPresentationCompiler
+import org.scalaide.core.compiler.InteractiveCompilationUnit
 import org.scalaide.core.internal.quickassist.AddFieldProposal
 import org.scalaide.core.internal.quickassist.AddMethodProposal
 import org.scalaide.core.internal.quickassist.AddValOrDefProposal
 import org.scalaide.core.internal.quickassist.createmethod.ParameterList
 import org.scalaide.core.internal.quickassist.createmethod.ReturnType
 import org.scalaide.core.internal.quickassist.createmethod.TypeParameterList
+import org.scalaide.core.internal.statistics.Features.CreateMethod
 
 object AbstractMemberProposal {
   def apply(global: IScalaPresentationCompiler)(abstrMethod: global.MethodSymbol, impl: global.ImplDef)(
     icu: Option[InteractiveCompilationUnit], addMethodTarget: AddMethodTarget) = {
 
-    new {
+    new AbstractMemberProposal {
       override val compiler: global.type = global
       override val targetSourceFile = icu
       override val abstractMethod = abstrMethod
       override val implDef = impl
       override val target = addMethodTarget
-    } with AbstractMemberProposal
+    }
   }
 }
 
-trait AbstractMemberProposal extends AddValOrDefProposal with AddMethodProposal with AddFieldProposal {
+abstract class AbstractMemberProposal extends AddValOrDefProposal(CreateMethod) with AddMethodProposal with AddFieldProposal {
   protected val compiler: IScalaPresentationCompiler
   import compiler._
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/changecase/ChangeCaseProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/changecase/ChangeCaseProposal.scala
@@ -5,6 +5,8 @@ import scala.reflect.internal.util.RangePosition
 
 import org.eclipse.jface.text.IDocument
 import org.scalaide.core.compiler.InteractiveCompilationUnit
+import org.scalaide.core.internal.quickassist.RelevanceValues
+import org.scalaide.core.internal.statistics.Features.FixSpellingMistake
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.ui.ScalaImages
 
@@ -13,11 +15,12 @@ import org.scalaide.ui.ScalaImages
  * Eg "asdf".subString would offer to change it to .substring instead.
  */
 case class ChangeCaseProposal(originalName: String, newName: String, offset: Int, length: Int) extends BasicCompletionProposal(
+  feature = FixSpellingMistake,
   relevance = RelevanceValues.ChangeCaseProposal,
   displayString = s"Change to '${newName}'",
   image = ScalaImages.CORRECTION_RENAME.createImage()) {
 
-  override def apply(document: IDocument): Unit = {
+  override def applyProposal(document: IDocument): Unit = {
     val o = offset + length - originalName.length
     document.replace(o, originalName.length, newName)
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/createmethod/CreateMethodProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/createmethod/CreateMethodProposal.scala
@@ -11,9 +11,12 @@ import org.scalaide.core.internal.quickassist.AddMethodProposal
 import org.scalaide.core.internal.quickassist.AddValOrDefProposal
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
 import org.scalaide.core.compiler.InteractiveCompilationUnit
+import org.scalaide.core.internal.statistics.Features.CreateMethod
 
-case class CreateMethodProposal(fullyQualifiedEnclosingType: Option[String], override val defName: String,
-  override val target: AddMethodTarget, icu: InteractiveCompilationUnit, offset: Int, length: Int) extends AddValOrDefProposal with AddMethodProposal {
+case class CreateMethodProposal(
+  fullyQualifiedEnclosingType: Option[String], override val defName: String,
+  override val target: AddMethodTarget, icu: InteractiveCompilationUnit, offset: Int, length: Int)
+    extends AddValOrDefProposal(CreateMethod) with AddMethodProposal {
 
   private val UnaryMethodNames = "+-!~".map("unary_" + _)
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/expand/ExpandCaseClassBinding.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/expand/ExpandCaseClassBinding.scala
@@ -1,13 +1,16 @@
 package org.scalaide.core.internal.quickassist
 package expand
 
+import org.scalaide.core.internal.statistics.Features
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
 import org.scalaide.core.quickassist.QuickAssist
 
 object ExpandCaseClassBindingProposal
   extends ProposalRefactoringHandlerAdapter(
-      new org.scalaide.refactoring.internal.ExpandCaseClassBinding, "Expand case class binding")
+      Features.ExpandCaseClassBinding,
+      new org.scalaide.refactoring.internal.ExpandCaseClassBinding,
+      Features.ExpandCaseClassBinding.description)
 
 class ExpandCaseClassBinding extends QuickAssist {
   override def compute(ctx: InvocationContext): Seq[BasicCompletionProposal] =

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/expand/ExpandImplicits.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/expand/ExpandImplicits.scala
@@ -1,17 +1,17 @@
 package org.scalaide.core.internal.quickassist
 package expand
 
-import org.eclipse.jface.text.Position
+import org.scalaide.core.internal.statistics.Features.ExpandImplicitArgument
+import org.scalaide.core.internal.statistics.Features.ExpandImplicitConversion
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
 import org.scalaide.core.quickassist.QuickAssist
-import org.scalaide.util.eclipse.EditorUtils
 
 class ImplicitConversionExpandingProposal(s: String, offset: Int, length: Int)
-  extends ExpandingProposalBase(s, "Expand this implicit conversion: ", offset, length)
+  extends ExpandingProposalBase(ExpandImplicitConversion, s, "Expand this implicit conversion: ", offset, length)
 
 class ImplicitArgumentExpandingProposal(s: String, offset: Int, length: Int)
-  extends ExpandingProposalBase(s, "Explicitly inline the implicit arguments: ", offset, length)
+  extends ExpandingProposalBase(ExpandImplicitArgument, s, "Explicitly inline the implicit arguments: ", offset, length)
 
 object ExpandImplicits {
   private final val ImplicitConversionFound = "(?s)Implicit conversion found: `(.*?)` => `(.*):.*?`".r

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/expand/ExpandingProposalBase.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/expand/ExpandingProposalBase.scala
@@ -4,16 +4,17 @@ package expand
 import org.eclipse.jface.text.IDocument
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.ui.internal.editor.decorators.implicits.ImplicitHighlightingPresenter
+import org.scalaide.core.internal.statistics.Features.Feature
 
-class ExpandingProposalBase(msg: String, displayString: String, offset: Int, length: Int)
-  extends BasicCompletionProposal(relevance = RelevanceValues.ExpandingProposalBase, displayString = displayString + msg) {
+class ExpandingProposalBase(feature: Feature, msg: String, displayString: String, offset: Int, length: Int)
+  extends BasicCompletionProposal(feature, relevance = RelevanceValues.ExpandingProposalBase, displayString = displayString + msg) {
 
   /**
    * Inserts the proposed completion into the given document.
    *
    * @param document the document into which to insert the proposed completion
    */
-  override def apply(document: IDocument): Unit = {
+  override def applyProposal(document: IDocument): Unit = {
     // We extract the replacement string from the marker's message.
     val ReplacementExtractor = s"(?s).*${ImplicitHighlightingPresenter.DisplayStringSeparator}(.*)".r
     val ReplacementExtractor(replacement) = msg

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/explicit/ExpandText.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/explicit/ExpandText.scala
@@ -1,12 +1,13 @@
 package org.scalaide.core.internal.quickassist.explicit
 
 import org.eclipse.jface.text.IDocument
+import org.scalaide.core.internal.statistics.Features.Feature
 import org.scalaide.core.quickassist.BasicCompletionProposal
 
 /** A generic completion proposal that inserts text at a given offset.
  */
-class ExpandText(relevance: Int, displayString: String, tpt: String, offset: Int) extends BasicCompletionProposal(relevance, displayString) {
-  override def apply(document: IDocument): Unit = {
+class ExpandText(feature: Feature, relevance: Int, displayString: String, tpt: String, offset: Int) extends BasicCompletionProposal(feature, relevance, displayString) {
+  override def applyProposal(document: IDocument): Unit = {
     document.replace(offset, 0, tpt)
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/explicit/ExplicitReturnType.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/explicit/ExplicitReturnType.scala
@@ -2,13 +2,13 @@ package org.scalaide.core.internal.quickassist.explicit
 
 import scala.reflect.internal.Chars
 import scala.tools.nsc.ast.parser.Tokens
-
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
 import org.scalaide.core.compiler.InteractiveCompilationUnit
 import org.scalaide.core.compiler.Token
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
 import org.scalaide.core.quickassist.QuickAssist
+import org.scalaide.core.internal.statistics.Features.ExplicitReturnType
 
 /** A quick fix that adds an explicit return type to a given val or def
  */
@@ -50,7 +50,7 @@ class ExplicitReturnType extends QuickAssist {
               if (Chars.isOperatorPart(sourceFile.content(insertion - 1))) " : "
               else ": "
 
-            Some(new ExpandText(150, s"Add explicit type $tpe", colonSpace + tpe, insertion))
+            Some(new ExpandText(ExplicitReturnType, 150, s"Add explicit type $tpe", colonSpace + tpe, insertion))
           } else None
         }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/extract/ExtractExpressions.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/extract/ExtractExpressions.scala
@@ -34,7 +34,7 @@ class ExtractExpressions extends QuickAssist {
         val pos = extraction.extractionTarget.enclosing.pos
 
         proposals += new ExtractionProposal(extraction.displayName, pos.start, pos.end, relevance) {
-          override def apply(doc: IDocument) = {
+          override def applyProposal(doc: IDocument) = {
             refactoring.perform(extraction) match {
               case Right((change: TextChange) :: Nil) =>
                 EditorUtils.doWithCurrentEditor { editor =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/inline/InlineLocal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/inline/InlineLocal.scala
@@ -1,13 +1,14 @@
 package org.scalaide.core.internal.quickassist
 package inline
 
+import org.scalaide.core.internal.statistics.Features.InlineLocalValue
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.core.quickassist.InvocationContext
 import org.scalaide.core.quickassist.QuickAssist
 
 object InlineLocalProposal
   extends ProposalRefactoringHandlerAdapter(
-      new org.scalaide.refactoring.internal.InlineLocal, "Inline local value")
+      InlineLocalValue, new org.scalaide.refactoring.internal.InlineLocal, InlineLocalValue.description)
 
 class InlineLocal extends QuickAssist {
   override def compute(ctx: InvocationContext): Seq[BasicCompletionProposal] =

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -1,0 +1,199 @@
+package org.scalaide.core.internal.statistics
+
+import java.io.File
+import java.io.FileWriter
+
+import scala.pickling.FastTypeTag
+import scala.pickling.PBuilder
+import scala.pickling.PReader
+import scala.pickling.Pickler
+import scala.pickling.Unpickler
+import scala.pickling.pickler.AllPicklers
+
+import org.scalaide.util.eclipse.EclipseUtils
+import org.scalaide.core.internal.statistics.Features.CopyQualifiedName
+import org.scalaide.core.internal.statistics.Features.ExplicitReturnType
+import Features._
+
+object Statistics {
+
+  val IdeConfigStore = new File(System.getProperty("user.home") + File.separator + ".scalaide")
+
+  val StatisticsFile = new File(IdeConfigStore.getAbsolutePath + File.separator + "statistics")
+
+}
+
+class Statistics {
+  import Statistics._
+  import scala.pickling.Defaults._
+  import scala.pickling.json._
+
+  private var cache = Map[Feature, Stat]()
+
+  readStats()
+
+  def data: Seq[Stat] = cache.values.toList
+
+  def incUses(feature: Feature): Unit = {
+    val stat = cache.get(feature).getOrElse(Stat(feature, 0, System.nanoTime))
+    cache += feature → stat.copy(nrOfUses = stat.nrOfUses + 1, lastUsed = System.nanoTime)
+
+    writeStats()
+  }
+
+  private def readStats(): Unit = {
+    EclipseUtils.withSafeRunner("Error while reading statistics from disk") {
+      import Picklers._
+      if (StatisticsFile.exists())
+        cache = read[Seq[Stat]](StatisticsFile).map(stat ⇒ stat.feature → stat)(collection.breakOut)
+      else
+        Seq()
+    }
+  }
+
+  private def writeStats(): Unit = {
+    val values: Seq[Stat] = cache.map(_._2)(collection.breakOut)
+
+    EclipseUtils.withSafeRunner("Error while writing statistics to disk") {
+      import Picklers._
+      if (!StatisticsFile.exists()) {
+        IdeConfigStore.mkdirs()
+        StatisticsFile.createNewFile()
+      }
+      write(StatisticsFile, values)
+    }
+  }
+
+  private def write[A : Pickler : Unpickler](file: File, value: A): Unit = {
+    val pickled = value.pickle
+    val json = pickled.value
+
+    new FileWriter(file).append(json).close()
+  }
+
+  private def read[A : Pickler : Unpickler](file: File): A = {
+    val readJson = io.Source.fromFile(file).mkString
+    val readPickled = pickling.json.JSONPickle(readJson)
+    readPickled.unpickle[A]
+  }
+}
+
+object Groups {
+  sealed abstract class Group(val description: String)
+  object Uncategorized extends Group("Uncategorized")
+  object QuickAssist extends Group("Quick Assist")
+  object Refactoring extends Group("Refactoring")
+  object CodeAssist extends Group("Code Assist")
+  object SaveAction extends Group("Save Action")
+  object AutoEdit extends Group("Auto Edit")
+  object Wizard extends Group("Wizard")
+}
+
+object Features {
+  import Groups._
+
+  sealed abstract class Feature(val description: String, val group: Group)
+  object ExplicitReturnType extends Feature("Add explicit return type", QuickAssist)
+  object CopyQualifiedName extends Feature("Copy qualified name", Uncategorized)
+  object RestartPresentationCompiler extends Feature("Restart Presentation Compiler", Uncategorized)
+}
+
+case class Stat(feature: Feature, nrOfUses: Int, lastUsed: Long)
+
+private object Picklers {
+  object fqn {
+    val fExplicitReturnType = FastTypeTag[ExplicitReturnType.type].key
+    val fCopyQualifiedName = FastTypeTag[CopyQualifiedName.type].key
+
+    def asString(c: Feature): String = c match {
+      case ExplicitReturnType ⇒ fExplicitReturnType
+      case CopyQualifiedName ⇒ fCopyQualifiedName
+    }
+
+    def fromString(s: String): Feature = s match {
+      case `fExplicitReturnType` ⇒ ExplicitReturnType
+      case `fCopyQualifiedName` ⇒ CopyQualifiedName
+    }
+  }
+
+  implicit class RichPReader(private val reader: PReader) extends AnyVal {
+    def readTypedField[A](name: String, reader: PReader ⇒ A): A =
+      reader(this.reader.readField(name))
+  }
+
+  /*
+   * scala-pickling should actually generate the implementation of this pickler
+   * but because its macros fall flat on their faces while doing this the
+   * implementation was written manually. One related issue is at least SI-7588.
+   */
+  implicit val statPickler: Pickler[Stat] with Unpickler[Stat] = new Pickler[Stat] with Unpickler[Stat] {
+    override val tag = FastTypeTag[Stat]
+
+    override def pickle(s: Stat, b: PBuilder): Unit = {
+      b.pushHints()
+      b.hintTag(tag)
+
+      b.beginEntry(s)
+      b.putField("feature", b ⇒ {
+        b.pushHints()
+        b.hintTag(FastTypeTag.String)
+        b.hintStaticallyElidedType()
+        AllPicklers.stringPickler.pickle(fqn.asString(s.feature), b)
+        b.popHints()
+      })
+      b.putField("nrOfUses", b ⇒ {
+        b.pushHints()
+        b.hintTag(FastTypeTag.Int)
+        b.hintStaticallyElidedType()
+        AllPicklers.intPickler.pickle(s.nrOfUses, b)
+        b.popHints()
+      })
+      b.putField("lastUsed", b ⇒ {
+        b.pushHints()
+        b.hintTag(FastTypeTag.Long)
+        b.hintStaticallyElidedType()
+        AllPicklers.longPickler.pickle(s.lastUsed, b)
+        b.popHints()
+      })
+      b.endEntry()
+
+      b.popHints()
+    }
+
+    override def unpickle(tag: String, r: PReader): Any = {
+      r.pushHints()
+      r.hintTag(this.tag)
+      r.beginEntry()
+
+      val feature = r.readTypedField("feature", r ⇒ {
+        r.pushHints()
+        r.hintTag(FastTypeTag.String)
+        r.hintStaticallyElidedType()
+        val s = AllPicklers.stringPickler.unpickleEntry(r).asInstanceOf[String]
+        r.popHints()
+        fqn.fromString(s)
+      })
+      val nrOfUses = r.readTypedField("nrOfUses", r ⇒ {
+        r.pushHints()
+        r.hintTag(FastTypeTag.Int)
+        r.hintStaticallyElidedType()
+        val i = AllPicklers.intPickler.unpickleEntry(r).asInstanceOf[Int]
+        r.popHints()
+        i
+      })
+      val lastUsed = r.readTypedField("lastUsed", r ⇒ {
+        r.pushHints()
+        r.hintTag(FastTypeTag.Long)
+        r.hintStaticallyElidedType()
+        val l = AllPicklers.longPickler.unpickleEntry(r).asInstanceOf[Long]
+        r.popHints()
+        l
+      })
+
+      r.endEntry()
+      r.popHints()
+      Stat(feature, nrOfUses, lastUsed)
+    }
+
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -70,7 +70,7 @@ class Statistics {
 
 object Groups {
   sealed abstract class Group(val description: String)
-  object Uncategorized extends Group("Uncategorized")
+  object Miscellaneous extends Group("Miscellaneous")
   object QuickAssist extends Group("Quick Assist")
   object Refactoring extends Group("Refactoring")
   object Editing extends Group("Editing")
@@ -94,10 +94,10 @@ object Features {
   object FixSpellingMistake extends Feature("Fix spelling mistake", QuickAssist)
   object CreateMethod extends Feature("Create method", QuickAssist)
   object ExtractCode extends Feature("Extract code", QuickAssist)
-  object CopyQualifiedName extends Feature("Copy qualified name", Uncategorized)
-  object RestartPresentationCompiler extends Feature("Restart Presentation Compiler", Uncategorized)
+  object CopyQualifiedName extends Feature("Copy qualified name", Miscellaneous)
+  object RestartPresentationCompiler extends Feature("Restart Presentation Compiler", Miscellaneous)
   /** Exists for backward compatibility with previous versions of the IDE. */
-  object NotSpecified extends Feature("<not specified>", Uncategorized)
+  object NotSpecified extends Feature("<not specified>", Miscellaneous)
   object CodeAssist extends Feature("Code completion", Editing)
   object CharactersSaved extends Feature("Number of typed characters saved thanks to code completion", Editing)
   object OrganizeImports extends Feature("Organize imports", Refactoring)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -36,9 +36,9 @@ class Statistics {
   def data: Seq[FeatureData] = cache.values.toList
   def startOfStats: Long = firstStat
 
-  def incUses(feature: Feature): Unit = {
+  def incUses(feature: Feature, numToInc: Int = 1): Unit = {
     val stat = cache.get(feature).getOrElse(FeatureData(feature, 0, System.currentTimeMillis))
-    cache += feature → stat.copy(nrOfUses = stat.nrOfUses + 1, lastUsed = System.currentTimeMillis)
+    cache += feature → stat.copy(nrOfUses = stat.nrOfUses + numToInc, lastUsed = System.currentTimeMillis)
 
     writeStats()
   }
@@ -87,7 +87,7 @@ object Groups {
   object Uncategorized extends Group("Uncategorized")
   object QuickAssist extends Group("Quick Assist")
   object Refactoring extends Group("Refactoring")
-  object CodeAssist extends Group("Code Assist")
+  object Editing extends Group("Editing")
   object SaveAction extends Group("Save Action")
   object AutoEdit extends Group("Auto Edit")
   object Wizard extends Group("Wizard")
@@ -112,6 +112,8 @@ object Features {
   object RestartPresentationCompiler extends Feature("Restart Presentation Compiler", Uncategorized)
   /** Exists for backward compatibility with previous versions of the IDE. */
   object NotSpecified extends Feature("<not specified>", Uncategorized)
+  object CodeAssist extends Feature("Code completion", Editing)
+  object CharactersSaved extends Feature("Number of typed characters saved thanks to code completion", Editing)
 }
 
 final case class StatData(firstStat: Long, featureData: Seq[FeatureData])
@@ -133,6 +135,8 @@ private object Picklers {
     val fCopyQualifiedName = FastTypeTag[CopyQualifiedName.type].key
     val fRestartPresentationCompiler = FastTypeTag[RestartPresentationCompiler.type].key
     val fNotSpecified = FastTypeTag[NotSpecified.type].key
+    val fCodeAssist = FastTypeTag[CodeAssist.type].key
+    val fCharactersSaved = FastTypeTag[CharactersSaved.type].key
 
     def asString(c: Feature): String = c match {
       case ExplicitReturnType          ⇒ fExplicitReturnType
@@ -149,6 +153,8 @@ private object Picklers {
       case CopyQualifiedName           ⇒ fCopyQualifiedName
       case RestartPresentationCompiler ⇒ fRestartPresentationCompiler
       case NotSpecified                ⇒ fNotSpecified
+      case CodeAssist                  ⇒ fCodeAssist
+      case CharactersSaved             ⇒ fCharactersSaved
     }
 
     def fromString(s: String): Feature = s match {
@@ -166,6 +172,8 @@ private object Picklers {
       case `fCopyQualifiedName`           ⇒ CopyQualifiedName
       case `fRestartPresentationCompiler` ⇒ RestartPresentationCompiler
       case `fNotSpecified`                ⇒ NotSpecified
+      case `fCodeAssist`                  ⇒ CodeAssist
+      case `fCharactersSaved`             ⇒ CharactersSaved
     }
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -94,8 +94,20 @@ object Features {
 
   sealed abstract class Feature(val description: String, val group: Group)
   object ExplicitReturnType extends Feature("Add explicit return type", QuickAssist)
+  object InlineLocalValue extends Feature("Inline local value", QuickAssist)
+  object ExpandCaseClassBinding extends Feature("Expand case class binding", QuickAssist)
+  object ExpandImplicitConversion extends Feature("Expand implicit conversion", QuickAssist)
+  object ExpandImplicitArgument extends Feature("Expand implicit argument", QuickAssist)
+  object FixTypeMismatch extends Feature("Fix type mismatch", QuickAssist)
+  object ImportMissingMember extends Feature("Import missing member", QuickAssist)
+  object CreateClass extends Feature("Create class", QuickAssist)
+  object FixSpellingMistake extends Feature("Fix spelling mistake", QuickAssist)
+  object CreateMethod extends Feature("Create method", QuickAssist)
+  object ExtractCode extends Feature("Extract code", QuickAssist)
   object CopyQualifiedName extends Feature("Copy qualified name", Uncategorized)
   object RestartPresentationCompiler extends Feature("Restart Presentation Compiler", Uncategorized)
+  /** Exists for backward compatibility with previous versions of the IDE. */
+  object NotSpecified extends Feature("<not specified>", Uncategorized)
 }
 
 case class Stat(feature: Feature, nrOfUses: Int, lastUsed: Long)
@@ -103,19 +115,52 @@ case class Stat(feature: Feature, nrOfUses: Int, lastUsed: Long)
 private object Picklers {
   object fqn {
     val fExplicitReturnType = FastTypeTag[ExplicitReturnType.type].key
+    val fInlineLocalValue = FastTypeTag[InlineLocalValue.type].key
+    val fExpandCaseClassBinding = FastTypeTag[ExpandCaseClassBinding.type].key
+    val fExpandImplicitConversion = FastTypeTag[ExpandImplicitConversion.type].key
+    val fExpandImplicitArgument = FastTypeTag[ExpandImplicitArgument.type].key
+    val fFixTypeMismatch = FastTypeTag[FixTypeMismatch.type].key
+    val fImportMissingMember = FastTypeTag[ImportMissingMember.type].key
+    val fCreateClass = FastTypeTag[CreateClass.type].key
+    val fFixSpellingMistake = FastTypeTag[FixSpellingMistake.type].key
+    val fCreateMethod = FastTypeTag[CreateMethod.type].key
+    val fExtractCode = FastTypeTag[ExtractCode.type].key
     val fCopyQualifiedName = FastTypeTag[CopyQualifiedName.type].key
     val fRestartPresentationCompiler = FastTypeTag[RestartPresentationCompiler.type].key
+    val fNotSpecified = FastTypeTag[NotSpecified.type].key
 
     def asString(c: Feature): String = c match {
-      case ExplicitReturnType ⇒ fExplicitReturnType
-      case CopyQualifiedName ⇒ fCopyQualifiedName
+      case ExplicitReturnType          ⇒ fExplicitReturnType
+      case InlineLocalValue            ⇒ fInlineLocalValue
+      case ExpandCaseClassBinding      ⇒ fExpandCaseClassBinding
+      case ExpandImplicitConversion    ⇒ fExpandImplicitConversion
+      case ExpandImplicitArgument      ⇒ fExpandImplicitArgument
+      case FixTypeMismatch             ⇒ fFixTypeMismatch
+      case ImportMissingMember         ⇒ fImportMissingMember
+      case CreateClass                 ⇒ fCreateClass
+      case FixSpellingMistake          ⇒ fFixSpellingMistake
+      case CreateMethod                ⇒ fCreateMethod
+      case ExtractCode                 ⇒ fExtractCode
+      case CopyQualifiedName           ⇒ fCopyQualifiedName
       case RestartPresentationCompiler ⇒ fRestartPresentationCompiler
+      case NotSpecified                ⇒ fNotSpecified
     }
 
     def fromString(s: String): Feature = s match {
-      case `fExplicitReturnType` ⇒ ExplicitReturnType
-      case `fCopyQualifiedName` ⇒ CopyQualifiedName
+      case `fExplicitReturnType`          ⇒ ExplicitReturnType
+      case `fInlineLocalValue`            ⇒ InlineLocalValue
+      case `fExpandCaseClassBinding`      ⇒ ExpandCaseClassBinding
+      case `fExpandImplicitConversion`    ⇒ ExpandImplicitConversion
+      case `fExpandImplicitArgument`      ⇒ ExpandImplicitArgument
+      case `fFixTypeMismatch`             ⇒ FixTypeMismatch
+      case `fImportMissingMember`         ⇒ ImportMissingMember
+      case `fCreateClass`                 ⇒ CreateClass
+      case `fFixSpellingMistake`          ⇒ FixSpellingMistake
+      case `fCreateMethod`                ⇒ CreateMethod
+      case `fExtractCode`                 ⇒ ExtractCode
+      case `fCopyQualifiedName`           ⇒ CopyQualifiedName
       case `fRestartPresentationCompiler` ⇒ RestartPresentationCompiler
+      case `fNotSpecified`                ⇒ NotSpecified
     }
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -34,6 +34,7 @@ class Statistics {
   readStats()
 
   def data: Seq[FeatureData] = cache.values.toList
+  def startOfStats: Long = firstStat
 
   def incUses(feature: Feature): Unit = {
     val stat = cache.get(feature).getOrElse(FeatureData(feature, 0, System.currentTimeMillis))

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -100,6 +100,17 @@ object Features {
   object NotSpecified extends Feature("<not specified>", Uncategorized)
   object CodeAssist extends Feature("Code completion", Editing)
   object CharactersSaved extends Feature("Number of typed characters saved thanks to code completion", Editing)
+  object OrganizeImports extends Feature("Organize imports", Refactoring)
+  object ExtractMemberToTrait extends Feature("Extract member to trait", Refactoring)
+  object MoveConstructorToCompanion extends Feature("Move constructor to companion object", Refactoring)
+  object GenerateHashcodeAndEquals extends Feature("Generate hashCode and equals method", Refactoring)
+  object IntroduceProductNTrait extends Feature("Introduce ProductN trait", Refactoring)
+  object LocalRename extends Feature("Rename local value", Refactoring)
+  object GlobalRename extends Feature("Rename global value", Refactoring)
+  object MoveClass extends Feature("Move class/object/trait", Refactoring)
+  object SplitParameterLists extends Feature("Split parameter lists", Refactoring)
+  object MergeParameterLists extends Feature("Merge parameter lists", Refactoring)
+  object ChangeParameterOrder extends Feature("Change parameter order", Refactoring)
 }
 
 final case class StatData(firstStat: Long, featureData: Seq[FeatureData])
@@ -123,6 +134,17 @@ private object Picklers {
     val fNotSpecified = FastTypeTag[NotSpecified.type].key
     val fCodeAssist = FastTypeTag[CodeAssist.type].key
     val fCharactersSaved = FastTypeTag[CharactersSaved.type].key
+    val fOrganizeImports = FastTypeTag[OrganizeImports.type].key
+    val fExtractMemberToTrait = FastTypeTag[ExtractMemberToTrait.type].key
+    val fMoveConstructorToCompanion = FastTypeTag[MoveConstructorToCompanion.type].key
+    val fGenerateHashcodeAndEquals = FastTypeTag[GenerateHashcodeAndEquals.type].key
+    val fIntroduceProductNTrait = FastTypeTag[IntroduceProductNTrait.type].key
+    val fLocalRename = FastTypeTag[LocalRename.type].key
+    val fGlobalRename = FastTypeTag[GlobalRename.type].key
+    val fMoveClass = FastTypeTag[MoveClass.type].key
+    val fSplitParameterLists = FastTypeTag[SplitParameterLists.type].key
+    val fMergeParameterLists = FastTypeTag[MergeParameterLists.type].key
+    val fChangeParameterOrder = FastTypeTag[ChangeParameterOrder.type].key
 
     def asString(c: Feature): String = c match {
       case ExplicitReturnType          ⇒ fExplicitReturnType
@@ -141,6 +163,17 @@ private object Picklers {
       case NotSpecified                ⇒ fNotSpecified
       case CodeAssist                  ⇒ fCodeAssist
       case CharactersSaved             ⇒ fCharactersSaved
+      case OrganizeImports             ⇒ fOrganizeImports
+      case ExtractMemberToTrait        ⇒ fExtractMemberToTrait
+      case MoveConstructorToCompanion  ⇒ fMoveConstructorToCompanion
+      case GenerateHashcodeAndEquals   ⇒ fGenerateHashcodeAndEquals
+      case IntroduceProductNTrait      ⇒ fIntroduceProductNTrait
+      case LocalRename                 ⇒ fLocalRename
+      case GlobalRename                ⇒ fGlobalRename
+      case MoveClass                   ⇒ fMoveClass
+      case SplitParameterLists         ⇒ fSplitParameterLists
+      case MergeParameterLists         ⇒ fMergeParameterLists
+      case ChangeParameterOrder        ⇒ fChangeParameterOrder
     }
 
     def fromString(s: String): Feature = s match {
@@ -160,6 +193,17 @@ private object Picklers {
       case `fNotSpecified`                ⇒ NotSpecified
       case `fCodeAssist`                  ⇒ CodeAssist
       case `fCharactersSaved`             ⇒ CharactersSaved
+      case `fOrganizeImports`             ⇒ OrganizeImports
+      case `fExtractMemberToTrait`        ⇒ ExtractMemberToTrait
+      case `fMoveConstructorToCompanion`  ⇒ MoveConstructorToCompanion
+      case `fGenerateHashcodeAndEquals`   ⇒ GenerateHashcodeAndEquals
+      case `fIntroduceProductNTrait`      ⇒ IntroduceProductNTrait
+      case `fLocalRename`                 ⇒ LocalRename
+      case `fGlobalRename`                ⇒ GlobalRename
+      case `fMoveClass`                   ⇒ MoveClass
+      case `fSplitParameterLists`         ⇒ SplitParameterLists
+      case `fMergeParameterLists`         ⇒ MergeParameterLists
+      case `fChangeParameterOrder`        ⇒ ChangeParameterOrder
     }
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -36,8 +36,8 @@ class Statistics {
   def data: Seq[FeatureData] = cache.values.toList
 
   def incUses(feature: Feature): Unit = {
-    val stat = cache.get(feature).getOrElse(FeatureData(feature, 0, System.nanoTime))
-    cache += feature → stat.copy(nrOfUses = stat.nrOfUses + 1, lastUsed = System.nanoTime)
+    val stat = cache.get(feature).getOrElse(FeatureData(feature, 0, System.currentTimeMillis))
+    cache += feature → stat.copy(nrOfUses = stat.nrOfUses + 1, lastUsed = System.currentTimeMillis)
 
     writeStats()
   }
@@ -54,7 +54,7 @@ class Statistics {
   }
 
   private def writeStats(): Unit = {
-    if (firstStat == 0) firstStat = System.nanoTime
+    if (firstStat == 0) firstStat = System.currentTimeMillis
     val stats = StatData(firstStat, cache.map(_._2)(collection.breakOut))
 
     EclipseUtils.withSafeRunner("Error while writing statistics to disk") {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/statistics/Statistics.scala
@@ -104,15 +104,18 @@ private object Picklers {
   object fqn {
     val fExplicitReturnType = FastTypeTag[ExplicitReturnType.type].key
     val fCopyQualifiedName = FastTypeTag[CopyQualifiedName.type].key
+    val fRestartPresentationCompiler = FastTypeTag[RestartPresentationCompiler.type].key
 
     def asString(c: Feature): String = c match {
       case ExplicitReturnType ⇒ fExplicitReturnType
       case CopyQualifiedName ⇒ fCopyQualifiedName
+      case RestartPresentationCompiler ⇒ fRestartPresentationCompiler
     }
 
     def fromString(s: String): Feature = s match {
       case `fExplicitReturnType` ⇒ ExplicitReturnType
       case `fCopyQualifiedName` ⇒ CopyQualifiedName
+      case `fRestartPresentationCompiler` ⇒ RestartPresentationCompiler
     }
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/quickassist/BasicCompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/quickassist/BasicCompletionProposal.scala
@@ -5,10 +5,14 @@ import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.contentassist.IContextInformation
 import org.eclipse.swt.graphics.Image
 import org.eclipse.swt.graphics.Point
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.statistics.Features._
 
 /**
  * Models an entry in the quick assist proposal.
  *
+ * @param feature
+ *        The association with the statistic tracking system of the IDE.
  * @param relevance
  *        Denotes at which position in among all available entries this entry
  *        occurs. A higher value means a better position.
@@ -18,11 +22,31 @@ import org.eclipse.swt.graphics.Point
  *        An image shown beside the `displayString`. If this is `null` no image
  *        is shown.
  */
-abstract class BasicCompletionProposal(relevance: Int, displayString: String, image: Image = null) extends IJavaCompletionProposal {
+abstract class BasicCompletionProposal(val feature: Feature, relevance: Int, displayString: String, image: Image = null) extends IJavaCompletionProposal {
+
+  @deprecated("use primary constructor instead", "4.1")
+  def this(relevance: Int, displayString: String) =
+    this(NotSpecified, relevance, displayString, null)
+
+  @deprecated("use primary constructor instead", "4.1")
+  def this(relevance: Int, displayString: String, image: Image) =
+    this(NotSpecified, relevance, displayString, image)
+
   override def getRelevance(): Int = relevance
   override def getDisplayString(): String = displayString
   override def getSelection(document: IDocument): Point = null
   override def getAdditionalProposalInfo(): String = null
   override def getImage(): Image = image
   override def getContextInformation(): IContextInformation = null
+
+  final override def apply(doc: IDocument): Unit = {
+    ScalaPlugin().statistics.incUses(feature)
+    applyProposal(doc)
+  }
+
+  /**
+   * This method is automatically called by the IDE, whenever the proposal needs
+   * to be applied to `doc`.
+   */
+  def applyProposal(doc: IDocument): Unit
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ExpandCaseClassBinding.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ExpandCaseClassBinding.scala
@@ -1,7 +1,9 @@
 package org.scalaide.refactoring.internal
 
 import scala.tools.refactoring.implementations
+
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.NotSpecified
 
 /**
  * A refactoring that expands bindings to case-classes in pattern matches with
@@ -14,7 +16,8 @@ class ExpandCaseClassBinding extends RefactoringExecutor with RefactoringExecuto
     new ExpandCaseClassBindingScalaIdeRefactoring(selectionStart, selectionEnd, file)
 
   class ExpandCaseClassBindingScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-    extends ScalaIdeRefactoring("Expand Case Class Binding", file, start, end) {
+    // feature is [[NotSpecified]] because the refactoring is already counted as quick assist
+    extends ScalaIdeRefactoring(NotSpecified, "Expand Case Class Binding", file, start, end) {
 
     val refactoring = file.withSourceFile((_, compiler) => new implementations.ExpandCaseClassBinding {
       val global = compiler

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ExtractTrait.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ExtractTrait.scala
@@ -1,6 +1,5 @@
 package org.scalaide.refactoring.internal
 
-import org.scalaide.refactoring.internal.ui.ExtractTraitConfigurationPageGenerator
 import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.common.NewFileChange
 import scala.tools.refactoring.common.TextChange
@@ -11,8 +10,9 @@ import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.jdt.internal.corext.refactoring.nls.changes.CreateFileChange
 import org.eclipse.ltk.core.refactoring.{Change => EclipseChange}
 import org.eclipse.ltk.core.refactoring.CompositeChange
-
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.ExtractMemberToTrait
+import org.scalaide.refactoring.internal.ui.ExtractTraitConfigurationPageGenerator
 
 /**
  * The ExtractTrait refactoring extracts members (vals, vars and defs) of a class
@@ -25,7 +25,7 @@ class ExtractTrait extends RefactoringExecutorWithWizard {
   def createRefactoring(selectionStart: Int, selectionEnd: Int, file: ScalaSourceFile) = new ExtractTraitScalaIdeRefactoring(selectionStart, selectionEnd, file)
 
   class ExtractTraitScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-    extends ScalaIdeRefactoring("Extract trait", file, start, end) with ExtractTraitConfigurationPageGenerator {
+    extends ScalaIdeRefactoring(ExtractMemberToTrait, "Extract trait", file, start, end) with ExtractTraitConfigurationPageGenerator {
 
     val refactoring = withCompiler { c =>
       new implementations.ExtractTrait with GlobalIndexes {

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/IndexedRefactorings.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/IndexedRefactorings.scala
@@ -1,11 +1,13 @@
 package org.scalaide.refactoring.internal
 
-import org.scalaide.core.IScalaProject
-import org.scalaide.core.internal.jdt.model.ScalaSourceFile
 import scala.tools.refactoring.MultiStageRefactoring
 import scala.tools.refactoring.analysis.GlobalIndexes
+
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.ltk.core.refactoring.RefactoringStatus
+import org.scalaide.core.IScalaProject
+import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.Feature
 
 /**
  * Helper trait that adds an index variable to a refactoring.
@@ -21,8 +23,8 @@ trait Indexed {
 /**
  * Abstract ScalaIdeRefactoring for refactorings that need an index of the full project.
  */
-abstract class IndexedIdeRefactoring(refactoringName: String, start: Int, end: Int, sourcefile: ScalaSourceFile)
-  extends ScalaIdeRefactoring(refactoringName, sourcefile, start, end) with FullProjectIndex {
+abstract class IndexedIdeRefactoring(feature: Feature, refactoringName: String, start: Int, end: Int, sourcefile: ScalaSourceFile)
+  extends ScalaIdeRefactoring(feature, refactoringName, sourcefile, start, end) with FullProjectIndex {
 
   val project: IScalaProject = sourcefile.scalaProject
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/InlineLocal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/InlineLocal.scala
@@ -3,6 +3,7 @@ package org.scalaide.refactoring.internal
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
 import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.implementations
+import org.scalaide.core.internal.statistics.Features.NotSpecified
 
 /**
  * The Inline Local -- also known as Inline Temp -- refactoring is the dual to Extract Local.
@@ -17,7 +18,8 @@ class InlineLocal extends RefactoringExecutor with RefactoringExecutorWithoutWiz
     new InlineLocalScalaIdeRefactoring(selectionStart, selectionEnd, file)
 
   class InlineLocalScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-      extends ScalaIdeRefactoring("Inline Local", file, start, end) {
+      // feature marked as [[NotSpecified]] because it is already categorized as quick assist
+      extends ScalaIdeRefactoring(NotSpecified, "Inline Local", file, start, end) {
 
     val refactoring = file.withSourceFile((sourceFile, compiler) => new implementations.InlineLocal with GlobalIndexes {
       val global = compiler

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/MoveConstructorToCompanionObject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/MoveConstructorToCompanionObject.scala
@@ -1,8 +1,10 @@
 package org.scalaide.refactoring.internal
 
-import org.scalaide.core.internal.jdt.model.ScalaSourceFile
 import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.implementations
+
+import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.MoveConstructorToCompanion
 
 /**
  * This refactoring redirects calls to the primary constructor to the
@@ -14,7 +16,7 @@ class MoveConstructorToCompanionObject extends RefactoringExecutorWithWizard {
   def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new MoveConstructorToCompanionObjectIdeRefactoring(start, end, file)
 
   class MoveConstructorToCompanionObjectIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-    extends IndexedIdeRefactoring("Move constructor to companion object", start, end, file) {
+    extends IndexedIdeRefactoring(MoveConstructorToCompanion, "Move constructor to companion object", start, end, file) {
 
     val refactoring = withCompiler { compiler =>
       new implementations.MoveConstructorToCompanionObject with GlobalIndexes with Indexed {
@@ -23,7 +25,6 @@ class MoveConstructorToCompanionObject extends RefactoringExecutorWithWizard {
     }
 
     val refactoringParameters = new refactoring.RefactoringParameters
-
 
     override def indexHints() = {
       val classdef = preparationResult.right.toOption

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
@@ -2,7 +2,9 @@ package org.scalaide.refactoring.internal
 
 import java.text.Collator
 import java.util.Comparator
+
 import scala.tools.refactoring.implementations
+
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.core.compiler.IProblem
@@ -18,6 +20,7 @@ import org.eclipse.jface.window.Window
 import org.scalaide.core.internal.jdt.model.LazyToplevelClass
 import org.scalaide.core.internal.jdt.model.ScalaElement
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.OrganizeImports
 import org.scalaide.ui.internal.preferences.OrganizeImportsPreferences._
 import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.internal.eclipse.TextEditUtils
@@ -212,7 +215,7 @@ class OrganizeImports extends RefactoringExecutorWithoutWizard {
     }
   }
 
-  class OrganizeImportsScalaIdeRefactoring(file: ScalaSourceFile) extends ScalaIdeRefactoring("Organize Imports", file, 0, 0) {
+  class OrganizeImportsScalaIdeRefactoring(file: ScalaSourceFile) extends ScalaIdeRefactoring(OrganizeImports, "Organize Imports", file, 0, 0) {
 
     lazy val compilationUnitHasProblems = file.getProblems != null && file.getProblems.exists(_.isError)
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ScalaIdeRefactoring.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/ScalaIdeRefactoring.scala
@@ -28,6 +28,8 @@ import org.eclipse.core.runtime.Path
 import org.eclipse.core.runtime.IPath
 import scala.reflect.io.AbstractFile
 import org.eclipse.core.resources.ResourcesPlugin
+import org.scalaide.core.internal.statistics.Features.Feature
+import org.scalaide.core.internal.ScalaPlugin
 
 /**
  * This is the abstract base class for all the concrete refactoring instances.
@@ -53,7 +55,7 @@ import org.eclipse.core.resources.ResourcesPlugin
  * @param getName The displayable name of this refactoring.
  * @param file The file this refactoring started from.
  */
-abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFile, selectionStart: Int, selectionEnd: Int)
+abstract class ScalaIdeRefactoring(val feature: Feature, val getName: String, val file: ScalaSourceFile, selectionStart: Int, selectionEnd: Int)
   extends LTKRefactoring with UserPreferencesFormatting {
 
   /**
@@ -162,6 +164,7 @@ abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFil
    * @return The list of changes or an empty list when an error occurred.
    */
   private [refactoring] def performRefactoring(): List[Change] = {
+    ScalaPlugin().statistics.incUses(feature)
 
     val params = refactoringParameters
     val sel = selection()
@@ -198,8 +201,8 @@ abstract class ScalaIdeRefactoring(val getName: String, val file: ScalaSourceFil
  * Should be extended by Scala IDE refactorings that mixin
  * [[import scala.tools.refactoring.ParameterlessRefactoring]].
  */
-abstract class ParameterlessScalaIdeRefactoring(getName: String, file: ScalaSourceFile, selectionStart: Int, selectionEnd: Int)
-  extends ScalaIdeRefactoring(getName, file, selectionStart, selectionEnd) {
+abstract class ParameterlessScalaIdeRefactoring(feature: Feature, getName: String, file: ScalaSourceFile, selectionStart: Int, selectionEnd: Int)
+  extends ScalaIdeRefactoring(feature, getName, file, selectionStart, selectionEnd) {
 
   override val refactoring: MultiStageRefactoring with InteractiveScalaCompiler with ParameterlessRefactoring
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/ExtractionExecutor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/ExtractionExecutor.scala
@@ -116,7 +116,7 @@ trait ExtractionExecutor extends RefactoringExecutor {
           val proposals = es.extractions.map { e =>
             val pos = e.extractionTarget.enclosing.pos
             new ExtractionProposal(e.displayName, pos.start, pos.end) {
-              def apply(doc: IDocument) = {
+              def applyProposal(doc: IDocument) = {
                 block(Some(e))
               }
             }

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/ExtractionExecutor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/ExtractionExecutor.scala
@@ -3,6 +3,7 @@ package org.scalaide.refactoring.internal.extract
 import scala.tools.refactoring.common.InteractiveScalaCompiler
 import scala.tools.refactoring.common.TextChange
 import scala.tools.refactoring.implementations.extraction.ExtractionRefactoring
+
 import org.eclipse.jface.dialogs.IDialogConstants
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.ITextViewer
@@ -15,6 +16,7 @@ import org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation
 import org.eclipse.swt.widgets.Shell
 import org.eclipse.ui.PlatformUI
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.NotSpecified
 import org.scalaide.refactoring.internal.RefactoringExecutor
 import org.scalaide.refactoring.internal.ScalaIdeRefactoring
 import org.scalaide.util.eclipse.EditorUtils
@@ -22,7 +24,8 @@ import org.scalaide.util.internal.eclipse.TextEditUtils
 
 trait ExtractionExecutor extends RefactoringExecutor {
   abstract class ScalaIdeExtractionRefactoring(selectionStart: Int, selectionEnd: Int, file: ScalaSourceFile)
-    extends ScalaIdeRefactoring("Extract...", file, selectionStart, selectionEnd) {
+    // feature is [[NotSpecified]] because it is already categorized as quick assist
+    extends ScalaIdeRefactoring(NotSpecified, "Extract...", file, selectionStart, selectionEnd) {
     val refactoring: ExtractionRefactoring with InteractiveScalaCompiler
 
     var selectedExtraction: Option[refactoring.Extraction] = None

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/ExtractionProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/extract/ExtractionProposal.scala
@@ -6,11 +6,12 @@ import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.ITextViewer
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension2
 import org.eclipse.ui.IFileEditorInput
+import org.scalaide.core.internal.statistics.Features.ExtractCode
 import org.scalaide.core.quickassist.BasicCompletionProposal
 import org.scalaide.util.eclipse.EditorUtils
 
 abstract class ExtractionProposal(displayString: String, hightlightFrom: Int, highlightTo: Int, relevance: Int = 0)
-  extends BasicCompletionProposal(relevance, displayString) with ICompletionProposalExtension2 {
+  extends BasicCompletionProposal(ExtractCode, relevance, displayString) with ICompletionProposalExtension2 {
 
   private var markerOpt: Option[IMarker] = None
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/ChangeParameterOrder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/ChangeParameterOrder.scala
@@ -4,7 +4,8 @@ package method
 import scala.tools.refactoring.implementations
 
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.scalaide.refactoring.internal.method.ui.ChangeParameterOrderConfigurationPageGenerator
+import org.scalaide.core.internal.statistics.Features.ChangeParameterOrder
+import ui.ChangeParameterOrderConfigurationPageGenerator
 
 /**
  * A method signature refactoring that changes the order of parameters within
@@ -16,7 +17,7 @@ class ChangeParameterOrder extends RefactoringExecutorWithWizard {
   def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new ChangeParameterOrderIdeRefactoring(start, end, file)
 
   class ChangeParameterOrderIdeRefactoring(start: Int, end: Int, f: ScalaSourceFile)
-    extends MethodSignatureIdeRefactoring("Change parameter order", start, end, f) with ChangeParameterOrderConfigurationPageGenerator {
+    extends MethodSignatureIdeRefactoring(ChangeParameterOrder, "Change parameter order", start, end, f) with ChangeParameterOrderConfigurationPageGenerator {
 
     override val refactoring = withCompiler { compiler =>
       new implementations.ChangeParamOrder with IndexedMethodSignatureRefactoring {

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/MergeParameterLists.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/MergeParameterLists.scala
@@ -4,7 +4,8 @@ package method
 import scala.tools.refactoring.implementations
 
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.scalaide.refactoring.internal.method.ui.MergeParameterListsConfigurationPageGenerator
+import org.scalaide.core.internal.statistics.Features.MergeParameterLists
+import ui.MergeParameterListsConfigurationPageGenerator
 
 /**
  * A method signature refactoring that merges selected parameter lists of a method.
@@ -15,7 +16,7 @@ class MergeParameterLists extends RefactoringExecutorWithWizard {
   def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new MergeParameterListsIdeRefactoring(start, end, file)
 
   class MergeParameterListsIdeRefactoring(start: Int, end: Int, f: ScalaSourceFile)
-    extends MethodSignatureIdeRefactoring("Merge parameter lists", start, end, f) with MergeParameterListsConfigurationPageGenerator {
+    extends MethodSignatureIdeRefactoring(MergeParameterLists, "Merge parameter lists", start, end, f) with MergeParameterListsConfigurationPageGenerator {
 
     override val refactoring = withCompiler { compiler =>
       new implementations.MergeParameterLists with IndexedMethodSignatureRefactoring {

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/MethodSignatureIdeRefactoring.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/MethodSignatureIdeRefactoring.scala
@@ -9,13 +9,14 @@ import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.implementations.MethodSignatureRefactoring
 import org.eclipse.ltk.ui.refactoring.UserInputWizardPage
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardPage
+import org.scalaide.core.internal.statistics.Features.Feature
 
 /**
  * Abstract refactoring that contains common functionality of method signature
  * refactorings.
  */
-abstract class MethodSignatureIdeRefactoring(refactoringName: String, start: Int, end: Int, file: ScalaSourceFile)
-  extends IndexedIdeRefactoring(refactoringName, start, end, file) {
+abstract class MethodSignatureIdeRefactoring(feature: Feature, refactoringName: String, start: Int, end: Int, file: ScalaSourceFile)
+  extends IndexedIdeRefactoring(feature, refactoringName, start, end, file) {
 
   // Provides the wizard page
   this: MethodSignatureRefactoringConfigurationPageGenerator =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/SplitParameterLists.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/method/SplitParameterLists.scala
@@ -4,8 +4,8 @@ package method
 import scala.tools.refactoring.implementations
 
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.scalaide.refactoring.internal.RefactoringExecutorWithWizard
-import org.scalaide.refactoring.internal.method.ui.SplitParameterListsConfigurationPageGenerator
+import org.scalaide.core.internal.statistics.Features.SplitParameterLists
+import ui.SplitParameterListsConfigurationPageGenerator
 
 /**
  * A method signature refactoring that splits parameter lists of a method.
@@ -16,7 +16,7 @@ class SplitParameterLists extends RefactoringExecutorWithWizard {
   def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new SplitParameterListsIdeRefactoring(start, end, file)
 
   class SplitParameterListsIdeRefactoring(start: Int, end: Int, f: ScalaSourceFile)
-    extends MethodSignatureIdeRefactoring("Split parameter lists", start, end, f) with SplitParameterListsConfigurationPageGenerator {
+    extends MethodSignatureIdeRefactoring(SplitParameterLists, "Split parameter lists", start, end, f) with SplitParameterListsConfigurationPageGenerator {
 
     override val refactoring = withCompiler { compiler =>
       new implementations.SplitParameterLists with IndexedMethodSignatureRefactoring {

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/move/MoveClass.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/move/MoveClass.scala
@@ -1,6 +1,7 @@
 package org.scalaide.refactoring.internal
 package move
 
+import scala.language.reflectiveCalls
 import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.common.ConsoleTracing
 import scala.tools.refactoring.common.NewFileChange
@@ -16,9 +17,7 @@ import org.eclipse.ltk.core.refactoring.CompositeChange
 import org.eclipse.ltk.core.refactoring.RefactoringStatus
 import org.eclipse.ltk.core.refactoring.resource.MoveResourceChange
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.scalaide.refactoring.internal.FullProjectIndex
-import org.scalaide.refactoring.internal.RefactoringExecutorWithWizard
-import org.scalaide.refactoring.internal.ScalaIdeRefactoring
+import org.scalaide.core.internal.statistics.Features.MoveClass
 
 /**
  * The Move Class refactoring moves (non-nested) classes, objects and traits between different
@@ -33,7 +32,7 @@ class MoveClass extends RefactoringExecutorWithWizard {
   def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new MoveClassScalaIdeRefactoring(start, end, file)
 
   class MoveClassScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-      extends ScalaIdeRefactoring("Move Class/Trait/Object", file, start, end) with FullProjectIndex {
+      extends ScalaIdeRefactoring(MoveClass, "Move Class/Trait/Object", file, start, end) with FullProjectIndex {
 
     val project = file.scalaProject
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/rename/GlobalRename.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/rename/GlobalRename.scala
@@ -1,19 +1,17 @@
 package org.scalaide.refactoring.internal
 package rename
 
+import scala.language.reflectiveCalls
 import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.analysis.NameValidation
 import scala.tools.refactoring.implementations
-import org.eclipse.core.resources.IFile
+
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.ltk.core.refactoring.RefactoringStatus
-import org.eclipse.ltk.core.refactoring.resource.RenameResourceChange
-import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.scalaide.refactoring.internal.FullProjectIndex
-import org.scalaide.refactoring.internal.RefactoringExecutorWithWizard
-import org.scalaide.refactoring.internal.ScalaIdeRefactoring
-import org.scalaide.refactoring.internal.ui.NewNameWizardPage
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
+import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.GlobalRename
+import org.scalaide.refactoring.internal.ui.NewNameWizardPage
 
 /**
  * This refactoring is used for all global rename refactorings and also from
@@ -27,7 +25,7 @@ class GlobalRename extends RefactoringExecutorWithWizard {
   def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new RenameScalaIdeRefactoring(start, end, file)
 
   class RenameScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-    extends ScalaIdeRefactoring("Rename", file, start, end) with FullProjectIndex {
+    extends ScalaIdeRefactoring(GlobalRename, "Rename", file, start, end) with FullProjectIndex {
 
     val project = file.scalaProject
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/rename/LocalRename.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/rename/LocalRename.scala
@@ -5,8 +5,7 @@ import scala.tools.refactoring.analysis.GlobalIndexes
 import scala.tools.refactoring.implementations
 
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.scalaide.refactoring.internal.RefactoringExecutor
-import org.scalaide.refactoring.internal.ScalaIdeRefactoring
+import org.scalaide.core.internal.statistics.Features.LocalRename
 import org.scalaide.util.eclipse.EditorUtils
 
 /**
@@ -20,7 +19,8 @@ class LocalRename extends RefactoringExecutor {
 
   def createRefactoring(start: Int, end: Int, file: ScalaSourceFile) = new RenameScalaIdeRefactoring(start, end, file)
 
-  class RenameScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile) extends ScalaIdeRefactoring("Inline Rename", file, start, end) {
+  class RenameScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
+      extends ScalaIdeRefactoring(LocalRename, "Inline Rename", file, start, end) {
 
     def refactoringParameters = ""
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/ClassParameterDrivenIdeRefactoring.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/ClassParameterDrivenIdeRefactoring.scala
@@ -1,9 +1,11 @@
 package org.scalaide.refactoring.internal.source
 
-import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.scalaide.refactoring.internal.ScalaIdeRefactoring
 import scala.tools.refactoring.implementations.ClassParameterDrivenSourceGeneration
+
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardPage
+import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.Feature
+import org.scalaide.refactoring.internal.ScalaIdeRefactoring
 
 /**
  * Abstract refactoring for common functionality of refactorings that
@@ -11,8 +13,8 @@ import org.eclipse.ltk.ui.refactoring.RefactoringWizardPage
  * @see GenerateHashcodeAndEquals
  * @see IntroduceProductNTrait
  */
-abstract class ClassParameterDrivenIdeRefactoring(name: String, start: Int, end: Int, sourcefile: ScalaSourceFile)
-  extends ScalaIdeRefactoring(name, sourcefile, start, end) {
+abstract class ClassParameterDrivenIdeRefactoring(feature: Feature, name: String, start: Int, end: Int, sourcefile: ScalaSourceFile)
+  extends ScalaIdeRefactoring(feature, name, sourcefile, start, end) {
 
   val refactoring: ClassParameterDrivenSourceGeneration
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/GenerateHashcodeAndEquals.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/GenerateHashcodeAndEquals.scala
@@ -5,6 +5,7 @@ import scala.tools.refactoring.implementations
 
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardPage
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.GenerateHashcodeAndEquals
 import org.scalaide.refactoring.internal.RefactoringExecutorWithWizard
 
 import ui.GenerateHashcodeAndEqualsConfigurationPageGenerator
@@ -19,7 +20,7 @@ class GenerateHashcodeAndEquals extends RefactoringExecutorWithWizard {
   def createRefactoring(selectionStart: Int, selectionEnd: Int, file: ScalaSourceFile) = new GenerateHashcodeAndEqualsScalaIdeRefactoring(selectionStart, selectionEnd, file)
 
   class GenerateHashcodeAndEqualsScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-    extends ClassParameterDrivenIdeRefactoring("Generate hashCode and equals", start, end, file) with GenerateHashcodeAndEqualsConfigurationPageGenerator {
+    extends ClassParameterDrivenIdeRefactoring(GenerateHashcodeAndEquals, "Generate hashCode and equals", start, end, file) with GenerateHashcodeAndEqualsConfigurationPageGenerator {
 
     val refactoring = withCompiler { c =>
       new implementations.GenerateHashcodeAndEquals {

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/IntroduceProductNTrait.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/IntroduceProductNTrait.scala
@@ -19,13 +19,13 @@ import ui.IntroduceProductNTraitConfigurationPageGenerator
  */
 class IntroduceProductNTrait extends RefactoringExecutorWithWizard {
 
-  def createRefactoring(selectionStart: Int, selectionEnd: Int, file: ScalaSourceFile) = new GenerateHashcodeAndEqualsScalaIdeRefactoring(selectionStart, selectionEnd, file)
+  def createRefactoring(selectionStart: Int, selectionEnd: Int, file: ScalaSourceFile) = new IntroduceProductNTraitRefactoring(selectionStart, selectionEnd, file)
 
-  class GenerateHashcodeAndEqualsScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-    extends ClassParameterDrivenIdeRefactoring(IntroduceProductNTrait, "Generate hashCode and equals", start, end, file) with IntroduceProductNTraitConfigurationPageGenerator {
+  class IntroduceProductNTraitRefactoring(start: Int, end: Int, file: ScalaSourceFile)
+    extends ClassParameterDrivenIdeRefactoring(IntroduceProductNTrait, "Introduce ProductN trait", start, end, file) with IntroduceProductNTraitConfigurationPageGenerator {
 
     val refactoring = withCompiler { c =>
-      new implementations.IntroduceProductNTrait{
+      new implementations.IntroduceProductNTrait {
         val global = c
       }
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/IntroduceProductNTrait.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/source/IntroduceProductNTrait.scala
@@ -5,6 +5,7 @@ import scala.tools.refactoring.implementations
 
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardPage
 import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+import org.scalaide.core.internal.statistics.Features.IntroduceProductNTrait
 import org.scalaide.refactoring.internal.RefactoringExecutorWithWizard
 
 import ui.IntroduceProductNTraitConfigurationPageGenerator
@@ -21,7 +22,7 @@ class IntroduceProductNTrait extends RefactoringExecutorWithWizard {
   def createRefactoring(selectionStart: Int, selectionEnd: Int, file: ScalaSourceFile) = new GenerateHashcodeAndEqualsScalaIdeRefactoring(selectionStart, selectionEnd, file)
 
   class GenerateHashcodeAndEqualsScalaIdeRefactoring(start: Int, end: Int, file: ScalaSourceFile)
-    extends ClassParameterDrivenIdeRefactoring("Generate hashCode and equals", start, end, file) with IntroduceProductNTraitConfigurationPageGenerator {
+    extends ClassParameterDrivenIdeRefactoring(IntroduceProductNTrait, "Generate hashCode and equals", start, end, file) with IntroduceProductNTraitConfigurationPageGenerator {
 
     val refactoring = withCompiler { c =>
       new implementations.IntroduceProductNTrait{

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RestartPresentationCompilerAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RestartPresentationCompilerAction.scala
@@ -2,9 +2,13 @@ package org.scalaide.ui.internal.actions
 
 import org.eclipse.core.resources.IProject
 import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.statistics.Features
 
 class RestartPresentationCompilerAction extends AbstractPopupAction {
   override def performAction(project: IProject): Unit = {
+    ScalaPlugin().statistics.incUses(Features.RestartPresentationCompiler)
+
     val scalaProject = IScalaPlugin().asScalaProject(project)
     scalaProject foreach (_.presentationCompiler.askRestart())
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/ScalaCopyQualifiedNameAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/ScalaCopyQualifiedNameAction.scala
@@ -1,19 +1,20 @@
 package org.scalaide.ui.internal.actions
 
+import org.eclipse.jdt.internal.ui.IJavaHelpContextIds
+import org.eclipse.jdt.internal.ui.JavaPluginImages
 import org.eclipse.jdt.internal.ui.actions.ActionMessages
-import org.eclipse.jdt.internal.ui.actions.CopyQualifiedNameAction
+import org.eclipse.jdt.ui.actions.SelectionDispatchAction
 import org.eclipse.jface.dialogs.MessageDialog
 import org.eclipse.swt.SWTError
 import org.eclipse.swt.dnd.Clipboard
 import org.eclipse.swt.dnd.DND
 import org.eclipse.swt.dnd.TextTransfer
 import org.eclipse.swt.dnd.Transfer
-import org.scalaide.core.compiler.NamePrinter
-import org.scalaide.ui.internal.editor.ScalaCompilationUnitEditor
-import org.eclipse.jdt.ui.actions.SelectionDispatchAction
-import org.eclipse.jdt.internal.ui.JavaPluginImages
 import org.eclipse.ui.PlatformUI
-import org.eclipse.jdt.internal.ui.IJavaHelpContextIds
+import org.scalaide.core.compiler.NamePrinter
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.statistics.Features
+import org.scalaide.ui.internal.editor.ScalaCompilationUnitEditor
 
 /**
  * A Scala-aware replacement for CopyQualifiedNameAction.
@@ -21,7 +22,9 @@ import org.eclipse.jdt.internal.ui.IJavaHelpContextIds
 class ScalaCopyQualifiedNameAction(editor: ScalaCompilationUnitEditor) extends SelectionDispatchAction(editor.getSite) {
   initGui()
 
-  override def run() {
+  override def run(): Unit = {
+    ScalaPlugin().statistics.incUses(Features.CopyQualifiedName)
+
     val qname = {
       for (cu <- compilationUnit) yield {
         val selection = editor.getViewer.getSelectedRange
@@ -34,7 +37,7 @@ class ScalaCopyQualifiedNameAction(editor: ScalaCompilationUnitEditor) extends S
       copyToClipboard(qname.get)
   }
 
-  private def copyToClipboard(str: String) {
+  private def copyToClipboard(str: String): Unit = {
     val data: Array[Object] = Array(str)
     val dataTypes: Array[Transfer] = Array(TextTransfer.getInstance)
     val clipboard = new Clipboard(getShell().getDisplay())
@@ -55,7 +58,7 @@ class ScalaCopyQualifiedNameAction(editor: ScalaCompilationUnitEditor) extends S
     }
   }
 
-  private def initGui() {
+  private def initGui(): Unit = {
     setText(ActionMessages.CopyQualifiedNameAction_ActionName);
     setToolTipText(ActionMessages.CopyQualifiedNameAction_ToolTipText);
     setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_COPY_QUALIFIED_NAME);

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/completion/ScalaCompletionProposalImpl.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/completion/ScalaCompletionProposalImpl.scala
@@ -45,6 +45,9 @@ import org.scalaide.core.completion.MemberKind
 import org.scalaide.ui.ScalaImages
 import org.eclipse.jface.text.contentassist.ICompletionProposal
 import org.scalaide.ui.completion.ScalaCompletionProposal
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.statistics.Features.CodeAssist
+import org.scalaide.core.internal.statistics.Features.CharactersSaved
 
 /** A completion proposal for the Eclipse completion framework. It wraps a [[CompletionProposal]] returned
  *  by the presentation compiler, and implements the methods needed by the platform.
@@ -118,6 +121,8 @@ class ScalaCompletionProposalImpl(proposal: CompletionProposal)
   }
 
   override def apply(viewer: ITextViewer, trigger: Char, stateMask: Int, offset: Int): Unit = {
+    ScalaPlugin().statistics.incUses(CodeAssist)
+
     val showOnlyTooltips = context == CompletionContext.NewContext || context == CompletionContext.ApplyContext
 
     if (!showOnlyTooltips) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SaveActionsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/SaveActionsPreferencePage.scala
@@ -154,13 +154,6 @@ class SaveActionsPreferencePage extends PreferencePage with IWorkbenchPreference
     t
   }
 
-  private def mkLabel(parent: Composite, text: String, columnSize: Int = 1): Label = {
-    val lb = new Label(parent, SWT.NONE)
-    lb.setText(text)
-    lb.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, columnSize, 1))
-    lb
-  }
-
   private def isEnabled(saveAction: SaveActionSetting): Boolean =
     prefStore.getBoolean(saveAction.id)
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaPreferences.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaPreferences.scala
@@ -1,83 +1,16 @@
 package org.scalaide.ui.internal.preferences
 
-import org.eclipse.jface.preference.IPreferenceStore
-import org.eclipse.ui.IWorkbenchPreferencePage
-import org.eclipse.ui.IWorkbench
-import org.eclipse.ui.dialogs.PropertyPage
+import org.eclipse.jface.preference.PreferencePage
+import org.eclipse.swt.SWT
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.swt.widgets.Control
-import org.eclipse.swt.widgets.Group
-import org.eclipse.swt.layout.GridLayout
-import org.eclipse.swt.layout.GridData
-import org.eclipse.swt.SWT
-import org.scalaide.logging.HasLogger
-import org.scalaide.core.IScalaPlugin
+import org.eclipse.ui.IWorkbench
+import org.eclipse.ui.IWorkbenchPreferencePage
 
-class ScalaPreferences extends PropertyPage with IWorkbenchPreferencePage with EclipseSettings
-  with ScalaPluginPreferencePage with HasLogger {
-
-  /** Pulls the preference store associated with this plugin */
-  override def doGetPreferenceStore(): IPreferenceStore = {
-    IScalaPlugin().getPreferenceStore()
-  }
-
-  override def init(wb: IWorkbench) {}
-
-  /** Returns the id of what preference page we use */
-  override val eclipseBoxes: List[EclipseSetting.EclipseBox] = Nil
-
+class ScalaPreferences extends PreferencePage with IWorkbenchPreferencePage {
   def createContents(parent: Composite): Control = {
-    val composite = {
-      //No Outer Composite
-      val tmp = new Composite(parent, SWT.NONE)
-      val layout = new GridLayout(1, false)
-      tmp.setLayout(layout)
-      val data = new GridData(GridData.FILL)
-      data.grabExcessHorizontalSpace = true
-      data.horizontalAlignment = GridData.FILL
-      tmp.setLayoutData(data)
-      tmp
-    }
-
-    eclipseBoxes.foreach(eBox => {
-      val group = new Group(composite, SWT.SHADOW_ETCHED_IN)
-      group.setText(eBox.name)
-      val layout = new GridLayout(3, false)
-      group.setLayout(layout)
-      val data = new GridData(GridData.FILL)
-      data.grabExcessHorizontalSpace = true
-      data.horizontalAlignment = GridData.FILL
-      group.setLayoutData(data)
-      eBox.eSettings.foreach(_.addTo(group))
-    })
-    composite
+    new Composite(parent, SWT.NONE)
   }
 
-  override def performOk = try {
-    eclipseBoxes.foreach(_.eSettings.foreach(_.apply()))
-    save()
-    true
-  } catch {
-    case ex: Throwable => eclipseLog.error(ex); false
-  }
-
-  def updateApply() {
-    updateApplyButton
-  }
-
-  /** Updates the apply button with the appropriate enablement. */
-  protected override def updateApplyButton(): Unit = {
-    if (getApplyButton != null) {
-      if (isValid) {
-        getApplyButton.setEnabled(isChanged)
-      } else {
-        getApplyButton.setEnabled(false)
-      }
-    }
-  }
-
-  def save(): Unit = {
-    //Don't let user click "apply" again until a change
-    updateApplyButton
-  }
+  def init(workbench: IWorkbench): Unit = ()
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaPreferences.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScalaPreferences.scala
@@ -1,16 +1,47 @@
 package org.scalaide.ui.internal.preferences
 
-import org.eclipse.jface.preference.PreferencePage
-import org.eclipse.swt.SWT
-import org.eclipse.swt.widgets.Composite
-import org.eclipse.swt.widgets.Control
+import java.io.File
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer
+import org.eclipse.jface.preference.FieldEditorPreferencePage
+import org.eclipse.jface.preference.StringFieldEditor
 import org.eclipse.ui.IWorkbench
 import org.eclipse.ui.IWorkbenchPreferencePage
+import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.ScalaIdeDataStore
 
-class ScalaPreferences extends PreferencePage with IWorkbenchPreferencePage {
-  def createContents(parent: Composite): Control = {
-    new Composite(parent, SWT.NONE)
+class ScalaPreferences extends FieldEditorPreferencePage with IWorkbenchPreferencePage {
+
+  private var dataStoreField: StringFieldEditor = _
+
+  override def createFieldEditors(): Unit = {
+    dataStoreField = new StringFieldEditor(ScalaIdeDataStore.DataStoreId, "Path to data store: ", getFieldEditorParent) {
+      override def checkState() = {
+        val f = new File(getTextControl.getText)
+        val isValid = f.exists() && f.isDirectory()
+        if (isValid)
+          clearErrorMessage()
+        else
+          showErrorMessage("Path must point to a directory")
+        isValid
+      }
+    }
+    addField(dataStoreField)
+  }
+
+  override def initialize(): Unit = {
+    super.initialize()
+    dataStoreField.setStringValue(ScalaIdeDataStore.dataStoreLocation)
   }
 
   def init(workbench: IWorkbench): Unit = ()
+}
+
+class ScalaPreferenceInitializer extends AbstractPreferenceInitializer {
+
+  override def initializeDefaultPreferences(): Unit = {
+    val store = IScalaPlugin().getPreferenceStore
+    store.setDefault(ScalaIdeDataStore.DataStoreId, ScalaIdeDataStore.DefaultDataStoreLocation)
+  }
+
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -23,22 +23,25 @@ import org.eclipse.ui.IWorkbenchPreferencePage
 import org.scalaide.core.internal.ScalaPlugin
 import org.scalaide.core.internal.statistics.FeatureData
 import org.scalaide.core.internal.statistics.Features.CharactersSaved
+import org.scalaide.core.internal.statistics.Features.NotSpecified
 import org.scalaide.util.eclipse.SWTUtils._
 
 class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferencePage {
 
   /*
-   * [[CharactersSaved]] should not be displayed in the list of used features.
+   * Some features should not be displayed in the list of used features. These
+   * are part of `filteredData`, the displayed ones are `data`
    */
-  private val (data, Array(charsSaved)) = {
+  private val (data, filteredData) = {
     val d = ScalaPlugin().statistics.data.toArray
-    d.partition(_.feature != CharactersSaved)
+    d.partition(fd ⇒ !Set(CharactersSaved, NotSpecified)(fd.feature))
   }
 
   def createContents(parent: Composite): Control = {
     val base = new Composite(parent, SWT.NONE)
     base.setLayout(new GridLayout(1, true))
 
+    val charsSaved = filteredData.find(_.feature == CharactersSaved).get
     mkLabel(base, s"Statistics tracking started at $startOfStats.")
     mkLabel(base, s"Code completion has saved you from typing approx. ${charsSaved.nrOfUses} characters")
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -22,17 +22,25 @@ import org.eclipse.ui.IWorkbench
 import org.eclipse.ui.IWorkbenchPreferencePage
 import org.scalaide.core.internal.ScalaPlugin
 import org.scalaide.core.internal.statistics.FeatureData
+import org.scalaide.core.internal.statistics.Features.CharactersSaved
 import org.scalaide.util.eclipse.SWTUtils._
 
 class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferencePage {
 
-  private val data = ScalaPlugin().statistics.data.toArray
+  /*
+   * [[CharactersSaved]] should not be displayed in the list of used features.
+   */
+  private val (data, Array(charsSaved)) = {
+    val d = ScalaPlugin().statistics.data.toArray
+    d.partition(_.feature != CharactersSaved)
+  }
 
   def createContents(parent: Composite): Control = {
     val base = new Composite(parent, SWT.NONE)
     base.setLayout(new GridLayout(1, true))
 
     mkLabel(base, s"Statistics tracking started at $startOfStats.")
+    mkLabel(base, s"Code completion has saved you from typing approx. ${charsSaved.nrOfUses} characters")
 
     val tableComposite = new Composite(base, SWT.NONE)
     tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1))

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -92,7 +92,7 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
   private def timeAgo(time: Long): String = {
     import scala.concurrent.duration._
 
-    (System.nanoTime - time).nanos match {
+    (System.currentTimeMillis - time).millis match {
       case d if d < 0.nanos   ⇒ "Never"
       case d if d < 2.minutes ⇒ "Moments ago"
       case d if d < 1.hour    ⇒ s"${d.toMinutes} minutes ago"

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -1,5 +1,8 @@
 package org.scalaide.ui.internal.preferences
 
+import java.text.DateFormat
+import java.util.Calendar
+
 import org.eclipse.jface.layout.TableColumnLayout
 import org.eclipse.jface.preference.PreferencePage
 import org.eclipse.jface.viewers.ColumnWeightData
@@ -28,6 +31,8 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
   def createContents(parent: Composite): Control = {
     val base = new Composite(parent, SWT.NONE)
     base.setLayout(new GridLayout(1, true))
+
+    mkLabel(base, s"Statistics tracking started at $startOfStats.")
 
     val tableComposite = new Composite(base, SWT.NONE)
     tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1))
@@ -87,6 +92,13 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
     viewer.setInput(data)
 
     base
+  }
+
+  private def startOfStats: String = {
+    val df = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+    val c = Calendar.getInstance
+    c.setTimeInMillis(ScalaPlugin().statistics.startOfStats)
+    df.format(c.getTime)
   }
 
   private def timeAgo(time: Long): String = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -127,8 +127,8 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
     }
     import Column._, Direction._
 
-    var sortCol: Column = Feature
-    var sortDir: Direction = Ascending
+    var sortCol: Column = NrOfUses
+    var sortDir: Direction = Descending
 
     override def compare(viewer: Viewer, o1: AnyRef, o2: AnyRef): Int = {
       def cmp = (o1, o2) match {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -131,18 +131,15 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
     var sortDir: Direction = Ascending
 
     override def compare(viewer: Viewer, o1: AnyRef, o2: AnyRef): Int = {
-      def str(o: AnyRef) = o match {
-        case FeatureData(feature, nrOfUses, lastUsed) ⇒ sortCol match {
-          case Feature  ⇒ feature.description
-          case Group    ⇒ feature.group.description
-          case NrOfUses ⇒ nrOfUses.toString
-          case LastUsed ⇒ lastUsed.toString
+      def cmp = (o1, o2) match {
+        case (o1: FeatureData, o2: FeatureData) ⇒ sortCol match {
+          case Feature  ⇒ o1.feature.description compareTo o2.feature.description
+          case Group    ⇒ o1.feature.group.description compareTo o2.feature.group.description
+          case NrOfUses ⇒ (o1.nrOfUses-o2.nrOfUses).toInt
+          case LastUsed ⇒ (o1.lastUsed-o2.lastUsed).toInt
         }
       }
-      sortDir match {
-        case Ascending ⇒ str(o1) compareTo str(o2)
-        case Descending ⇒ str(o2) compareTo str(o1)
-      }
+      if (sortDir == Ascending) cmp else -cmp
     }
 
     def doSort(col: Column) = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -1,0 +1,165 @@
+package org.scalaide.ui.internal.preferences
+
+import org.eclipse.jface.layout.TableColumnLayout
+import org.eclipse.jface.preference.PreferencePage
+import org.eclipse.jface.viewers.ColumnWeightData
+import org.eclipse.jface.viewers.IStructuredContentProvider
+import org.eclipse.jface.viewers.TableViewer
+import org.eclipse.jface.viewers.TableViewerColumn
+import org.eclipse.jface.viewers.Viewer
+import org.eclipse.jface.viewers.ViewerSorter
+import org.eclipse.swt.SWT
+import org.eclipse.swt.events.SelectionEvent
+import org.eclipse.swt.layout.GridData
+import org.eclipse.swt.layout.GridLayout
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Control
+import org.eclipse.swt.widgets.Table
+import org.eclipse.ui.IWorkbench
+import org.eclipse.ui.IWorkbenchPreferencePage
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.statistics.Stat
+import org.scalaide.util.eclipse.SWTUtils._
+
+class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferencePage {
+
+  private val data = ScalaPlugin().statistics.data.toArray
+
+  def createContents(parent: Composite): Control = {
+    val base = new Composite(parent, SWT.NONE)
+    base.setLayout(new GridLayout(1, true))
+
+    val tableComposite = new Composite(base, SWT.NONE)
+    tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1))
+
+    val table = new Table(tableComposite, SWT.BORDER | SWT.SINGLE | SWT.FULL_SELECTION | SWT.V_SCROLL)
+    table.setHeaderVisible(true)
+    table.setLinesVisible(true)
+
+    val tcl = new TableColumnLayout
+    tableComposite.setLayout(tcl)
+
+    val viewer = new TableViewer(table)
+    viewer.setContentProvider(ContentProvider)
+    viewer.setSorter(ColumnSorter)
+
+    val columnFeature = new TableViewerColumn(viewer, SWT.NONE)
+    columnFeature.getColumn.setText("Feature")
+    columnFeature.onLabelUpdate(_.asInstanceOf[Stat].feature.description)
+    columnFeature.getColumn.addSelectionListener { e: SelectionEvent ⇒
+      ColumnSorter.doSort(ColumnSorter.Column.Feature)
+      viewer.refresh()
+    }
+    tcl.setColumnData(columnFeature.getColumn, new ColumnWeightData(3, true))
+
+    val columnGroup = new TableViewerColumn(viewer, SWT.NONE)
+    columnGroup.getColumn.setText("Group")
+    columnGroup.onLabelUpdate(_.asInstanceOf[Stat].feature.group.description)
+    columnGroup.getColumn.addSelectionListener { e: SelectionEvent ⇒
+      ColumnSorter.doSort(ColumnSorter.Column.Group)
+      viewer.refresh()
+    }
+    tcl.setColumnData(columnGroup.getColumn, new ColumnWeightData(2, true))
+
+    val columnUsed = new TableViewerColumn(viewer, SWT.NONE)
+    columnUsed.getColumn.setText("Used")
+    columnUsed.onLabelUpdate(_.asInstanceOf[Stat].nrOfUses match {
+      case 0 ⇒ "Never"
+      case 1 ⇒ "Once"
+      case 2 ⇒ "Twice"
+      case n ⇒ s"$n times"
+    })
+    columnUsed.getColumn.addSelectionListener { e: SelectionEvent ⇒
+      ColumnSorter.doSort(ColumnSorter.Column.NrOfUses)
+      viewer.refresh()
+    }
+    tcl.setColumnData(columnUsed.getColumn, new ColumnWeightData(1, true))
+
+    val columnLastUsed = new TableViewerColumn(viewer, SWT.NONE)
+    columnLastUsed.getColumn.setText("Last used")
+    columnLastUsed.onLabelUpdate { d ⇒
+      val stat = d.asInstanceOf[Stat]
+      if (stat.lastUsed == 0)
+        "Never"
+      else
+        timeAgo(stat.lastUsed)
+    }
+    columnLastUsed.getColumn.addSelectionListener { e: SelectionEvent ⇒
+      ColumnSorter.doSort(ColumnSorter.Column.LastUsed)
+      viewer.refresh()
+    }
+    tcl.setColumnData(columnLastUsed.getColumn, new ColumnWeightData(1, true))
+
+    viewer.setInput(data)
+
+    base
+  }
+
+  private def timeAgo(time: Long): String = {
+    import scala.concurrent.duration._
+    val d = (System.nanoTime - time).nanos
+
+    if (d < 2.minutes)
+      "moments ago"
+    else if (d < 1.hour)
+      s"${d.toMinutes} minutes ago"
+    else if (d < 1.day)
+      s"${d.toHours} hours ago"
+    else
+      s"${d.toDays} days ago"
+  }
+
+  def init(workbench: IWorkbench): Unit = ()
+
+  private object ColumnSorter extends ViewerSorter {
+
+    object Column extends Enumeration {
+      type Column = Value
+      val Feature, Group, NrOfUses, LastUsed = Value
+    }
+    object Direction extends Enumeration {
+      type Direction = Value
+      val Ascending, Descending = Value
+    }
+    import Column._, Direction._
+
+    var sortCol: Column = Feature
+    var sortDir: Direction = Ascending
+
+    override def compare(viewer: Viewer, o1: AnyRef, o2: AnyRef): Int = {
+      def str(o: AnyRef) = o match {
+        case Stat(feature, nrOfUses, lastUsed) ⇒ sortCol match {
+          case Feature  ⇒ feature.description
+          case Group    ⇒ feature.group.description
+          case NrOfUses ⇒ nrOfUses.toString
+          case LastUsed ⇒ lastUsed.toString
+        }
+      }
+      sortDir match {
+        case Ascending ⇒ str(o1) compareTo str(o2)
+        case Descending ⇒ str(o2) compareTo str(o1)
+      }
+    }
+
+    def doSort(col: Column) = {
+      if (col == sortCol)
+        sortDir = if (sortDir == Ascending) Descending else Ascending
+      else {
+        sortCol = col
+        sortDir = Ascending
+      }
+    }
+
+  }
+
+  private object ContentProvider extends IStructuredContentProvider {
+    def dispose(): Unit = ()
+
+    def getElements(input: Any): Array[AnyRef] = {
+      input.asInstanceOf[Array[AnyRef]]
+    }
+
+    def inputChanged(viewer: Viewer, oldInput: Any, newInput: Any): Unit = ()
+  }
+
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -18,7 +18,7 @@ import org.eclipse.swt.widgets.Table
 import org.eclipse.ui.IWorkbench
 import org.eclipse.ui.IWorkbenchPreferencePage
 import org.scalaide.core.internal.ScalaPlugin
-import org.scalaide.core.internal.statistics.Stat
+import org.scalaide.core.internal.statistics.FeatureData
 import org.scalaide.util.eclipse.SWTUtils._
 
 class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferencePage {
@@ -45,7 +45,7 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
 
     val columnFeature = new TableViewerColumn(viewer, SWT.NONE)
     columnFeature.getColumn.setText("Feature")
-    columnFeature.onLabelUpdate(_.asInstanceOf[Stat].feature.description)
+    columnFeature.onLabelUpdate(_.asInstanceOf[FeatureData].feature.description)
     columnFeature.getColumn.addSelectionListener { e: SelectionEvent ⇒
       ColumnSorter.doSort(ColumnSorter.Column.Feature)
       viewer.refresh()
@@ -54,7 +54,7 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
 
     val columnGroup = new TableViewerColumn(viewer, SWT.NONE)
     columnGroup.getColumn.setText("Group")
-    columnGroup.onLabelUpdate(_.asInstanceOf[Stat].feature.group.description)
+    columnGroup.onLabelUpdate(_.asInstanceOf[FeatureData].feature.group.description)
     columnGroup.getColumn.addSelectionListener { e: SelectionEvent ⇒
       ColumnSorter.doSort(ColumnSorter.Column.Group)
       viewer.refresh()
@@ -63,7 +63,7 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
 
     val columnUsed = new TableViewerColumn(viewer, SWT.NONE)
     columnUsed.getColumn.setText("Used")
-    columnUsed.onLabelUpdate(_.asInstanceOf[Stat].nrOfUses match {
+    columnUsed.onLabelUpdate(_.asInstanceOf[FeatureData].nrOfUses match {
       case 0 ⇒ "Never"
       case 1 ⇒ "Once"
       case 2 ⇒ "Twice"
@@ -77,7 +77,7 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
 
     val columnLastUsed = new TableViewerColumn(viewer, SWT.NONE)
     columnLastUsed.getColumn.setText("Last used")
-    columnLastUsed.onLabelUpdate(d ⇒ timeAgo(d.asInstanceOf[Stat].lastUsed))
+    columnLastUsed.onLabelUpdate(d ⇒ timeAgo(d.asInstanceOf[FeatureData].lastUsed))
     columnLastUsed.getColumn.addSelectionListener { e: SelectionEvent ⇒
       ColumnSorter.doSort(ColumnSorter.Column.LastUsed)
       viewer.refresh()
@@ -120,7 +120,7 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
 
     override def compare(viewer: Viewer, o1: AnyRef, o2: AnyRef): Int = {
       def str(o: AnyRef) = o match {
-        case Stat(feature, nrOfUses, lastUsed) ⇒ sortCol match {
+        case FeatureData(feature, nrOfUses, lastUsed) ⇒ sortCol match {
           case Feature  ⇒ feature.description
           case Group    ⇒ feature.group.description
           case NrOfUses ⇒ nrOfUses.toString

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/StatisticsPreferencePage.scala
@@ -77,13 +77,7 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
 
     val columnLastUsed = new TableViewerColumn(viewer, SWT.NONE)
     columnLastUsed.getColumn.setText("Last used")
-    columnLastUsed.onLabelUpdate { d ⇒
-      val stat = d.asInstanceOf[Stat]
-      if (stat.lastUsed == 0)
-        "Never"
-      else
-        timeAgo(stat.lastUsed)
-    }
+    columnLastUsed.onLabelUpdate(d ⇒ timeAgo(d.asInstanceOf[Stat].lastUsed))
     columnLastUsed.getColumn.addSelectionListener { e: SelectionEvent ⇒
       ColumnSorter.doSort(ColumnSorter.Column.LastUsed)
       viewer.refresh()
@@ -97,16 +91,14 @@ class StatisticsPreferencePage extends PreferencePage with IWorkbenchPreferenceP
 
   private def timeAgo(time: Long): String = {
     import scala.concurrent.duration._
-    val d = (System.nanoTime - time).nanos
 
-    if (d < 2.minutes)
-      "moments ago"
-    else if (d < 1.hour)
-      s"${d.toMinutes} minutes ago"
-    else if (d < 1.day)
-      s"${d.toHours} hours ago"
-    else
-      s"${d.toDays} days ago"
+    (System.nanoTime - time).nanos match {
+      case d if d < 0.nanos   ⇒ "Never"
+      case d if d < 2.minutes ⇒ "Moments ago"
+      case d if d < 1.hour    ⇒ s"${d.toMinutes} minutes ago"
+      case d if d < 1.day     ⇒ s"${d.toHours} hours ago"
+      case d                  ⇒ s"${d.toDays} days ago"
+    }
   }
 
   def init(workbench: IWorkbench): Unit = ()

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/SWTUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/SWTUtils.scala
@@ -184,4 +184,14 @@ object SWTUtils {
     mkLink(parent, """<a href="org.eclipse.ui.editors.preferencePages.Annotations">Text Editors/Annotations</a>""", style)(anchorToLinkText)
   }
 
+  /**
+   * Creates a label on a given `parent` whose layout is `GridLayout`.
+   */
+  def mkLabel(parent: Composite, text: String, columnSize: Int = 1): Label = {
+    val lb = new Label(parent, SWT.NONE)
+    lb.setText(text)
+    lb.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, columnSize, 1))
+    lb
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
     <jdt.core.version.range>Select an Eclipse profile</jdt.core.version.range>
     <version.tag>local</version.tag>
     <sbt.version>0.13.6</sbt.version>
+    <pickling.version>0.10.0</pickling.version>
+    <parser.combinators.version>1.0.2</parser.combinators.version>
 
     <!-- the repos containing the Scala dependencies -->
     <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-${scala.short.version}x</repo.scala-refactoring>
@@ -518,6 +520,16 @@
             <artifactId>hamcrest-core</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang.modules</groupId>
+        <artifactId>scala-pickling_${scala.minor.version}</artifactId>
+        <version>${pickling.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang.modules</groupId>
+        <artifactId>scala-parser-combinators_${scala.minor.version}</artifactId>
+        <version>${parser.combinators.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This is not yet completely finished but I open a PR anyway, maybe someone has time to already look at it.

This is a new feature that tracks user actions and stores the in the (configurable) directory `~/.scalaide`. It is inspired by [IDEAs Productivity Guide](https://blog.idrsolutions.com/2014/07/develop-intellij-idea-check-productivity-guide/) and hopefully evolves one time to an Eclipse independent preference store and reporting tool that allows us to find out which features users use, which they use less and what errors they are facing.

Right now it doesn't yet track all features (save actions are missing for example) and it is a little bit cumbersome implemented.

- [ ] Add Scaladoc for new API
- [ ] Fix Manifests
- [ ] Restore source compatibility in `BasicCompletionProposal`
- [ ] Show all registered features in pref page, not just the used ones
- [ ] Make `Feature` type open for IDE extensions (remove `sealed` keyword)
- [ ] Don't alias `File.separator` with a val
- [ ] Export new `statistics` package in OSGi config

Fixes [#1002189](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002189)