### PR TITLE
Basic support for Hot Code Replacement in debugged JVM

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/SemanticHighlightingParticipants.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/SemanticHighlightingParticipants.scala
@@ -23,7 +23,7 @@ object SemanticHighlightingParticipants {
   def extensions: Seq[SemanticHighlightingParticipant] = {
     val elems = EclipseUtils.configElementsForExtension(ExtensionPointId)
     elems flatMap { e =>
-      EclipseUtils.withSafeRunner("Error occurred while trying to create semantic highlighting participant.") {
+      EclipseUtils.withSafeRunner("Error occurred while trying to create semantic highlighting participant") {
         e.createExecutableExtension("class").asInstanceOf[SemanticHighlightingParticipant]
       }
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/Nature.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/Nature.scala
@@ -57,7 +57,7 @@ class Nature extends IProjectNature {
 
     updateBuilders(project, List(JavaCore.BUILDER_ID), SdtConstants.BuilderId)
 
-    EclipseUtils.withSafeRunner("Error occurred while trying to add Scala library to classpath.") {
+    EclipseUtils.withSafeRunner("Error occurred while trying to add Scala library to classpath") {
       Nature.addScalaLibAndSave(getProject)
     }
   }
@@ -68,7 +68,7 @@ class Nature extends IProjectNature {
 
     updateBuilders(project, List(SdtConstants.BuilderId), JavaCore.BUILDER_ID)
 
-    EclipseUtils.withSafeRunner("Error occurred while trying to remove Scala library from classpath.") {
+    EclipseUtils.withSafeRunner("Error occurred while trying to remove Scala library from classpath") {
       val jp = JavaCore.create(getProject)
       Nature.removeScalaLib(jp)
       jp.save(null, true)
@@ -76,7 +76,7 @@ class Nature extends IProjectNature {
   }
 
   private def updateBuilders(project: IProject, buildersToRemove: List[String], builderToAdd: String) {
-    EclipseUtils.withSafeRunner(s"Error occurred while trying to update builder of project '$project'.") {
+    EclipseUtils.withSafeRunner(s"Error occurred while trying to update builder of project '$project'") {
       val description = project.getDescription
       val previousCommands = description.getBuildSpec
       val filteredCommands = previousCommands.filterNot(buildersToRemove contains _.getBuilderName)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -553,7 +553,7 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
       val settings = ScalaPresentationCompiler.defaultScalaSettings(msg => settingsError(IMarker.SEVERITY_ERROR, msg, null))
       clearSettingsErrors()
       initializeCompilerSettings(settings, _ => true)
-      // source path should be emtpy. The build manager decides what files get recompiled when.
+      // source path should be empty. The build manager decides what files get recompiled when.
       // if scalac finds a source file newer than its corresponding classfile, it will 'compileLate'
       // that file, using an AbstractFile/PlainFile instead of the EclipseResource instance. This later
       // causes problems if errors are reported against that file. Anyway, it's wrong to have a sourcepath

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunDiagnosticAction.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/actions/RunDiagnosticAction.scala
@@ -27,7 +27,7 @@ class RunDiagnosticAction extends IObjectActionDelegate with IWorkbenchWindowAct
   override def selectionChanged(action: IAction, selection: ISelection) {  }
 
   override def run(action: IAction) {
-    EclipseUtils.withSafeRunner("Error occurred while trying to create diagnostic dialog.") {
+    EclipseUtils.withSafeRunner("Error occurred while trying to create diagnostic dialog") {
       action.getId match {
         case RUN_DIAGNOSTICS =>
           val shell = if (parentWindow == null) SWTUtils.getShell else parentWindow.getShell

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
@@ -76,7 +76,7 @@ class ScalaSourceFileEditor
 
     val exts = getSourceViewer() match {
       case jsv: JavaSourceViewer => SemanticHighlightingParticipants.extensions flatMap { ext =>
-        EclipseUtils.withSafeRunner(s"Error occurred while creating semantic action of '${nameOf(ext)}'.") {
+        EclipseUtils.withSafeRunner(s"Error occurred while creating semantic action of '${nameOf(ext)}'") {
           ext.participant(jsv)
         }
       }
@@ -86,7 +86,7 @@ class ScalaSourceFileEditor
     override def reconciled(ast: CompilationUnit, forced: Boolean, progressMonitor: IProgressMonitor) = {
       getInteractiveCompilationUnit() match {
         case scu: ScalaCompilationUnit => exts foreach { ext =>
-          EclipseUtils.withSafeRunner(s"Error occurred while executing '${nameOf(ext)}'.") {
+          EclipseUtils.withSafeRunner(s"Error occurred while executing '${nameOf(ext)}'") {
             ext(scu)
           }
         }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/spelling/SpellingService.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/spelling/SpellingService.scala
@@ -40,7 +40,7 @@ final class SpellingService(store: IPreferenceStore, engine: ISpellingEngine) ex
       collector.beginCollecting()
 
       if (store.getBoolean(ESpellingService.PREFERENCE_SPELLING_ENABLED)) {
-        EclipseUtils.withSafeRunner("Error occurred while executing spelling engine.") {
+        EclipseUtils.withSafeRunner("Error occurred while executing spelling engine") {
           engine.check(document, regions, context, collector, monitor)
         }
       }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/handlers/ClasspathErrorPromptStatusHandler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/handlers/ClasspathErrorPromptStatusHandler.scala
@@ -68,7 +68,7 @@ class ClasspathErrorPromptStatusHandler extends RichStatusHandler {
       val buttonId = dialog.getReturnCode()
       if (buttonId == IDialogConstants.OK_ID)
         continuation.get trySuccess { () =>
-          EclipseUtils.withSafeRunner("Error occurred while trying to set source level.") {
+          EclipseUtils.withSafeRunner("Error occurred while trying to set source level") {
             project.setDesiredSourceLevel(ScalaVersion(previousScalaVer), "Classpath check dialog tasked with restoring compatibility")
           }
         }

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/EclipseUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/EclipseUtils.scala
@@ -202,20 +202,20 @@ object EclipseUtils extends HasLogger {
 
   /**
    * Executes a given function `f` in a safe runner that catches potential
-   * occuring exceptions and logs them together with `errorMsg` if this is the
+   * occurring exceptions and logs them together with `errorMsg` if this is the
    * case.
    *
    * If no error occurs, the result of `f` is returned, otherwise `None`.
    */
-  def withSafeRunner[A](errorMsg: String)(f: => A): Option[A] = {
-    var res = null.asInstanceOf[A]
+  def withSafeRunner[A](errorMsg: => String)(f: => A): Option[A] = {
+    var res: Option[A] = None
     SafeRunner.run(new ISafeRunnable {
       override def handleException(e: Throwable) =
         eclipseLog.error(s"$errorMsg. Check the previous stack trace for more information.")
 
-      override def run() = res = f
+      override def run() = { res = Option(f) }
     })
-    Option(res)
+    res
   }
 
   /** Returns the root resource of this workspace.

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugBreakpointTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugBreakpointTest.scala
@@ -58,16 +58,16 @@ class ScalaDebugBreakpointTest {
     try {
       session.waitForBreakpointsToBeEnabled(bp11, bp13)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
 
       bp11.setEnabled(false)
       session.waitForBreakpointsToBeDisabled(bp11)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "simple1()V", 13)
 
       bp11.setEnabled(true); bp13.setEnabled(false)
@@ -75,10 +75,10 @@ class ScalaDebugBreakpointTest {
       session.waitForBreakpointsToBeEnabled(bp11)
       session.waitForBreakpointsToBeDisabled(bp13)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
 
       session.resumeToCompletion()
@@ -102,13 +102,13 @@ class ScalaDebugBreakpointTest {
     try {
       session.waitForBreakpointsToBeEnabled(bp20, bp22, bp26)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "fors()V", 20)
 
       bp22.setEnabled(false)
       session.waitForBreakpointsToBeDisabled(bp22)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME + "$$anonfun$fors$2", "apply$mcVI$sp(I)V", 26)
 
       bp26.setEnabled(false)
@@ -141,7 +141,7 @@ class ScalaDebugBreakpointTest {
       bp11.setEnabled(true)
       session.waitForBreakpointsToBeEnabled(bp11)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "simple1()V", 11)
 
       bp11.setEnabled(false)
@@ -172,7 +172,7 @@ class ScalaDebugBreakpointTest {
       bp22.setEnabled(true)
       session.waitForBreakpointsToBeEnabled(bp22)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME + "$$anonfun$fors$1", "apply$mcVI$sp(I)V", 22)
 
       bp22.setEnabled(false)
@@ -202,7 +202,7 @@ class ScalaDebugBreakpointTest {
       bp21.setEnabled(true)
       session.waitForBreakpointsToBeEnabled(bp21)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME + "$$anonfun$fors$1", "apply$mcVI$sp(I)V", 21)
       // by now, the class has been loaded, so ClassPrepareEvent won't be triggered for the next breakpoint
 
@@ -214,7 +214,7 @@ class ScalaDebugBreakpointTest {
       bp22.setEnabled(true)
       session.waitForBreakpointsToBeEnabled(bp22)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME + "$$anonfun$fors$1", "apply$mcVI$sp(I)V", 22)
 
       bp22.setEnabled(false)
@@ -307,7 +307,7 @@ class ScalaDebugBreakpointTest {
     try {
       session.waitForBreakpointsToBeEnabled(bp20, bp26)
 
-      session.resumetoSuspension()
+      session.resumeToSuspension()
       session.checkStackFrame(BP_TYPENAME, "fors()V", 20)
 
       session.skipAllBreakpoints(true)

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
@@ -272,15 +272,15 @@ class ScalaDebugTestSession private (launchConfiguration: ILaunchConfiguration) 
     DebugPlugin.getDefault().removeDebugEventListener(debugEventListener)
   }
 
-  def resumetoSuspension() {
-    assertEquals("Bad state before resumeToCompletion", SUSPENDED, state)
+  def resumeToSuspension() {
+    assertEquals("Bad state before resumeToSuspension", SUSPENDED, state)
 
     setActionRequested
     currentStackFrame.resume
 
     waitUntilSuspended
 
-    assertEquals("Bad state after resumeToCompletion", SUSPENDED, state)
+    assertEquals("Bad state after resumeToSuspension", SUSPENDED, state)
   }
 
   def disconnect() {
@@ -342,9 +342,17 @@ class ScalaDebugTestSession private (launchConfiguration: ILaunchConfiguration) 
   def checkStackFrame(typeName: String, methodFullSignature: String, line: Int) {
     assertEquals("Bad state before checkStackFrame", SUSPENDED, state)
 
-    assertEquals("Wrong typeName", typeName, currentStackFrame.stackFrame.location.declaringType.name)
-    assertEquals("Wrong method/line" + currentStackFrame.getLineNumber, methodFullSignature, currentStackFrame.stackFrame.location.method.name + currentStackFrame.stackFrame.location.method.signature)
-    assertEquals("Wrong line", line, currentStackFrame.getLineNumber)
+    val currentLocation = currentStackFrame.stackFrame.location
+    val currentTypeName = currentLocation.declaringType.name
+    val currentMethodFullSignature = currentLocation.method.name + currentLocation.method.signature
+    val currentLineNumber = currentStackFrame.getLineNumber
+
+    def frameInfo(typeName: String, methodSignature: String, lineNumber: Int) =
+      s"type: $typeName, method: $methodSignature, line: $lineNumber"
+
+    val currentFrameInfo = frameInfo(currentTypeName, currentMethodFullSignature, currentLineNumber)
+    val expectedFrameInfo = frameInfo(typeName, methodFullSignature, line)
+    assertEquals("Wrong frame", expectedFrameInfo, currentFrameInfo)
   }
 
   // access data in the current stackframe
@@ -355,7 +363,13 @@ class ScalaDebugTestSession private (launchConfiguration: ILaunchConfiguration) 
   def getLocalVariable(name: String): ScalaValue = {
     assertEquals("Bad state before getLocalVariable", SUSPENDED, state)
 
-    currentStackFrame.getVariables.find(_.getName == name).get.getValue.asInstanceOf[ScalaValue]
+    val variables = currentStackFrame.getVariables
+    val variable = variables.find(_.getName == name).getOrElse {
+      val availableVariables = variables.map(_.getName).mkString(", ")
+      throw new AssertionError(s"Variable with name $name not found. Available variables: $availableVariables")
+    }
+
+    variable.getValue.asInstanceOf[ScalaValue]
   }
 
   def skipAllBreakpoints(enabled: Boolean): Unit =

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSuite.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSuite.scala
@@ -6,6 +6,7 @@ package org.scalaide.debug.internal
 import org.junit.runners.Suite
 import org.junit.runner.RunWith
 import org.scalaide.debug.internal.editor.StackFrameVariableOfTreeFinderTest
+import org.scalaide.debug.internal.hcr.HotCodeReplaceTest
 import org.scalaide.debug.internal.launching.RemoteConnectorTest
 import org.scalaide.debug.internal.model.ScalaThreadTest
 import org.scalaide.debug.internal.model.ScalaStackFrameTest
@@ -36,6 +37,7 @@ import org.scalaide.debug.internal.model.ScalaDebugCacheTest
     classOf[RemoteConnectorTest],
     classOf[ScalaDebugBreakpointTest],
     classOf[ScalaDebugCacheTest],
-    classOf[StackFrameVariableOfTreeFinderTest]
+    classOf[StackFrameVariableOfTreeFinderTest],
+    classOf[HotCodeReplaceTest]
     ))
 class ScalaDebugTestSuite

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2015 Contributor. All rights reserved.
+ */
+package org.scalaide.debug.internal.hcr
+
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.debug.core.model.IBreakpoint
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.scalaide.core.testsetup.TestProjectSetup
+import org.scalaide.debug.internal.ScalaDebugRunningTest
+import org.scalaide.debug.internal.ScalaDebugTestSession
+import org.scalaide.debug.internal.preferences.HotCodeReplacePreferences
+
+private object HotCodeReplaceTest {
+
+  class Matcher[T](check: T => Unit) {
+    def mustEqual(expected: T): Unit = check(expected)
+  }
+
+  case class Location(typeName: String, methodSignature: String, lineNumber: Int) {
+    def asObsolete = Location(typeName, "Obsolete method", lineNumber = -1)
+  }
+
+  val MainObjectTypeName = "debug.MainObject$"
+  val NestedClassTypeName = "debug.MainObject$nestedObject$NestedClass"
+  val CustomThreadTypeName = "debug.MainObject$CustomThread$"
+  val TestedFilePath = "debug/Hcr.scala"
+  val IntFromCtorArgName = "intFromCtor"
+
+  val RecursiveMethodSignature = "recursiveMethod(I)I"
+  val MainMethodSignature = "mainMethod()V"
+  val ClassMethodSignature = "classMethod()I"
+  val RunMethodSignature = "run()V"
+
+  val ClassMethodBeginning = Location(NestedClassTypeName, ClassMethodSignature, 7)
+  val ClassMethodEnd = ClassMethodBeginning.copy(lineNumber = 8)
+
+  val RecursiveMethodBeginning = Location(MainObjectTypeName, RecursiveMethodSignature, 14)
+  val RecursiveMethodSelfCall = RecursiveMethodBeginning.copy(lineNumber = 17)
+  val RecursiveMethodEnd = RecursiveMethodBeginning.copy(lineNumber = 20)
+
+  val MainMethodBeginning = Location(MainObjectTypeName, MainMethodSignature, 24)
+  val MainMethodEnd = MainMethodBeginning.copy(lineNumber = 25)
+
+  val RunMethodBeginning = Location(CustomThreadTypeName, RunMethodSignature, 32)
+  val RunMethodEnd = RunMethodBeginning.copy(lineNumber = 33)
+
+  val DefaultRecursiveMethodLocalIntValue = 105
+}
+
+/**
+ * Tests whether HCR works (classes are correctly replaced in VM and we get new values)
+ * and whether associated settings are correctly applied.
+ */
+class HotCodeReplaceTest
+    extends TestProjectSetup("hot-code-replace", bundleName = "org.scala-ide.sdt.debug.tests")
+    with ScalaDebugRunningTest {
+
+  import HotCodeReplaceTest._
+
+  private var session: ScalaDebugTestSession = _
+  private var breakpoints: List[IBreakpoint] = Nil
+
+  // hcr-related tests modify sources so for each test we recreate test workspace in original state
+  @Before
+  def initializeTests(): Unit = {
+    project.underlying.build(IncrementalProjectBuilder.CLEAN_BUILD, new NullProgressMonitor)
+    project.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor)
+    session = initDebugSession("hcr")
+    HotCodeReplacePreferences.hcrEnabled = true
+    HotCodeReplacePreferences.dropObsoleteFramesAutomatically = true
+  }
+
+  @After
+  def cleanDebugSession(): Unit = {
+    breakpoints foreach session.removeBreakpoint
+    session.terminate()
+    session = null
+    SDTTestUtils.deleteProjects(project)
+  }
+
+  private def initDebugSession(launchConfigurationName: String) =
+    ScalaDebugTestSession(file(launchConfigurationName + ".launch"))
+
+  private val recursiveMethodLocalInt = intValueMatcher("recursiveMethodLocalInt")
+  private val remainingRecursiveCallsCounter = intValueMatcher("remainingRecursiveCallsCounter")
+  private val classLocalInt = intValueMatcher("classLocalInt")
+
+  private def intValueMatcher(valName: String): Matcher[Int] = {
+    def expectIntValue(expectedValue: Int): Unit = {
+      val actualValue = session.getLocalVariable(valName).getValueString().toInt
+      assertEquals(s"Wrong value of $valName", expectedValue, actualValue)
+    }
+    new Matcher(expectIntValue)
+  }
+
+  private val currentFrameLocation: Matcher[Location] = {
+    def expectCurrentFrameLocation(expectedLocation: Location): Unit =
+      session.checkStackFrame(expectedLocation.typeName, expectedLocation.methodSignature, expectedLocation.lineNumber)
+
+    new Matcher(expectCurrentFrameLocation)
+  }
+
+  private def dropToTopFrame(): Unit = session dropToFrame session.currentStackFrame
+  private def dropToFrameWithIndex(frameIndex: Int): Unit = session dropToFrame session.currentStackFrames(frameIndex)
+
+  private def addLineBreakpointAt(location: Location): Unit =
+    breakpoints = breakpoints :+ session.addLineBreakpoint(location.typeName, location.lineNumber)
+
+  private def disableHcr(): Unit =
+    HotCodeReplacePreferences.hcrEnabled = false
+
+  private def disableHcrForFilesContainingErrors(): Unit =
+    HotCodeReplacePreferences.performHcrForFilesContainingErrors = false
+
+  private def buildWithNewValueAssignedToClassLocalInt(newValue: Int): Unit =
+    buildWithModifiedLine(TestedFilePath, ClassMethodBeginning.lineNumber, s"val classLocalInt = $newValue")
+
+  private def buildWithNewValueReturnedFromClassMethod(newLine: String): Unit =
+    buildWithModifiedLine(TestedFilePath, ClassMethodEnd.lineNumber, newLine)
+
+  private def buildWithNewParamOfNestedClassFactoryMethod(paramValue: Int): Unit =
+    buildWithModifiedLine(TestedFilePath,
+      RecursiveMethodBeginning.lineNumber,
+      s"val instance = nestedObject.NestedClass($paramValue)")
+
+  private def buildWithNewValueAssignedToCustomThreadLocalString(newValue: String): Unit =
+    buildWithModifiedLine(TestedFilePath,
+      RunMethodBeginning.lineNumber,
+      s"""val customThreadLocalString = "$newValue"""")
+
+  private def buildWithNewParamOfRecursiveMethod(newValue: Int): Unit =
+    buildWithModifiedLine(TestedFilePath, MainMethodEnd.lineNumber, s"recursiveMethod($newValue)")
+
+  private def buildWithIncorrectParamOfRecursiveMethod(newValue: String): Unit =
+    buildWithModifiedLine(TestedFilePath, MainMethodEnd.lineNumber, s"""recursiveMethod("$newValue")""")
+
+  private def createAndGoToBreakpointAtTheEndOfRecursiveMethod(): Unit = {
+    // GIVEN the thread is suspended at the correct breakpoint and we're sure initial values are correct
+    addLineBreakpointAt(RecursiveMethodEnd)
+    session.launch()
+    session.waitUntilSuspended()
+    currentFrameLocation mustEqual RecursiveMethodEnd
+    remainingRecursiveCallsCounter mustEqual 0
+    recursiveMethodLocalInt mustEqual DefaultRecursiveMethodLocalIntValue
+  }
+
+  private def createAndGoToBreakpointAtTheEndOfClassMethod(): Unit = {
+    // GIVEN the thread is suspended at the correct breakpoint and we're sure initial value is correct
+    addLineBreakpointAt(ClassMethodEnd)
+    session.launch()
+    session.waitUntilSuspended()
+    currentFrameLocation mustEqual ClassMethodEnd
+    classLocalInt mustEqual 7
+  }
+
+  @Test
+  def successfulHcrWithSimpleMethod(): Unit = {
+    createAndGoToBreakpointAtTheEndOfClassMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewValueAssignedToClassLocalInt(8)
+
+    // THEN we automatically returned to the beginning of a method
+    currentFrameLocation mustEqual ClassMethodBeginning
+
+    // WHEN resume execution
+    session.resumeToSuspension()
+
+    // THEN we stopped at the breakpoint, new value is applied
+    currentFrameLocation mustEqual ClassMethodEnd
+    classLocalInt mustEqual 8
+
+    // WHEN edit code once again and rebuild
+    buildWithNewValueAssignedToClassLocalInt(10)
+
+    // THEN we automatically returned to the beginning of a method
+    currentFrameLocation mustEqual ClassMethodBeginning
+
+    // WHEN resume execution
+    session.resumeToSuspension()
+
+    // THEN we stopped at the breakpoint, new value is applied
+    currentFrameLocation mustEqual ClassMethodEnd
+    classLocalInt mustEqual 10
+  }
+
+  @Test
+  def hcrWithDisabledAutomaticDroppingFrames(): Unit = {
+    HotCodeReplacePreferences.dropObsoleteFramesAutomatically = false
+    HotCodeReplacePreferences.allowToDropObsoleteFramesManually = true
+
+    createAndGoToBreakpointAtTheEndOfClassMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewValueAssignedToClassLocalInt(8)
+
+    // THEN current frame is obsolete
+    currentFrameLocation mustEqual ClassMethodEnd.asObsolete
+
+    // WHEN drop one frame and resume
+    dropToTopFrame()
+    session.resumeToSuspension()
+
+    // THEN thread is suspended at the same breakpoint and new values are applied
+    currentFrameLocation mustEqual ClassMethodEnd
+    classLocalInt mustEqual 8
+  }
+
+  @Test
+  def successfulHcrWithMethodNotInStackTrace(): Unit = {
+    createAndGoToBreakpointAtTheEndOfRecursiveMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewValueReturnedFromClassMethod(s"230 + $IntFromCtorArgName")
+
+    // AND return to the beginning of a current method
+    dropToTopFrame()
+    currentFrameLocation mustEqual RecursiveMethodBeginning
+
+    // AND recompute current frame
+    session.resumeToSuspension()
+
+    // THEN final values are correct
+    currentFrameLocation mustEqual RecursiveMethodEnd
+    remainingRecursiveCallsCounter mustEqual 0
+    recursiveMethodLocalInt mustEqual 235
+  }
+
+  @Test
+  def disabledHcrWithMethodNotInStackTrace(): Unit = {
+    disableHcr()
+    createAndGoToBreakpointAtTheEndOfRecursiveMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewValueReturnedFromClassMethod(s"230 + $IntFromCtorArgName")
+
+    // AND return to the beginning of a current method
+    dropToTopFrame()
+    currentFrameLocation mustEqual RecursiveMethodBeginning
+
+    // AND recompute current frame
+    session.resumeToSuspension()
+
+    // THEN final values are correct
+    currentFrameLocation mustEqual RecursiveMethodEnd
+    remainingRecursiveCallsCounter mustEqual 0
+    recursiveMethodLocalInt mustEqual DefaultRecursiveMethodLocalIntValue
+  }
+
+  @Test
+  def classesNotReplacedDueToErrorsInCodeWithMethodNotInStackTrace(): Unit = {
+    disableHcrForFilesContainingErrors()
+    createAndGoToBreakpointAtTheEndOfRecursiveMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewValueReturnedFromClassMethod(s"2015 + compilation error!")
+
+    // AND return to the beginning of a current method
+    dropToTopFrame()
+    currentFrameLocation mustEqual RecursiveMethodBeginning
+
+    // AND recompute current frame
+    session.resumeToSuspension()
+
+    // THEN final values are correct
+    currentFrameLocation mustEqual RecursiveMethodEnd
+    remainingRecursiveCallsCounter mustEqual 0
+    recursiveMethodLocalInt mustEqual DefaultRecursiveMethodLocalIntValue
+  }
+
+  @Ignore("Probably the VM crash will be fixed, when the automatic semantic dropping frames BEFORE HCR will be implemented")
+  @Test
+  def successfulHcrWithRecursiveMethod(): Unit = {
+    createAndGoToBreakpointAtTheEndOfRecursiveMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewParamOfNestedClassFactoryMethod(50)
+
+    // THEN we automatically returned to the beginning of a method and dropped all old frames
+    // related to this method from the recursive call
+    currentFrameLocation mustEqual RecursiveMethodBeginning
+    remainingRecursiveCallsCounter mustEqual 2
+
+    // WHEN resume execution
+    session.resumeToSuspension()
+
+    // THEN we stopped at the breakpoint, new values are applied
+    currentFrameLocation mustEqual RecursiveMethodEnd
+    remainingRecursiveCallsCounter mustEqual 0
+    recursiveMethodLocalInt mustEqual 150
+  }
+
+  @Test
+  def successfulHcrWithAffectedFartherFrame(): Unit = {
+    createAndGoToBreakpointAtTheEndOfRecursiveMethod()
+
+    addLineBreakpointAt(RecursiveMethodSelfCall)
+
+    // WHEN edit code and rebuild
+    buildWithNewParamOfRecursiveMethod(4)
+
+    // THEN we automatically returned to the beginning of a method
+    currentFrameLocation mustEqual MainMethodBeginning
+
+    // WHEN resume execution
+    session.resumeToSuspension()
+
+    // THEN final values are correct
+    currentFrameLocation mustEqual RecursiveMethodSelfCall
+    remainingRecursiveCallsCounter mustEqual 4
+    recursiveMethodLocalInt mustEqual DefaultRecursiveMethodLocalIntValue
+  }
+
+  @Test
+  def disabledHcr(): Unit = {
+    disableHcr()
+    createAndGoToBreakpointAtTheEndOfRecursiveMethod()
+
+    addLineBreakpointAt(RecursiveMethodSelfCall)
+
+    // WHEN edit code and rebuild with disabled HCR
+    buildWithNewParamOfRecursiveMethod(4)
+
+    // THEN classes are not replaced
+    currentFrameLocation mustEqual RecursiveMethodEnd
+    dropToFrameWithIndex(3)
+
+    currentFrameLocation mustEqual MainMethodBeginning
+
+    session.resumeToSuspension()
+
+    currentFrameLocation mustEqual RecursiveMethodSelfCall
+    remainingRecursiveCallsCounter mustEqual 2
+    recursiveMethodLocalInt mustEqual DefaultRecursiveMethodLocalIntValue
+  }
+
+  @Test
+  def classesNotReplacedDueToErrorsInCode(): Unit = {
+    disableHcrForFilesContainingErrors()
+    createAndGoToBreakpointAtTheEndOfRecursiveMethod()
+
+    addLineBreakpointAt(RecursiveMethodSelfCall)
+
+    // WHEN edit code and rebuild with errors
+    buildWithIncorrectParamOfRecursiveMethod("compilation error as it's not Int")
+
+    // THEN classes are not replaced
+    currentFrameLocation mustEqual RecursiveMethodEnd
+    dropToFrameWithIndex(3)
+
+    currentFrameLocation mustEqual MainMethodBeginning
+
+    session.resumeToSuspension()
+
+    currentFrameLocation mustEqual RecursiveMethodSelfCall
+    remainingRecursiveCallsCounter mustEqual 2
+    recursiveMethodLocalInt mustEqual DefaultRecursiveMethodLocalIntValue
+  }
+
+  // Sometimes after a few HCR operations VM doesn't mark frames as obsolete. Then we don't perform
+  // Drop To Frame what is misleading. Then user have to run it manually and everything starts working
+  // as expected. Anyway it should get better when we'll stop using isObsolete to state what should be dropped.
+  @Ignore("Hopefully it will be fixed, when the automatic semantic dropping frames BEFORE HCR will be implemented")
+  @Test
+  def automaticDroppingFramesAfterManyHcrOperationsInARow(): Unit = {
+    createAndGoToBreakpointAtTheEndOfClassMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewValueAssignedToClassLocalInt(10)
+
+    // THEN we automatically returned to the beginning of a method
+    currentFrameLocation mustEqual ClassMethodBeginning
+
+    // WHEN edit code and rebuild once again without resuming in meantime
+    buildWithNewParamOfNestedClassFactoryMethod(50)
+
+    // THEN we automatically returned to the beginning of a method containing the last change
+    currentFrameLocation mustEqual RecursiveMethodBeginning
+    // WHEN resume execution
+    session.resumeToSuspension()
+
+    // THEN we stopped at the breakpoint, new value is applied
+    currentFrameLocation mustEqual ClassMethodEnd
+    classLocalInt mustEqual 10
+  }
+
+  @Test
+  def doNotDropLastFrame(): Unit = {
+    // GIVEN the thread is suspended at the correct breakpoint in the separate thread and initial values are correct
+    addLineBreakpointAt(RunMethodEnd)
+    session.launch()
+    session.waitUntilSuspended()
+    currentFrameLocation mustEqual RunMethodEnd
+
+    // WHEN edit code and rebuild
+    buildWithNewValueAssignedToCustomThreadLocalString("other string")
+
+    // THEN current frame is obsolete - we couldn't drop the only stack frame
+    currentFrameLocation mustEqual RunMethodEnd.asObsolete
+  }
+
+  @Test
+  def prohibitedDroppingObsoleteFramesManuallyDoesNotAffectAutomaticDropping(): Unit = {
+    HotCodeReplacePreferences.allowToDropObsoleteFramesManually = false
+    createAndGoToBreakpointAtTheEndOfClassMethod()
+
+    // WHEN edit code and rebuild
+    buildWithNewValueAssignedToClassLocalInt(8)
+
+    // THEN we automatically returned to the beginning despite set flag
+    currentFrameLocation mustEqual ClassMethodBeginning
+  }
+}

--- a/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/.classpath
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/.project
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>hcr</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/hcr.launch
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/hcr.launch
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="scala.application">
+    <stringAttribute key="bad_container_name" value="/debug/f"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/hot-code-replace/src/debug/Hcr.scala"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+        <mapEntry key="[debug]" value="scala.application.new"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="debug.MainObject"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="hot-code-replace"/>
+</launchConfiguration>

--- a/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/src/debug/Hcr.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/src/debug/Hcr.scala
@@ -1,0 +1,38 @@
+package debug
+
+object MainObject extends App {
+  object nestedObject {
+    case class NestedClass(intFromCtor: Int) {
+      def classMethod = {
+        val classLocalInt = 7
+        100 + intFromCtor // change this with manual drop to frame
+      }
+    }
+  }
+
+  def recursiveMethod(remainingRecursiveCallsCounter: Int): Int = {
+    val instance = nestedObject.NestedClass(5) // change this to have frames dropped automatically
+    val recursiveMethodLocalInt = instance.classMethod
+    if (remainingRecursiveCallsCounter > 0)
+      recursiveMethod(remainingRecursiveCallsCounter - 1) + 1 // avoid tail recursion as we need additional frames
+    else
+      // breakpoint here
+      recursiveMethodLocalInt
+  }
+
+  def mainMethod() : Unit = {
+    val unused = "unused string"
+    recursiveMethod(2) // change this to have frames dropped automatically
+  }
+
+  mainMethod()
+
+  object CustomThread extends Thread {
+    override def run(): Unit = {
+      val customThreadLocalString = "some string"
+      println("put breakpoint here - we won't execute this println")
+    }
+  }
+
+  CustomThread.start()
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/breakpoints/BreakpointSupport.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/breakpoints/BreakpointSupport.scala
@@ -64,7 +64,7 @@ private object BreakpointSupportActor {
   }
 
   def apply(breakpoint: IBreakpoint, debugTarget: ScalaDebugTarget): Actor = {
-    val typeName= breakpoint.typeName
+    val typeName = breakpoint.typeName
 
     val breakpointRequests = createBreakpointsRequests(breakpoint, typeName, debugTarget)
 
@@ -174,6 +174,8 @@ private class BreakpointSupportActor private (
       reply(None)
     case ScalaDebugBreakpointManager.GetBreakpointRequestState(_) =>
       reply(requestsEnabled)
+    case ScalaDebugBreakpointManagerActor.ReenableBreakpointAfterHcr =>
+      reenableBreakpointRequestsAfterHcr()
   }
 
   /**
@@ -218,5 +220,18 @@ private class BreakpointSupportActor private (
    */
   private def breakpointHit(location: Location, thread: ThreadReference) {
     debugTarget.threadSuspended(thread, DebugEvent.BREAKPOINT)
+  }
+
+  /**
+   * After hcr often we don't get events related to breakpoint requests.
+   * Reenabling them seems to help in most of cases.
+   */
+  private def reenableBreakpointRequestsAfterHcr(): Unit = {
+    breakpointRequests.foreach { breakpointRequest =>
+      if (breakpointRequest.isEnabled()) {
+        breakpointRequest.disable()
+        breakpointRequest.enable()
+      }
+    }
   }
 }

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/breakpoints/BreakpointSupport.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/breakpoints/BreakpointSupport.scala
@@ -52,6 +52,9 @@ private object BreakpointSupportActor {
   // specific events
   case class Changed(delta: IMarkerDelta)
 
+  /** The message used to reenable breakpoint requests managed by the given actor. */
+  case object ReenableBreakpointAfterHcr
+
   val eventHandlerMappings = EventHandlerMapping.mappings
 
   /**
@@ -174,7 +177,7 @@ private class BreakpointSupportActor private (
       reply(None)
     case ScalaDebugBreakpointManager.GetBreakpointRequestState(_) =>
       reply(requestsEnabled)
-    case ScalaDebugBreakpointManagerActor.ReenableBreakpointAfterHcr =>
+    case BreakpointSupportActor.ReenableBreakpointAfterHcr =>
       reenableBreakpointRequestsAfterHcr()
   }
 

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ChangedClassFilesVisitor.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ChangedClassFilesVisitor.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2015 Contributor. All rights reserved.
+ */
+package org.scalaide.debug.internal.hcr
+
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IMarker
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.resources.IResourceDelta
+import org.eclipse.core.resources.IResourceDeltaVisitor
+import org.eclipse.core.runtime.IPath
+import org.eclipse.core.runtime.Path
+import org.eclipse.jdt.core.ICompilationUnit
+import org.eclipse.jdt.core.IJavaModelMarker
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.core.ToolFactory
+import org.eclipse.jdt.core.util.IClassFileReader
+import org.eclipse.jdt.internal.debug.core.JavaDebugUtils
+import org.scalaide.logging.HasLogger
+import org.scalaide.debug.internal.preferences.HotCodeReplacePreferences
+
+private[internal] case class ClassFileResource(fullyQualifiedName: String, classFile: IFile)
+
+/**
+ * Collects classes affected by changes in code and optionally skips these ones which contain
+ * error markers in associated source files.
+ * The implementation of this class is inspired by
+ * org.eclipse.jdt.internal.debug.core.hcr.JavaHotCodeReplaceManager.ChangedClassFilesVisitor
+ * used in Java HCR implementation.
+ */
+private[internal] class ChangedClassFilesVisitor extends IResourceDeltaVisitor with HasLogger {
+  import ChangedClassFilesVisitor._
+
+  // the value stored as a field to finish applying the same strategy to all classes even when someone changed
+  // the configuration in the meantime
+  private var replaceDespiteCompilationErrors = HotCodeReplacePreferences.performHcrForFilesContainingErrors
+
+  /**
+   * Found classes containing changes.
+   */
+  private val changedClasses = scala.collection.mutable.Set[ClassFileResource]()
+
+  def getChangedClasses: List[ClassFileResource] = changedClasses.toList
+
+  /**
+   * It should be called always before the visitor is reused.
+   */
+  def reset(): Unit = {
+    replaceDespiteCompilationErrors = HotCodeReplacePreferences.performHcrForFilesContainingErrors
+    changedClasses.clear()
+  }
+
+  /**
+   * Looks for modified classes, adds them to changedClasses and decides whether children should be visited.
+   * @return whether children should be visited or not
+   */
+  override def visit(delta: IResourceDelta): Boolean = delta match {
+    case MayContainChangedClassesIn(resource) => resource.getType match {
+      case IResource.FILE =>
+        resource match {
+          case file: IFile if isContentChanged(delta) && isClassFile(file) =>
+            visitClassFile(file)
+          case _ => // no changes or not a class file - nothing to do
+        }
+        false
+      case _ => true
+    }
+    case _ => false
+  }
+
+  private def visitClassFile(classFile: IFile): Unit =
+    for {
+      localPath <- Option(classFile.getLocation())
+      reader <- classFileReader(localPath)
+    } {
+      val slashDelimitedQualifiedName = new String(reader.getClassName())
+
+      if (replaceDespiteCompilationErrors || !hasCompilationErrors(classFile, reader, slashDelimitedQualifiedName)) {
+        val className = slashDelimitedQualifiedName.replace('/', '.')
+        changedClasses.add(ClassFileResource(className, classFile))
+      }
+    }
+
+  private def classFileReader(path: IPath) = {
+    val osSpecificPath = path.toOSString()
+    Option(ToolFactory.createDefaultClassFileReader(osSpecificPath, IClassFileReader.CLASSFILE_ATTRIBUTES))
+  }
+
+  /**
+   * Checks whether there are errors markers located in src file associated with given class file.
+   *
+   * @param classFile class file for given type
+   * @param reader class file reader for given type
+   * @param fullyQualifiedName slash delimited name of type
+   */
+  private def hasCompilationErrors(classFile: IFile, reader: IClassFileReader, fullyQualifiedName: String): Boolean =
+    try {
+      def isErrorMarker(marker: IMarker): Boolean =
+        marker.getAttribute(IMarker.SEVERITY, /* defaultValue = */ IMarker.SEVERITY_INFO) == IMarker.SEVERITY_ERROR
+
+      def hasErrorMarkers(sourceFile: IResource): Boolean = {
+        val problemMarkers = sourceFile.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE)
+        problemMarkers exists isErrorMarker
+      }
+
+      val srcFile = getSourceFile(classFile, reader, fullyQualifiedName)
+      srcFile exists hasErrorMarkers
+    } catch {
+      case e: Exception =>
+        logger.error(s"Something went wrong when looking for compilation error markers for type $fullyQualifiedName", e)
+        true
+    }
+
+  /**
+   * Tries to find the source file for given type in the associated project.
+   */
+  private def getSourceFile(classFile: IFile, reader: IClassFileReader, fullyQualifiedName: String): Option[IResource] = {
+    try {
+      val project: IJavaProject = JavaCore.create(classFile.getProject)
+
+      val sourceAttribute = Option(reader.getSourceFileAttribute)
+      val sourceFileName = sourceAttribute map { srcAttr =>
+        new String(srcAttr.getSourceFileName())
+      }
+
+      sourceFileName.flatMap { srcName =>
+        val i = fullyQualifiedName.lastIndexOf('/')
+        val sourceFilePath = if (i > 0) fullyQualifiedName.substring(0, i + 1) + srcName else srcName
+        Option(project.findElement(new Path(sourceFilePath)))
+      }.getOrElse {
+        JavaDebugUtils.findElement(fullyQualifiedName, project)
+      } match {
+        case cu: ICompilationUnit => Some(cu.getCorrespondingResource())
+        case _ => None
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Something went wrong when looking for src file for type $fullyQualifiedName", e)
+        None
+    }
+  }
+
+  private def isClassFile(file: IFile) = "class" == file.getFullPath().getFileExtension()
+
+  private def isContentChanged(delta: IResourceDelta) = 0 != (delta.getFlags() & IResourceDelta.CONTENT)
+}
+
+private[hcr] object ChangedClassFilesVisitor {
+
+  private object MayContainChangedClassesIn {
+    def unapply(delta: IResourceDelta): Option[IResource] =
+      if (delta == null || 0 == (delta.getKind() & IResourceDelta.CHANGED)) None
+      else Option(delta.getResource())
+  }
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ScalaHotCodeReplaceManager.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ScalaHotCodeReplaceManager.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2015 Contributor. All rights reserved.
+ */
+package org.scalaide.debug.internal.hcr
+
+import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.collection.mutable.Publisher
+
+import org.eclipse.core.resources.IResourceChangeEvent
+import org.eclipse.core.resources.IResourceChangeListener
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.debug.core.DebugEvent
+import org.eclipse.debug.core.DebugPlugin
+import org.scalaide.debug.internal.BaseDebuggerActor
+import org.scalaide.debug.internal.model.ScalaDebugTarget
+import org.scalaide.debug.internal.model.ScalaDebugTarget.ReplaceClasses
+import org.scalaide.debug.internal.preferences.HotCodeReplacePreferences
+import org.scalaide.logging.HasLogger
+
+import com.sun.jdi.ReferenceType
+
+import ScalaHotCodeReplaceManager.HCRFailed
+import ScalaHotCodeReplaceManager.HCRNotSupported
+import ScalaHotCodeReplaceManager.HCRResult
+
+private[internal] object ScalaHotCodeReplaceManager {
+
+  private[hcr] sealed trait HCRResult
+  private[hcr] case class HCRNotSupported(launchName: String) extends HCRResult
+  private[hcr] case class HCRFailed(launchName: String) extends HCRResult
+
+  def create(debugTargetCompanionActor: BaseDebuggerActor): Option[ScalaHotCodeReplaceManager] = {
+    if (HotCodeReplacePreferences.hcrEnabled)
+      Some(new ScalaHotCodeReplaceManager(debugTargetCompanionActor))
+    else
+      None
+  }
+}
+
+/**
+ * Monitors changed resources and notifies debug target's companion actor, when there are some changed class files
+ * which could be replaced in VM.
+ */
+class ScalaHotCodeReplaceManager private (debugTargetCompanionActor: BaseDebuggerActor) extends IResourceChangeListener with HasLogger {
+
+  import scala.collection.JavaConverters._
+
+  private lazy val visitor = new ChangedClassFilesVisitor
+
+  private[internal] def init(): Unit = {
+    ResourcesPlugin.getWorkspace().addResourceChangeListener(this, IResourceChangeEvent.POST_BUILD)
+  }
+
+  private[internal] def dispose(): Unit = {
+    ResourcesPlugin.getWorkspace().removeResourceChangeListener(this)
+  }
+
+  override def resourceChanged(event: IResourceChangeEvent): Unit = {
+    val changedClasses = getChangedClasses(event)
+    if (changedClasses.nonEmpty)
+      debugTargetCompanionActor ! ReplaceClasses(changedClasses)
+  }
+
+  private def getChangedClasses(event: IResourceChangeEvent): List[ClassFileResource] = {
+    val delta = event.getDelta()
+    if (delta == null || event.getType() != IResourceChangeEvent.POST_BUILD)
+      Nil
+    else
+      try {
+        visitor.reset()
+        delta.accept(visitor)
+        visitor.getChangedClasses
+      } catch {
+        case e: Exception =>
+          logger.error(s"Something went wrong when processing an event with delta $delta", e)
+          // quiet failure - should we do something else?
+          Nil
+      }
+  }
+}
+
+private[internal] trait HotCodeReplaceExecutor extends Publisher[HCRResult] with HasLogger {
+  import scala.collection.JavaConverters._
+
+  protected val debugTarget: ScalaDebugTarget
+
+  /**
+   * If VM supports HCR, it replaces classes already loaded to VM using new class file versions.
+   */
+  def replaceClassesIfVMAllows(changedClasses: Seq[ClassFileResource]): Unit = {
+    val typesToReplace = changedClasses filter isLoadedToVM
+    if (typesToReplace.nonEmpty) {
+      val launchName = currentLaunchName
+
+      // we check this at the end to don't disturb user, if it's not really needed
+      if (supportsHcr) doHotCodeReplace(launchName, typesToReplace)
+      else runAsynchronously {
+        () => publish(HCRNotSupported(launchName))
+      }
+    }
+  }
+
+  private def doHotCodeReplace(launchName: String, typesToReplace: Seq[ClassFileResource]): Unit = {
+    try {
+      logger.debug(s"Performing Hot Code Replace for debug configuration '$launchName'")
+      debugTarget.isPerformingHotCodeReplace = true
+      // FIXME We need the automatic semantic dropping frames BEFORE HCR to prevent VM crashes.
+      // We should drop possibly affected frames in this place (remember to wait for the end of such
+      // an operation) and run Step Into after HCR. If no frames will be dropped, we'll just refresh
+      // current stack frames.
+      redefineTypes(typesToReplace)
+      updateScalaDebugEnv(typesToReplace)
+      logger.debug(s"Performing Hot Code Replace for debug configuration '$launchName' succeeded")
+    } catch {
+      case e: Exception =>
+        logger.error(s"Something went wrong when redefining classes in VM for debug configuration '$launchName'", e)
+        runAsynchronously {
+          () => publish(HCRFailed(launchName))
+        }
+    } finally {
+      debugTarget.isPerformingHotCodeReplace = false
+      debugTarget.fireChangeEvent(DebugEvent.CONTENT)
+    }
+  }
+
+  private def supportsHcr = debugTarget.virtualMachine.canRedefineClasses()
+
+  private def redefineTypes(changedClasses: Seq[ClassFileResource]): Unit = {
+    val bytesForClasses = getTypesToBytes(changedClasses)
+    debugTarget.virtualMachine.redefineClasses(bytesForClasses.asJava)
+  }
+
+  private def updateScalaDebugEnv(changedClasses: Seq[ClassFileResource]): Unit = {
+    debugTarget.updateStackFramesAfterHcr(HotCodeReplacePreferences.dropObsoleteFramesAutomatically)
+    debugTarget.breakpointManager.reenableBreakpointsInClasses(changedClasses.map(_.fullyQualifiedName))
+  }
+
+  // it has no sense to try to replace classes which are not loaded to VM
+  private def isLoadedToVM(changedClass: ClassFileResource) = !classesByName(changedClass.fullyQualifiedName).isEmpty()
+
+  private def getTypesToBytes(changedClasses: Seq[ClassFileResource]): Map[ReferenceType, Array[Byte]] =
+    changedClasses.flatMap { changedClass =>
+      val classes: Seq[ReferenceType] = classesByName(changedClass.fullyQualifiedName).asScala
+      val bytes = org.eclipse.jdt.internal.core.util.Util.getResourceContentsAsByteArray(changedClass.classFile)
+      classes.map(_ -> bytes)
+    }(collection.breakOut)
+
+  private def classesByName(name: String) = debugTarget.virtualMachine.classesByName(name)
+
+  private def runAsynchronously(fun: () => Unit): Unit = {
+    val runnable = new Runnable() {
+      override def run(): Unit = fun()
+    }
+    DebugPlugin.getDefault().asyncExec(runnable)
+  }
+
+  /**
+   * Returns an actual name of a launch configuration used to run this debug session.
+   * If user changed the name or removed the launch config in the meantime, this will be taken into account.
+   */
+  private def currentLaunchName: String = {
+    val config = Option(debugTarget.getLaunch().getLaunchConfiguration())
+    val launchName = config.map(_.getName)
+    launchName.getOrElse("<unknown>")
+  }
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ui/HotCodeReplaceListener.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ui/HotCodeReplaceListener.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 Contributor. All rights reserved.
+ */
+package org.scalaide.debug.internal.hcr
+package ui
+
+import scala.collection.mutable.Publisher
+import scala.collection.mutable.Subscriber
+
+import org.eclipse.jface.dialogs.MessageDialog
+import org.scalaide.debug.internal.preferences.HotCodeReplacePreferences
+import org.scalaide.util.eclipse.SWTUtils
+import org.scalaide.util.ui.DisplayThread
+
+import ScalaHotCodeReplaceManager.HCRFailed
+import ScalaHotCodeReplaceManager.HCRNotSupported
+import ScalaHotCodeReplaceManager.HCRResult
+
+/**
+ * Informs user when there's something wrong related to HCR.
+ */
+private[internal] object HotCodeReplaceListener extends Subscriber[HCRResult, Publisher[HCRResult]] {
+
+  override def notify(publisher: Publisher[HCRResult], event: HCRResult): Unit = event match {
+    case HCRNotSupported(launchName) =>
+      if (HotCodeReplacePreferences.notifyAboutUnsupportedHcr)
+        notifyAboutUnsupportedHCR(launchName)
+    case HCRFailed(launchName) =>
+      if (HotCodeReplacePreferences.notifyAboutFailedHcr)
+        notifyAboutFailedHCR(launchName)
+  }
+
+  private def notifyAboutUnsupportedHCR(launchName: String): Unit = DisplayThread.asyncExec {
+    val title = "Hot Code Replace not supported"
+    val message = s"""Hot Code Replace can't be performed for debug configuration '$launchName'.
+                     |Your VM doesn't support redefining classes.""".stripMargin
+    MessageDialog.openWarning(SWTUtils.getShell, title, message)
+  }
+
+  private def notifyAboutFailedHCR(launchName: String): Unit = DisplayThread.asyncExec {
+    val title = "Hot Code Replace failed"
+    val message = s"""Performing Hot Code Replace failed for debug configuration '$launchName'.
+                     |Your debug session can be in bizarre state. Consider restarting it.""".stripMargin
+    MessageDialog.openError(SWTUtils.getShell, title, message)
+  }
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugTarget.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugTarget.scala
@@ -167,9 +167,7 @@ abstract class ScalaDebugTarget private(val virtualMachine: VirtualMachine,
   private var threads = List[ScalaThread]()
 
   @volatile
-  private var isDuringHcr: Boolean = false
-  private[internal] def isPerformingHotCodeReplace: Boolean = isDuringHcr
-  private[internal] def isPerformingHotCodeReplace_=(isPerforming: Boolean) = { isDuringHcr = isPerforming }
+  private[internal] var isPerformingHotCodeReplace: Boolean = false
 
   private[debug] val eventDispatcher: ScalaJdiEventDispatcher
   private[debug] val breakpointManager: ScalaDebugBreakpointManager

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
@@ -52,8 +52,7 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
   override def canStepOver: Boolean = canStep
   override def canStepReturn: Boolean = canStep
   override def isStepping: Boolean = ???
-  private def canStep = suspended && // TODO: needs real logic
-    !target.isPerformingHotCodeReplace
+  private def canStep = suspended && !target.isPerformingHotCodeReplace
 
   override def stepInto(): Unit = stepIntoFrame(stackFrames.head)
   override def stepOver(): Unit = {
@@ -65,8 +64,7 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
 
   // Members declared in org.eclipse.debug.core.model.ISuspendResume
 
-  override def canResume: Boolean = suspended && // TODO: needs real logic
-    !target.isPerformingHotCodeReplace
+  override def canResume: Boolean = suspended && !target.isPerformingHotCodeReplace
   override def canSuspend: Boolean = !suspended // TODO: need real logic
   override def isSuspended: Boolean = util.Try(threadRef.isSuspended).getOrElse(false)
 

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
@@ -20,6 +20,7 @@ import org.scalaide.debug.internal.command.ScalaStepOver
 import org.scalaide.debug.internal.command.ScalaStep
 import org.scalaide.debug.internal.command.ScalaStepInto
 import org.scalaide.debug.internal.command.ScalaStepReturn
+import org.scalaide.debug.internal.preferences.HotCodeReplacePreferences
 import org.scalaide.logging.HasLogger
 import scala.actors.Future
 import scala.collection.JavaConverters.asScalaBufferConverter
@@ -47,10 +48,12 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
 
   // Members declared in org.eclipse.debug.core.model.IStep
 
-  override def canStepInto: Boolean = suspended // TODO: need real logic
-  override def canStepOver: Boolean = suspended // TODO: need real logic
-  override def canStepReturn: Boolean = suspended // TODO: need real logic
+  override def canStepInto: Boolean = canStep
+  override def canStepOver: Boolean = canStep
+  override def canStepReturn: Boolean = canStep
   override def isStepping: Boolean = ???
+  private def canStep = suspended && // TODO: needs real logic
+    !target.isPerformingHotCodeReplace
 
   override def stepInto(): Unit = stepIntoFrame(stackFrames.head)
   override def stepOver(): Unit = {
@@ -62,7 +65,8 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
 
   // Members declared in org.eclipse.debug.core.model.ISuspendResume
 
-  override def canResume: Boolean = suspended // TODO: need real logic
+  override def canResume: Boolean = suspended && // TODO: needs real logic
+    !target.isPerformingHotCodeReplace
   override def canSuspend: Boolean = !suspended // TODO: need real logic
   override def isSuspended: Boolean = util.Try(threadRef.isSuspended).getOrElse(false)
 
@@ -147,14 +151,23 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
   /**
    * It's not possible to drop the bottom stack frame. Moreover all dropped frames and also
    * the one below the target frame can't be native.
+   *
+   * @param frame frame which we'd like to drop and step into it once again
+   * @param relatedToHcr when dropping frames automatically after Hot Code Replace we need a bit different processing
    */
-  private[model] def canDropToFrame(frame: ScalaStackFrame): Boolean = {
+  private[model] def canDropToFrame(frame: ScalaStackFrame, relatedToHcr: Boolean = false): Boolean = {
     val frames = stackFrames
     val indexOfFrame = frames.indexOf(frame)
 
     val atLeastLastButOne = frames.size >= indexOfFrame + 2
-    def notNative = !frames.take(indexOfFrame + 2).exists(_.isNative)
-    canPopFrames && atLeastLastButOne && notNative
+    val canDropObsoleteFrames = HotCodeReplacePreferences.allowToDropObsoleteFramesManually
+
+    // Obsolete frames are marked as native so we have to ignore isNative when user really wants to drop obsolete frames manually.
+    // User has to be aware that it can cause problems when he'd really try to drop the native frame marked as obsolete.
+    def isNativeAndIsNotObsoleteWhenObsoleteAllowed(f: ScalaStackFrame) = f.isNative && !(canDropObsoleteFrames && f.isObsolete)
+
+    def notNative = !frames.take(indexOfFrame + 2).exists(isNativeAndIsNotObsoleteWhenObsoleteAllowed)
+    canPopFrames && atLeastLastButOne && (relatedToHcr || (!target.isPerformingHotCodeReplace && notNative))
   }
 
   private[model] def canPopFrames: Boolean = isSuspended && target.canPopFrames
@@ -165,15 +178,19 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
    * Removes all top stack frames starting from a given one and performs StepInto to reach the given frame again.
    * FOR THE COMPANION ACTOR ONLY.
    */
-  private[model] def dropToFrameInternal(frame: ScalaStackFrame): Unit =
-    if (canDropToFrame(frame)) {
-      val frames = stackFrames
-      val startFrameForStepInto = frames(frames.indexOf(frame) + 1)
-      threadRef.popFrames(frame.stackFrame)
-      stepIntoFrame(startFrameForStepInto)
+  private[model] def dropToFrameInternal(frame: ScalaStackFrame, relatedToHcr: Boolean = false): Unit =
+    (safeThreadCalls(()) or wrapJDIException("Exception while performing Drop To Frame")) {
+      if (canDropToFrame(frame, relatedToHcr)) {
+        val frames = stackFrames
+        val startFrameForStepInto = frames(frames.indexOf(frame) + 1)
+        threadRef.popFrames(frame.stackFrame)
+        stepIntoFrame(startFrameForStepInto)
+      }
     }
 
   def refreshStackFrames(): Unit = companionActor ! RebindStackFrames
+
+  private[internal] def updateStackFramesAfterHcr(msg: ScalaDebugTarget.UpdateStackFramesAfterHcr): Unit = companionActor ! msg
 
   private def processMethodInvocationResult(res: Option[Any]): Value = res match {
     case Some(Right(null)) =>
@@ -234,11 +251,36 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
    * FOR THE COMPANION ACTOR ONLY.
    */
   private[model] def rebindScalaStackFrames(): Unit = (safeThreadCalls(()) or wrapJDIException("Exception while rebinding stack frames")) {
+    rebindFrames()
+  }
+
+  private def rebindFrames(): Unit = {
     // FIXME: Should check that `threadRef.frames == stackFrames` before zipping
     threadRef.frames.asScala.zip(stackFrames).foreach {
       case (jdiStackFrame, scalaStackFrame) => scalaStackFrame.rebind(jdiStackFrame)
     }
   }
+
+  /**
+   * Refreshes frames and optionally drops affected ones.
+   * FOR THE COMPANION ACTOR ONLY.
+   */
+  private[model] def updateScalaStackFramesAfterHcr(dropAffectedFrames: Boolean): Unit =
+    (safeThreadCalls(()) or wrapJDIException("Exception while rebinding stack frames")) {
+      // obsolete frames will be marked as native so we need to check this before we'll rebind frames
+      val nativeFrameIndex = stackFrames.indexWhere(_.isNative)
+
+      rebindFrames()
+      if (dropAffectedFrames) {
+        val topNonNativeFrames =
+          if (nativeFrameIndex == -1) stackFrames
+          else stackFrames.take(nativeFrameIndex - 1) // we can't drop to native frame and also the first older frame can't be native
+        val obsoleteFrames = topNonNativeFrames.filter(_.isObsolete)
+        for (frame <- obsoleteFrames.lastOption)
+          dropToFrameInternal(frame, relatedToHcr = true)
+      }
+      fireChangeEvent(DebugEvent.CONTENT)
+    }
 
   import scala.util.control.Exception
   import Exception.Catch
@@ -292,6 +334,8 @@ private[model] class ScalaThreadActor private(thread: ScalaThread) extends BaseD
       thread.dropToFrameInternal(frame)
     case RebindStackFrames =>
       if (thread.isSuspended) thread.rebindScalaStackFrames()
+    case ScalaDebugTarget.UpdateStackFramesAfterHcr(dropAffectedFrames) =>
+      if (thread.isSuspended) thread.updateScalaStackFramesAfterHcr(dropAffectedFrames)
     case InvokeMethod(objectReference, method, args) =>
       reply(
         if (!thread.isSuspended) {

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/DebuggerPreferencePage.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/DebuggerPreferencePage.scala
@@ -81,9 +81,6 @@ object DebuggerPreferencePage {
   val HotCodeReplaceEnabled = "org.scala-ide.sdt.debug.hcr.enabled"
   val NotifyAboutFailedHcr = "org.scala-ide.sdt.debug.hcr.notifyFailed"
   val NotifyAboutUnsupportedHcr = "org.scala-ide.sdt.debug.hcr.notifyUnsupported"
-
-  // like in Java, it can lead to broken debug session but we have it for consistency
-  // with Java's hcr implementation
   val PerformHcrForFilesContainingErrors = "org.scala-ide.sdt.debug.hcr.performForFilesContainingErrors"
   val DropObsoleteFramesAutomatically = "org.scala-ide.sdt.debug.hcr.dropObsoleteFramesAutomatically"
   val AllowToDropObsoleteFramesManually = "org.scala-ide.sdt.debug.hcr.allowToDropObsoleteFramesManually"

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/DebuggerPreferencePage.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/DebuggerPreferencePage.scala
@@ -22,6 +22,18 @@ class DebuggerPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefer
   private val groups = scala.collection.mutable.MutableList[Group]()
 
   override def createFieldEditors(): Unit = {
+    createFiltersSection()
+    createHotCodeReplaceSection()
+  }
+
+  override def init(workbench: IWorkbench): Unit = {}
+
+  override def dispose: Unit = {
+    groups.foreach(_.dispose())
+    super.dispose()
+  }
+
+  private def createFiltersSection(): Unit = {
     val filtersSection = createGroupComposite("Configured step filters", getFieldEditorParent())
     addBooleanField(FILTER_SYNTHETIC, "Filter SYNTHETIC methods", filtersSection)
     addBooleanField(FILTER_GETTER, "Filter Scala getters", filtersSection)
@@ -30,11 +42,17 @@ class DebuggerPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefer
     addBooleanField(FILTER_FORWARDER, "Filter forwarder to trait methods", filtersSection)
   }
 
-  override def init(workbench: IWorkbench): Unit = {}
+  private def createHotCodeReplaceSection(): Unit = {
+    val hotCodeReplaceSection = createGroupComposite("Hot Code Replace", getFieldEditorParent())
+    addBooleanField(HotCodeReplaceEnabled,
+      "Debug applications with experimental HCR support turned on [the change won't be applied to already running ones]", hotCodeReplaceSection)
 
-  override def dispose: Unit = {
-    groups.foreach(_.dispose())
-    super.dispose()
+    addBooleanField(NotifyAboutFailedHcr, "Show a message when hot code replace fails", hotCodeReplaceSection)
+    addBooleanField(NotifyAboutUnsupportedHcr, "Show a message when hot code replace is not supported by VM", hotCodeReplaceSection)
+    addBooleanField(PerformHcrForFilesContainingErrors, "Replace class files containing compilation errors", hotCodeReplaceSection)
+    addBooleanField(DropObsoleteFramesAutomatically,
+      "When a thread is suspended, try to drop automatically frames recognised by VM as obsolete", hotCodeReplaceSection)
+    addBooleanField(AllowToDropObsoleteFramesManually, "Ignore obsolete state when checking if drop to frame can be performed", hotCodeReplaceSection)
   }
 
   private def addBooleanField(name: String, label: String, group: Group): Unit =
@@ -59,6 +77,16 @@ object DebuggerPreferencePage {
   val FILTER_SETTER = BASE_FILTER + Setter
   val FILTER_DEFAULT_GETTER = BASE_FILTER + DefaultGetter
   val FILTER_FORWARDER = BASE_FILTER + Forwarder
+
+  val HotCodeReplaceEnabled = "org.scala-ide.sdt.debug.hcr.enabled"
+  val NotifyAboutFailedHcr = "org.scala-ide.sdt.debug.hcr.notifyFailed"
+  val NotifyAboutUnsupportedHcr = "org.scala-ide.sdt.debug.hcr.notifyUnsupported"
+
+  // like in Java, it can lead to broken debug session but we have it for consistency
+  // with Java's hcr implementation
+  val PerformHcrForFilesContainingErrors = "org.scala-ide.sdt.debug.hcr.performForFilesContainingErrors"
+  val DropObsoleteFramesAutomatically = "org.scala-ide.sdt.debug.hcr.dropObsoleteFramesAutomatically"
+  val AllowToDropObsoleteFramesManually = "org.scala-ide.sdt.debug.hcr.allowToDropObsoleteFramesManually"
 }
 
 class DebugerPreferencesInitializer extends AbstractPreferenceInitializer {
@@ -71,5 +99,12 @@ class DebugerPreferencesInitializer extends AbstractPreferenceInitializer {
     store.setDefault(FILTER_SETTER, true)
     store.setDefault(FILTER_DEFAULT_GETTER, true)
     store.setDefault(FILTER_FORWARDER, true)
+
+    store.setDefault(HotCodeReplaceEnabled, false)
+    store.setDefault(NotifyAboutFailedHcr, true)
+    store.setDefault(NotifyAboutUnsupportedHcr, true)
+    store.setDefault(PerformHcrForFilesContainingErrors, false)
+    store.setDefault(DropObsoleteFramesAutomatically, true)
+    store.setDefault(AllowToDropObsoleteFramesManually, true)
   }
 }

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/HotCodeReplacePreferences.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/HotCodeReplacePreferences.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 Contributor. All rights reserved.
+ */
+package org.scalaide.debug.internal.preferences
+
+import org.scalaide.debug.internal.ScalaDebugPlugin
+
+/**
+ * Provides convenient way to access preference values related to Hot Code Replace feature.
+ */
+object HotCodeReplacePreferences {
+  import DebuggerPreferencePage._
+
+  private lazy val preferenceStore = ScalaDebugPlugin.plugin.getPreferenceStore()
+
+  def hcrEnabled: Boolean =
+    preferenceStore.getBoolean(HotCodeReplaceEnabled)
+
+  private[internal] def hcrEnabled_=(enabled: Boolean): Unit =
+    preferenceStore.setValue(HotCodeReplaceEnabled, enabled)
+
+  def notifyAboutFailedHcr: Boolean =
+    preferenceStore.getBoolean(NotifyAboutFailedHcr)
+
+  def notifyAboutUnsupportedHcr: Boolean =
+    preferenceStore.getBoolean(NotifyAboutUnsupportedHcr)
+
+  def performHcrForFilesContainingErrors: Boolean =
+    preferenceStore.getBoolean(PerformHcrForFilesContainingErrors)
+
+  private[internal] def performHcrForFilesContainingErrors_=(enabled: Boolean): Unit =
+    preferenceStore.setValue(PerformHcrForFilesContainingErrors, enabled)
+
+  def dropObsoleteFramesAutomatically: Boolean =
+    preferenceStore.getBoolean(DropObsoleteFramesAutomatically)
+
+  private[internal] def dropObsoleteFramesAutomatically_=(enabled: Boolean): Unit =
+    preferenceStore.setValue(DropObsoleteFramesAutomatically, enabled)
+
+  def allowToDropObsoleteFramesManually: Boolean =
+    preferenceStore.getBoolean(AllowToDropObsoleteFramesManually)
+
+  private[internal] def allowToDropObsoleteFramesManually_=(enabled: Boolean): Unit =
+    preferenceStore.setValue(AllowToDropObsoleteFramesManually, enabled)
+}


### PR DESCRIPTION
This PR adds the possibility to modify and compile code, when an application is run in a debug mode, and to have these changes visible and taken into account by the debugged VM without restarting the application. This feature can be turned on/off (right now it's turned off by default). User can decide whether files containing compilation errors should be skipped. Stack frames affected by changes can be automatically dropped. Sometimes users don't like automatic dropping frames after HCR and they prefer to do that manually (see HCR in IntelliJ). Right now there's added also such a possibility. On the other hand it's a question whether it should be available, if we'll know it can cause problems. Therefore, it may be removed in the future, if the HCR with automatic dropping frames would be much more reliable. There are also added several integration JUnit tests.

Note that HCR is limited by JVM's support for replacing classes. Its goal is to allow to experiment with the code inside methods/blocks rather than to develop the whole application in the interactive mode. Changes of methods' signatures etc. don't work - similarly to other HCR implementations from Eclipse or other IDEs.

The implementation is inspired by the HCR support for Java. Scala debug target, threads etc. don't extend the default Java/JDI model and build their own one. Therefore, they are skipped when processing events by various Java-focused managers.

There's added ScalaHotCodeReplaceManager which implements HCR support using the Scala model. Every ScalaDebugTarget has its instance of manager which is also the listener waiting for events related to changed resources. When we get an event about changed class files, we get byte arrays containing new versions of these files and replace the old ones in VM. After this operation it's needed to rebind frames (optionally also drop the obsolete ones) and to refresh breakpoints.

Each from several added tests contains a fragment where the code is modified and recompiled. To ensure that all events and messages are correctly propagated after the additional incremental build, it was needed to use Thread.sleep with 500 millis. I know it's quite ugly solution but it seems to work well and there are not many such tests.

There are serious reasons why this implementation is called the basic support:

- Automatic dropping frames is based on the information which frames are marked as obsolete.

- We get this information after performing HCR but it can cause problems. According to the comment from Eclipse's HCR implementation for Java, JVM is faulty when there are frames rendered as obsolete. Therefore, in Java implementation they try to find affected frames and drop them before performing HCR. We should do the same thing because VM sometimes crashes after HCR and some additional operations. This is the serious blocker. Anyway even current implementation can be quite helpful in many situations. Except JUnit tests it was used to debug e.g.some multithreaded application using futures.

- There's also another problem. After performing HCR sometimes already existing breakpoints behave strange. I had situations where from time to time I was getting a JDI event for the line breakpoint with the different location than the line specified for this breakpoint (sometimes it was one line before or after the expected one). I was investigating this for a while but didn't figure out what to do with that. Also I wasn't able to reproduce such a behaviour in tests. It's something, what should be checked once again after the addition of the new approach to drop affected frames. In case of problems it's always possible to recreate given frame manually, drop to the above frame and go to the expected breakpoint once again. Note: it's sometimes hard to hit breakpoints in Scala IDE even without HCR (they quite often are nondeterministic from the end-user's point of view of). Hence, it's not so simple to test this. It's not possible to fix everything, which basically is not related to this particular feature, but is also used when debugging.

- Dialogs shown when replacing classes is not supported by VM or fails don't contain buttons to terminate or restart debug session. Currently there's only an adequate message.

Lastly, the below disclaimer is required by the lawyers:

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.