### PR TITLE
Add Expression Evaluator to update site

### DIFF
--- a/org.scala-ide.sdt.dev.feature/feature.xml
+++ b/org.scala-ide.sdt.dev.feature/feature.xml
@@ -76,4 +76,20 @@ SUCH DAMAGE.
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.scala-ide.sdt.debug.expression.tests"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.scala-ide.sdt.debug.tests"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
 </feature>

--- a/org.scala-ide.sdt.feature/feature.xml
+++ b/org.scala-ide.sdt.feature/feature.xml
@@ -132,4 +132,11 @@ SUCH DAMAGE.
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.scala-ide.sdt.debug.expression"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/org.scala-ide.sdt.source.feature/feature.xml
+++ b/org.scala-ide.sdt.source.feature/feature.xml
@@ -77,4 +77,11 @@ SUCH DAMAGE.
     version="0.0.0"
     unpack="false"/>
 
+  <plugin
+    id="org.scala-ide.sdt.debug.expression.source"
+    download-size="0"
+    install-size="0"
+    version="0.0.0"
+    unpack="false"/>
+
 </feature>


### PR DESCRIPTION
I forgot to make the expression evaluator available to the update site
by adding it as feature entries to the corresponding configuration
files. Without these changes the EE is no part of the Scala IDE
installation.