### PR TITLE
[WIP] Check compiler plugins for version conflicts and cleanup

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -427,20 +427,27 @@ class ScalaProject private (val underlying: IProject) extends ClasspathManagemen
   /** Compiler settings that are honored by the presentation compiler. */
   private def isPCSetting(settings: Settings): Set[Settings#Setting] = {
     import settings.{ plugin => pluginSetting, _ }
-    Set(deprecation,
+
+    val compilerPluginSettings: Set[Settings#Setting] = Set(pluginOptions,
+      pluginSetting,
+      pluginsDir)
+
+    val generalSettings: Set[Settings#Setting] = Set(deprecation,
       unchecked,
-      pluginOptions,
       verbose,
       Xexperimental,
       future,
       Ylogcp,
-      pluginSetting,
-      pluginsDir,
       YpresentationDebug,
       YpresentationVerbose,
       YpresentationLog,
       YpresentationReplay,
       YpresentationDelay)
+
+    if (effectiveScalaInstallation().version == ScalaInstallation.platformInstallation.version)
+      generalSettings ++ compilerPluginSettings
+    else
+      generalSettings
   }
 
   private def initializeSetting(setting: Settings#Setting, propValue: String) {


### PR DESCRIPTION
PC options in case of incompatibilities.

Compiler plugins (like macro-paradise) are cross-compiled with
the full Scala version, and they are not binary compatible across
minor versions. We acknowledge that and check it properly in the
classpath validator.

Compiler plugins can’t be instantiated in the PC unless the
project Scala version (Installation) is exactly the same as
the platform (the one Eclipse is running). This commit fixes PC
crashes due to such incompatibilities.