### PR TITLE
Disable flaky tests that often fail in Scala PR validation

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/PresentationCompilerActivityListenerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/PresentationCompilerActivityListenerTest.scala
@@ -5,6 +5,7 @@ package org.scalaide.core.compiler
 
 import org.eclipse.jface.util.PropertyChangeEvent
 import org.junit.Test
+import org.junit.Ignore
 import org.junit.Assert._
 import org.scalaide.ui.internal.preferences.ResourcesPreferences
 import Thread.sleep
@@ -221,6 +222,7 @@ class PresentationCompilerActivityListenerTest {
     listener.stop()
   }
 
+  @Ignore("Flaky, often fails in Scala PR validation.")
   @Test
   def changingManyPreferencesAtOnce(): Unit = {
     val shutdownMock = new MockShutdownFun

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
@@ -58,6 +58,7 @@ private object HotCodeReplaceTest {
  * Tests whether HCR works (classes are correctly replaced in VM and we get new values)
  * and whether associated settings are correctly applied.
  */
+@Ignore("Flaky, often fails in Scala PR validation.")
 class HotCodeReplaceTest
     extends TestProjectSetup("hot-code-replace", bundleName = "org.scala-ide.sdt.debug.tests")
     with ScalaDebugRunningTest {


### PR DESCRIPTION
The tests in HotCodeReplaceTest and the test
PresentationCompilerActivityListenerTest#changingManyPreferencesAtOnce
fail often in Scala's PR validation.

Links to recent failures:

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/755/console
  - doNotDropLastFrame(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)
  - hcrWithDisabledAutomaticDroppingFrames(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)
  - successfulHcrWithSimpleMethod(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/753/console
  - hcrWithDisabledAutomaticDroppingFrames(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)
  - successfulHcrWithSimpleMethod(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/752/console
  - prohibitedDroppingObsoleteFramesManuallyDoesNotAffectAutomaticDropping(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/751/console
  - successfulHcrWithMethodNotInStackTrace(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)
  - successfulHcrWithSimpleMethod(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/750/console
  - changingManyPreferencesAtOnce(org.scalaide.core.compiler.PresentationCompilerActivityListenerTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/749/console
  - prohibitedDroppingObsoleteFramesManuallyDoesNotAffectAutomaticDropping(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/748/console
  - changingManyPreferencesAtOnce(org.scalaide.core.compiler.PresentationCompilerActivityListenerTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/746/console
  - prohibitedDroppingObsoleteFramesManuallyDoesNotAffectAutomaticDropping(org.scalaide.debug.internal.hcr.HotCodeReplaceTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/737/console
  - changingManyPreferencesAtOnce(org.scalaide.core.compiler.PresentationCompilerActivityListenerTest)

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/736/console
  - changingManyPreferencesAtOnce(org.scalaide.core.compiler.PresentationCompilerActivityListenerTest)