### PR TITLE
Smarter HCR-related tests

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
+import java.util.concurrent.TimeoutException
 import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IFolder
@@ -254,13 +255,15 @@ object SDTTestUtils extends HasLogger {
   }
 
   /** Wait until `pred` is true, or timeout (in ms). */
-  def waitUntil(timeout: Int)(pred: => Boolean): Unit = {
+  def waitUntil(timeout: Int, withTimeoutException: Boolean = false)(pred: => Boolean): Unit = {
     val start = System.currentTimeMillis()
     var cond = pred
     while ((System.currentTimeMillis() < start + timeout) && !cond) {
       Thread.sleep(100)
       cond = pred
     }
+    if (!cond && withTimeoutException)
+      throw new TimeoutException(s"Predicate is not fulfiled after declared time limit ($timeout millis).")
   }
 
   /**

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/ScalaDebugTestSession.scala
@@ -45,6 +45,9 @@ object ScalaDebugTestSession {
     debugEventListener
   }
 
+  def removeDebugEventListener(debugEventListener: IDebugEventSetListener): Unit =
+    DebugPlugin.getDefault.removeDebugEventListener(debugEventListener)
+
   def apply(launchConfiguration: ILaunchConfiguration): ScalaDebugTestSession = {
     val session = new ScalaDebugTestSession(launchConfiguration)
     session.skipAllBreakpoints(false)
@@ -132,6 +135,7 @@ class ScalaDebugTestSession private (launchConfiguration: ILaunchConfiguration) 
 
   // ----
 
+  @volatile
   var state = NOT_LAUNCHED
   var debugTarget: ScalaDebugTarget = null
   var currentStackFrame: ScalaStackFrame = null

--- a/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/src/debug/Hcr.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/src/debug/Hcr.scala
@@ -5,6 +5,7 @@ object MainObject extends App {
     case class NestedClass(intFromCtor: Int) {
       def classMethod = {
         val classLocalInt = 7
+        val classLocalIntReceivedFromJava = JavaClass.javaClassMethod
         100 + intFromCtor // change this with manual drop to frame
       }
     }
@@ -20,7 +21,7 @@ object MainObject extends App {
       recursiveMethodLocalInt
   }
 
-  def mainMethod() : Unit = {
+  def mainMethod(): Unit = {
     val unused = "unused string"
     recursiveMethod(2) // change this to have frames dropped automatically
   }

--- a/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/src/debug/JavaClass.java
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/hot-code-replace/src/debug/JavaClass.java
@@ -1,0 +1,7 @@
+package debug;
+
+public class JavaClass {
+  public static int javaClassMethod() {
+    return -20;
+  }
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ui/HotCodeReplaceListener.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/hcr/ui/HotCodeReplaceListener.scala
@@ -15,6 +15,7 @@ import org.scalaide.util.ui.DisplayThread
 import ScalaHotCodeReplaceManager.HCRFailed
 import ScalaHotCodeReplaceManager.HCRNotSupported
 import ScalaHotCodeReplaceManager.HCRResult
+import ScalaHotCodeReplaceManager.HCRSucceeded
 
 /**
  * Informs user when there's something wrong related to HCR.
@@ -22,6 +23,7 @@ import ScalaHotCodeReplaceManager.HCRResult
 private[internal] object HotCodeReplaceListener extends Subscriber[HCRResult, Publisher[HCRResult]] {
 
   override def notify(publisher: Publisher[HCRResult], event: HCRResult): Unit = event match {
+    case HCRSucceeded(launchName) => // nothing to do
     case HCRNotSupported(launchName) =>
       if (HotCodeReplacePreferences.notifyAboutUnsupportedHcr)
         notifyAboutUnsupportedHCR(launchName)


### PR DESCRIPTION
So far there was Thread.sleep used with some hardcoded value to ensure
that all events were propagated correctly after the build. In general
it was:

a) buld project with changes
b) there are some post-build actions performed and events are sent in
a background so wait 500 millis

It was causing problems in case of Scala's Jenkins for which 500
millis was too low value. Also it's not the best idea to wait 500
millis (always) even if it's not needed.

Therefore, this commit provides a bit smarter solution. From now on
HCR-related publisher publishes the `HCRSucceeded` event, when HCR is
finished. In tests we take into account what happens under the hood
in aforementioned point b. It is:

1. perform HCR
2. send a message to the thread-related actor => some asynchronous
processing (at the end we fire an event)
3. send a message to the breakpoints-related actor => some
asynchronous processing
4. notify subscribers about finished HCR (asynchronously)

In tests we wait for the events from points 2 and 4 (with some quite
big time limit, what should be helpful in case of Jenkins), and after
that check whether current stack frame is correct, variables have
proper values and so on. Unfortunately there's no event etc. from
`BreakpointSupport` so we check nothing related to the third point.

From now on the test checking whether disabling HCR works correctly
checks only that `ScalaHotCodeReplaceManager` is not created for
ScalaDebugTarget. It's enough.

There's also added to `ScalaHotCodeReplaceManager` the detailed
description how HCR works in case of errors in Java or Scala code
(the differences are a result of differences in deltas which we get
in events).