### PR TITLE
Fixes StackOverflowException in ScalaIndenter

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaIndenter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaIndenter.scala
@@ -1517,7 +1517,7 @@ class ScalaIndenter(
    */
   private def isStringOrCharLiteralAssignment(referenceTokenPos: Int, offset: Int) = {
     val restOfTheLine = document.get(referenceTokenPos, Math.max(offset - referenceTokenPos, 0))
-    val charLit = "'.'"
+    val charLit = """'(\\?.|\\u[\da-fA-F]{4})'"""
     val stringLit = "\".*\""
     val regex = s"($charLit|$stringLit)".r
     regex.findFirstIn(restOfTheLine.trim).isDefined

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaIndenter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaIndenter.scala
@@ -534,7 +534,6 @@ class ScalaIndenter(
     val maxCopyLength = if (tabSize > 0) minLength - minLength % tabSize else minLength // maximum indent to copy
     stripExceedingChars(buffer, maxCopyLength)
 
-
     def safeDivision(num: Int, denom: Int): (Int,Int) = if (denom > 0) (num / denom, num % denom) else (0, num)
 
     // add additional indent
@@ -1518,10 +1517,9 @@ class ScalaIndenter(
    */
   private def isStringOrCharLiteralAssignment(referenceTokenPos: Int, offset: Int) = {
     val restOfTheLine = document.get(referenceTokenPos, Math.max(offset - referenceTokenPos, 0))
-    val charLit = """'(.|\\\w|\\\\)'"""
-    val stringLit = """"(\\"|[^"])*")"""
-
-    val regex = s"(${charLit}|${stringLit}$$".r
+    val charLit = "'.'"
+    val stringLit = "\".*\""
+    val regex = s"($charLit|$stringLit)".r
     regex.findFirstIn(restOfTheLine.trim).isDefined
   }
 }


### PR DESCRIPTION
The main problem is an exponential blowup of a regex. Another problem is
that the val `restOfTheLine` doesn't really contain the rest of the line,
but the start of the string literal until the offset, what in this case
is the end of the string literal. Another problem is that the regex is
too complicated.

The easiest way to fix the problem was to simplify the regex and to stop
the regex computation as soon as a newline character occurs, which
happens because `.` doesn't match newline characters.

No tests included because a test suite doesn't exist. The following
should be the behavior (^ is the cursor before/after `<enter>` is pressed):

    def f = ""^
    //==>
    def f = ""
    ^

and

    def f = ^""
    //==>
    def f =
      ^""

Fixes #1002433