### PR TITLE
Disable flaky tests that often fail in Scala PR validation

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
@@ -116,6 +116,7 @@ private object HotCodeReplaceTest {
  * Tests whether HCR works (classes are correctly replaced in VM and we get new values)
  * and whether associated settings are correctly applied.
  */
+@Ignore("Flaky, often fails in Scala PR validation.")
 class HotCodeReplaceTest
     extends TestProjectSetup("hot-code-replace", bundleName = "org.scala-ide.sdt.debug.tests")
     with ScalaDebugRunningTest {


### PR DESCRIPTION
The tests were recently re-enabled, because they were improved. But they
are still not improved enough.

See:

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/821/console