### PR TITLE
Disable flaky test in ProjectDependenciesTest

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ProjectDependenciesTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ProjectDependenciesTest.scala
@@ -1,6 +1,7 @@
 package org.scalaide.core
 package sbtbuilder
 
+import org.junit.Ignore
 import org.junit.Test
 import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.core.IClasspathEntry
@@ -98,6 +99,7 @@ class ProjectDependenciesTest {
     }
   }
 
+  @Ignore
   @Test def transitive_dep_indirect() {
     val Seq(prjA, prjB, prjC) = createProjects("A", "B", "C")
 


### PR DESCRIPTION
This test failed a lot of times lately, see:

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/837/console

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/835/console

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/829/console

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/827/console

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/823/console

https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/816/console

----

It is weird that it failed only in the last days, did anything change that made this test flaky?