### PR TITLE
Bugfix - encoding and closing streams

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/TaskManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/TaskManager.scala
@@ -46,7 +46,7 @@ object TaskManager {
       iFile <- files
       scalaFile <- ScalaSourceFile.createFromPath(iFile.getFullPath.toOSString)
       sourceFile = scalaFile.lastSourceMap.sourceFile
-      Comment(msg, pos) <- extractComments(sourceFile, iFile.getContents)
+      Comment(msg, pos) <- extractComments(sourceFile, iFile.getContents, iFile.getCharset)
       if pos.isDefined
       task <- taskScanner.extractTasks(msg, pos)
       if task.pos.isDefined
@@ -56,8 +56,8 @@ object TaskManager {
     }
   }
 
-  private def extractComments(sourceFile: SourceFile, contentStream: InputStream): Seq[Comment] = {
-    val contents = scala.io.Source.fromInputStream(contentStream).mkString
+  private def extractComments(sourceFile: SourceFile, contentStream: InputStream, charset: String): Seq[Comment] = {
+    val contents = scala.io.Source.fromInputStream(contentStream)(charset).mkString
     for {
       token <- ScalaLexer.rawTokenise(contents, forgiveErrors = true)
       if (token.tokenType.isComment)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/TaskManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/TaskManager.scala
@@ -57,7 +57,10 @@ object TaskManager {
   }
 
   private def extractComments(sourceFile: SourceFile, contentStream: InputStream, charset: String): Seq[Comment] = {
-    val contents = scala.io.Source.fromInputStream(contentStream)(charset).mkString
+    val contents = try {
+      scala.io.Source.fromInputStream(contentStream)(charset).mkString
+    } finally contentStream.close()
+
     for {
       token <- ScalaLexer.rawTokenise(contents, forgiveErrors = true)
       if (token.tokenType.isComment)


### PR DESCRIPTION
Recent PR (#933) introduced a problem with Scala jenkins.

This PR (hopefully) fixes that issue and also resolves problem with some tests on Windows platform.

Lastly, the below disclaimer is required by the lawyers:

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.