### PR TITLE
Refactor/shorter logging in ee

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/logging/EclipseLogger.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/logging/EclipseLogger.scala
@@ -33,47 +33,55 @@ object EclipseLogger extends Logger {
 
   private val lastCrash: AtomicReference[Throwable] = new AtomicReference
 
-  def debug(message: => Any) {
+  def trace(message: => Any): Unit = {
     info(message)
   }
 
-  def debug(message: => Any, t: Throwable) {
+  def trace(message: => Any, t: Throwable): Unit = {
     info(message, t)
   }
 
-  def info(message: => Any) {
+  def debug(message: => Any): Unit = {
+    info(message)
+  }
+
+  def debug(message: => Any, t: Throwable): Unit = {
+    info(message, t)
+  }
+
+  def info(message: => Any): Unit = {
     info(message, null)
   }
 
-  def info(message: => Any, t: Throwable) {
+  def info(message: => Any, t: Throwable): Unit = {
     log(IStatus.INFO, message, t)
   }
 
-  def warn(message: => Any) {
+  def warn(message: => Any): Unit = {
     warn(message, null)
   }
 
-  def warn(message: => Any, t: Throwable) {
+  def warn(message: => Any, t: Throwable): Unit = {
     log(IStatus.WARNING, message, t)
   }
 
-  def error(message: => Any) {
+  def error(message: => Any): Unit = {
     error(message, null)
   }
 
-  def error(message: => Any, t: Throwable) {
+  def error(message: => Any, t: Throwable): Unit = {
     log(IStatus.ERROR, message, t)
   }
 
-  def fatal(message: => Any) {
+  def fatal(message: => Any): Unit = {
     error(message)
   }
 
-  def fatal(message: => Any, t: Throwable) {
+  def fatal(message: => Any, t: Throwable): Unit = {
     error(message, t)
   }
 
-  private def log(severity: Int, message: => Any, t: Throwable) {
+  private def log(severity: Int, message: => Any, t: Throwable): Unit = {
     if (t == null) logInUiThread(severity, message, t)
     else {
       // this is an optimization to log the exception at most once if the same exception is being re-thrown several times.

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/logging/log4j/Log4JAdapter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/logging/log4j/Log4JAdapter.scala
@@ -17,6 +17,13 @@ private class Log4JAdapter private (logger: Log4JLogger) extends Logger {
   // is enabled to avoid the cost of constructing the {{{message}}}. And that is the
   // reason for passing {{{message}}} by-name.
 
+  def trace(message: => Any): Unit = {
+    if(logger.isTraceEnabled) logger.trace(message)
+  }
+
+  def trace(message: => Any, t: Throwable): Unit = {
+    if(logger.isTraceEnabled) logger.trace(message, t)
+  }
 
   def info(message: => Any) {
     if(logger.isInfoEnabled) logger.info(message)

--- a/org.scala-ide.sdt.core/src/org/scalaide/logging/Level.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/logging/Level.scala
@@ -2,23 +2,28 @@ package org.scalaide.logging
 
 /** Available log levels. */
 object Level extends Enumeration {
+
   /** Log level for debugging messages.
    */
-  val DEBUG = Value
+  val DEBUG = Value(0)
 
   /** Log level for information messages.
    */
-  val INFO = Value
+  val INFO = Value(1)
 
   /** Log level for warning messages.
    */
-  val WARN = Value
+  val WARN = Value(2)
 
   /** Log level for error messages.
    */
-  val ERROR = Value
+  val ERROR = Value(3)
 
   /** Log level for fatal messages.
    */
-  val FATAL = Value
+  val FATAL = Value(4)
+
+  /** Log level for tracing messages.
+   */
+  val TRACE = Value(5)
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/logging/Logger.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/logging/Logger.scala
@@ -3,43 +3,51 @@ package org.scalaide.logging
 /** Defines the contract for implementing a Logger.*/
 trait Logger {
 
+  /** Logs a message at the TRACE level.
+   */
+  def trace(message: => Any): Unit
+
+  /** Logs a message at the TRACE level.
+   */
+  def trace(message: => Any, t: Throwable): Unit
+
   /** Logs a message at the INFO level.
    */
-  def info(message: => Any)
+  def info(message: => Any): Unit
 
   /** Logs a message with exception at the INFO level.
    */
-  def info(message: => Any, t: Throwable)
+  def info(message: => Any, t: Throwable): Unit
 
   /** Logs a message at the DEBUG level.
    */
-  def debug(message: => Any)
+  def debug(message: => Any): Unit
 
   /** Logs a message with exception at the DEBUG level.
    */
-  def debug(message: => Any, t: Throwable)
+  def debug(message: => Any, t: Throwable): Unit
 
   /** Logs a message at the WARN level.
    */
-  def warn(message: => Any)
+  def warn(message: => Any): Unit
 
   /** Logs a message with exception at the WARN level.
    */
-  def warn(message: => Any, t: Throwable)
+  def warn(message: => Any, t: Throwable): Unit
 
   /** Logs a message at the ERROR level.
    */
-  def error(message: => Any)
+  def error(message: => Any): Unit
 
   /** Logs a message with exception at the ERROR level.
    */
-  def error(message: => Any, t: Throwable)
+  def error(message: => Any, t: Throwable): Unit
 
   /** Logs a message at the FATAL level.
    */
-  def fatal(message: => Any)
+  def fatal(message: => Any): Unit
 
   /** Logs a message with exception at the FATAL level.
    */
-  def fatal(message: => Any, t: Throwable)
+  def fatal(message: => Any, t: Throwable): Unit
 }

--- a/org.scala-ide.sdt.debug.expression/src/org/scalaide/debug/internal/expression/ExpressionEvaluator.scala
+++ b/org.scala-ide.sdt.debug.expression/src/org/scalaide/debug/internal/expression/ExpressionEvaluator.scala
@@ -136,11 +136,13 @@ abstract class ExpressionEvaluator(protected val projectClassLoader: ClassLoader
       case exception: Throwable =>
         val codeAfterPhases = stringifyTreesAfterPhases(transformed.history)
         val message =
-          s"""Reflective compilation failed
-             |Trees transformation history:
+          s"Reflective compilation of: '$code' failed, full transformation history logged at 'TRACE' level"
+        val allHistory =
+          s"""Trees transformation history:
              |$codeAfterPhases
              |""".stripMargin
-        logger.error(message, exception)
+        logger.error(message)
+        logger.debug(allHistory, exception)
         throw exception
     }
   }
@@ -209,11 +211,13 @@ abstract class ExpressionEvaluator(protected val projectClassLoader: ClassLoader
           case e: Throwable =>
             val codeAfterPhases = stringifyTreesAfterPhases(lastData.history)
             val message =
-              s"""Applying phase: ${phase.phaseName} failed
-               |Trees before current transformation:
-               |$codeAfterPhases
-               |""".stripMargin
-            logger.error(message, e)
+              s"Applying phase: ${phase.phaseName} failed, full transformation history logged at 'TRACE' level"
+            val allHistory =
+              s"""Trees before current transformation:
+                 |$codeAfterPhases
+                 |""".stripMargin
+            logger.error(message)
+            logger.trace(allHistory, e)
             throw e
         }
     }


### PR DESCRIPTION
First commit adds `TRACE` level to logger, second changes long log messages in expression evaluator to use it.