### PR TITLE
Compilation error regression in 4.1-RC1

### DIFF
--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/jcompiler/BuildManagerAspect.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/jcompiler/BuildManagerAspect.aj
@@ -1,12 +1,11 @@
 package scala.tools.eclipse.contribution.weaving.jdt.jcompiler;
 
+import java.util.ArrayList;
+
 import org.eclipse.core.internal.events.BuildManager;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.jdt.internal.core.builder.AbstractImageBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Weaving on the BuildManager, to be able to replace and update
@@ -47,8 +46,6 @@ public aspect BuildManagerAspect {
   void around(AbstractImageBuilder aib, ArrayList sourceFiles):
     addAllSourceFiles(aib, sourceFiles) {
     proceed(aib, sourceFiles);
-    List sourcesToCompile = BuildManagerStore.INSTANCE.filterProjectSources(sourceFiles, aib);
-    sourceFiles.clear();
-    sourceFiles.addAll(sourcesToCompile);
+    BuildManagerStore.INSTANCE.filterProjectSources(sourceFiles, aib);
   }
 }

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/jcompiler/BuildManagerStore.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/jcompiler/BuildManagerStore.java
@@ -1,9 +1,10 @@
 package scala.tools.eclipse.contribution.weaving.jdt.jcompiler;
 
+import static java.util.Arrays.asList;
+
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import static java.util.Arrays.asList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.internal.core.builder.AbstractImageBuilder;
 import org.eclipse.jdt.internal.core.builder.JavaBuilder;
 import org.eclipse.jdt.internal.core.builder.SourceFile;
@@ -21,53 +23,55 @@ import org.eclipse.jdt.internal.core.builder.SourceFile;
  * Class used to store java files to be compile per projects
  */
 public class BuildManagerStore {
-  
+
   /**
    * Singleton
    */
-  public static final BuildManagerStore INSTANCE= new BuildManagerStore();
-  
+  public static final BuildManagerStore INSTANCE = new BuildManagerStore();
+
   /**
    * Project to java files to compile
    */
-  private Map<IProject, File[]> projectToJavaSourceFiles= new HashMap<IProject, File[]>();
-  
+  private Map<IProject, File[]> projectToJavaSourceFiles = new HashMap<IProject, File[]>();
+
   private BuildManagerStore() {
   }
-  
+
   /**
-   * Return a resource delta containing the same changes as the given delta, plus the files set to be compiled for 
-   * the given project.<br>
-   * If delta is <code>null</code>, or there are no files to compile for the given project, return the given resource delta.
+   * Return a resource delta containing the same changes as the given delta,
+   * plus the files set to be compiled for the given project.<br>
+   * If delta is <code>null</code>, or there are no files to compile for the
+   * given project, return the given resource delta.
    */
-  public IResourceDelta appendJavaSourceFilesToCompile(IResourceDelta delta, IProject project) {
+  public IResourceDelta appendJavaSourceFilesToCompile(IResourceDelta delta,
+      IProject project) {
     if (delta == null) {
       return delta;
     }
-    
+
     // no need to create a new resource delta if no files have to be added.
-    File[] files= projectToJavaSourceFiles.get(project);
+    File[] files = projectToJavaSourceFiles.get(project);
     if (files == null || files.length == 0) {
       return delta;
     }
 
     // create a new delta
-    ExpandableResourceDelta newDelta= ExpandableResourceDelta.duplicate(delta);
-    
+    ExpandableResourceDelta newDelta = ExpandableResourceDelta.duplicate(delta);
+
     // add the additional files
     IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
-    for (File file: files) {
-      for (IFile resource: workspaceRoot.findFilesForLocationURI(file.toURI())) {
+    for (File file : files) {
+      for (IFile resource : workspaceRoot.findFilesForLocationURI(file.toURI())) {
         // filter only the resources on the right project, to support nested projects
         if (resource.getProject() == project) {
           newDelta.addChangedResource(resource);
         }
       }
     }
-    
+
     return newDelta;
   }
-  
+
   /**
    * Set the java files to compile for the given project.<br>
    * Use <code>null</code> to reset the data for a project.
@@ -81,42 +85,56 @@ public class BuildManagerStore {
   }
 
   private IProject project(AbstractImageBuilder imageBuilder) {
-	Field[] fields = AbstractImageBuilder.class.getDeclaredFields();
-	Field javaBuilderField = null;
-	for (Field f: fields) {
-	  if ("javaBuilder".equals(f.getName())) {
-	    javaBuilderField = f;
-	    javaBuilderField.setAccessible(true);
-	  } 
-	}
-	JavaBuilder builder = null;
-	try {
-	  builder = (JavaBuilder)javaBuilderField.get(imageBuilder);
-	  if (builder == null) {
-	    throw new IllegalArgumentException("java builder of image builder is null");
-	  }
-	} catch(Exception e) {
-	  throw new IllegalArgumentException("image builder met problems with retrieving java builder", e);
-	}
+    Field[] fields = AbstractImageBuilder.class.getDeclaredFields();
+    Field javaBuilderField = null;
+    for (Field f : fields) {
+      if ("javaBuilder".equals(f.getName())) {
+        javaBuilderField = f;
+        javaBuilderField.setAccessible(true);
+      }
+    }
+    JavaBuilder builder = null;
+    try {
+      builder = (JavaBuilder) javaBuilderField.get(imageBuilder);
+      if (builder == null) {
+        throw new IllegalArgumentException("java builder of image builder is null");
+      }
+    } catch (Exception e) {
+      throw new IllegalArgumentException("image builder met problems with retrieving java builder", e);
+    }
     return builder.getProject();
   }
 
   /**
-   * Defensively filters <code>SourceFile</code> of current project in given scope.<br/>
+   * Defensively filters <code>SourceFile</code>s of current project in given
+   * scope and retains these of them which belong to current compilation scope.<br/>
+   * 
    * @param sources
    * @param imageBuilder
-   * @return these <code>SourceFile</code> which resources belong to current compilation scope
    */
-  public List<SourceFile> filterProjectSources(List<SourceFile> sources, AbstractImageBuilder imageBuilder) {
-	List<SourceFile> sourcesToCompile = new ArrayList<SourceFile>();
-	File[] scopeProjectSources = projectToJavaSourceFiles.get(project(imageBuilder));
-	List<File> projectFiles = scopeProjectSources != null ? asList(scopeProjectSources) : new ArrayList<File>();
-	for (SourceFile source: sources) {
-	  File file = source.resource.getRawLocation().makeAbsolute().toFile();
-	  if (projectFiles.contains(file)) {
-		sourcesToCompile.add(source);
-	  }
-	}
-	return sourcesToCompile;
+  public void filterProjectSources(List<SourceFile> sources, AbstractImageBuilder imageBuilder) {
+    IProject project = project(imageBuilder);
+    if (!isScalaProject(project)) {
+      return;
+    }
+    List<SourceFile> sourcesToCompile = new ArrayList<SourceFile>();
+    File[] scopeProjectSources = projectToJavaSourceFiles.get(project);
+    List<File> projectFiles = scopeProjectSources != null ? asList(scopeProjectSources) : new ArrayList<File>();
+    for (SourceFile source : sources) {
+      File file = source.resource.getRawLocation().makeAbsolute().toFile();
+      if (projectFiles.contains(file)) {
+        sourcesToCompile.add(source);
+      }
+    }
+    sources.retainAll(sourcesToCompile);
+  }
+
+  private boolean isScalaProject(IProject project) {
+    try {
+      final String SCALA_NATURE_ID = "org.scala-ide.sdt.core.scalanature";
+      return project.hasNature(SCALA_NATURE_ID);
+    } catch (CoreException definitelyIsNotOpenScalaProject) {
+      return false;
+    }
   }
 }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -52,6 +52,7 @@ import org.scalaide.ui.internal.editor.decorators.bynameparams.CallByNameParamAt
 import org.scalaide.ui.wizards.WizardTests
 import org.scalaide.util.eclipse.RegionUtilsTest
 import org.scalaide.util.internal.eclipse.TextSelectionTest
+import org.scalaide.core.sbtbuilder.ScalaProjectDependedOnJavaProjectTest
 
 @RunWith(classOf[Suite])
 @Suite.SuiteClasses(
@@ -107,6 +108,7 @@ import org.scalaide.util.internal.eclipse.TextSelectionTest
     classOf[CallByNameParamAtCreationPresenterTest],
     classOf[ScalaJavaDepTicket_1000607Test],
     classOf[ScalaJavaDepWhenJavaIsWrongTest],
-    classOf[ScopeCompileTest]
+    classOf[ScopeCompileTest],
+    classOf[ScalaProjectDependedOnJavaProjectTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -28,6 +28,7 @@ import org.scalaide.core.project.ScalaInstallationTest
 import org.scalaide.core.sbtbuilder.DeprecationWarningsTests
 import org.scalaide.core.sbtbuilder.MultiScalaVersionTest
 import org.scalaide.core.sbtbuilder.MultipleErrorsTest
+import org.scalaide.core.sbtbuilder.NameHashingVulnerabilityTest
 import org.scalaide.core.sbtbuilder.NestedProjectsTest
 import org.scalaide.core.sbtbuilder.OutputFoldersTest
 import org.scalaide.core.sbtbuilder.ProjectDependenciesTest
@@ -36,6 +37,7 @@ import org.scalaide.core.sbtbuilder.ScalaCompilerClasspathTest
 import org.scalaide.core.sbtbuilder.ScalaJavaDepTest
 import org.scalaide.core.sbtbuilder.ScalaJavaDepTicket_1000607Test
 import org.scalaide.core.sbtbuilder.ScalaJavaDepWhenJavaIsWrongTest
+import org.scalaide.core.sbtbuilder.ScalaProjectDependedOnJavaProjectTest
 import org.scalaide.core.sbtbuilder.ScopeCompileTest
 import org.scalaide.core.sbtbuilder.TodoBuilderTest
 import org.scalaide.core.semantic.HighlightingTestsSuite
@@ -52,7 +54,6 @@ import org.scalaide.ui.internal.editor.decorators.bynameparams.CallByNameParamAt
 import org.scalaide.ui.wizards.WizardTests
 import org.scalaide.util.eclipse.RegionUtilsTest
 import org.scalaide.util.internal.eclipse.TextSelectionTest
-import org.scalaide.core.sbtbuilder.ScalaProjectDependedOnJavaProjectTest
 
 @RunWith(classOf[Suite])
 @Suite.SuiteClasses(
@@ -109,6 +110,7 @@ import org.scalaide.core.sbtbuilder.ScalaProjectDependedOnJavaProjectTest
     classOf[ScalaJavaDepTicket_1000607Test],
     classOf[ScalaJavaDepWhenJavaIsWrongTest],
     classOf[ScopeCompileTest],
-    classOf[ScalaProjectDependedOnJavaProjectTest]
+    classOf[ScalaProjectDependedOnJavaProjectTest],
+    classOf[NameHashingVulnerabilityTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/ClasspathTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/classpath/ClasspathTests.scala
@@ -491,7 +491,7 @@ class ClasspathTests {
 
     val errors1 = projectErrors(SdtConstants.ProblemMarkerId, SdtConstants.SettingProblemMarkerId)
 
-    assertEquals("unexpected number of scala problems in project: " + errors1, 2, errors1.length)
+    assertEquals("unexpected number of scala problems in project: " + errors1, 3, errors1.length)
   }
 
   @Test
@@ -507,7 +507,7 @@ class ClasspathTests {
 
     val errors = projectErrors(SdtConstants.ProblemMarkerId, SdtConstants.SettingProblemMarkerId)
 
-    assertEquals("unexpected number of scala problems in project: " + errors, 1, errors.length)
+    assertEquals("unexpected number of scala problems in project: " + errors, 2, errors.length)
   }
 
   /**
@@ -524,7 +524,7 @@ class ClasspathTests {
     // two excepted code errors
     var markers = project.underlying.findMarkers(SdtConstants.ProblemMarkerId, true, IResource.DEPTH_INFINITE)
     val errors = SDTTestUtils.markersMessages(markers.toList)
-    assertEquals("Unexpected number of scala problems in project: " + errors, 2, errors.length)
+    assertEquals("Unexpected number of scala problems in project: " + errors, 3, errors.length)
 
     // switch to an invalid classpath
     setRawClasspathAndCheckMarkers(cleanRawClasspath, 0, 1)

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/NameHashingVulnerabilityTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/NameHashingVulnerabilityTest.scala
@@ -1,0 +1,88 @@
+package org.scalaide.core.sbtbuilder
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.IPath
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.IClasspathEntry
+import org.eclipse.jdt.core.IJavaModelMarker
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.core.JavaCore
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+import org.scalaide.core.IScalaProject
+import org.scalaide.core.SdtConstants
+import org.scalaide.core.testsetup.IProjectHelpers
+import org.scalaide.core.testsetup.IProjectOperations
+import org.scalaide.core.testsetup.SDTTestUtils.createProjectInWorkspace
+import org.scalaide.core.testsetup.SDTTestUtils.findProjectProblemMarkers
+import org.scalaide.core.testsetup.SDTTestUtils.markersMessages
+import org.scalaide.core.testsetup.SDTTestUtils.workspace
+import org.scalaide.ui.internal.preferences.ScalaPluginSettings
+import org.scalaide.util.eclipse.EclipseUtils
+import org.scalaide.util.internal.SettingConverterUtil
+
+import NameHashingVulnerabilityTest.project
+
+object NameHashingVulnerabilityTest extends IProjectOperations {
+  import org.scalaide.core.testsetup.SDTTestUtils._
+  private val projectName = "nameHashingVulnerability"
+  private var project: IScalaProject = _
+  private val bundleName = "org.scala-ide.sdt.core.tests"
+
+  private def withSrcOutputStructure(project: IProject, jProject: IJavaProject): Seq[IClasspathEntry] = {
+    val mainSourceFolder = project.getFolder("/src/main")
+    val mainOutputFolder = project.getFolder("/target/main")
+    val testSourceFolder = project.getFolder("/src/test")
+    val testOutputFolder = project.getFolder("/target/test")
+    Seq(mainSourceFolder -> mainOutputFolder,
+      testSourceFolder -> testOutputFolder).map {
+        case (src, out) => JavaCore.newSourceEntry(
+          jProject.getPackageFragmentRoot(src).getPath,
+          Array[IPath](),
+          jProject.getPackageFragmentRoot(out).getPath)
+      }
+  }
+
+  @BeforeClass def setup(): Unit = {
+    initializeProjects(bundleName, Seq(projectName)) {
+      project = createProjectInWorkspace(projectName, withSrcOutputStructure _)
+    }
+  }
+
+  @AfterClass def cleanup(): Unit = {
+    EclipseUtils.workspaceRunnableIn(EclipseUtils.workspaceRoot.getWorkspace) { _ =>
+      project.underlying.delete( /* force = */ true, /* monitor = */ null)
+    }
+  }
+}
+
+class NameHashingVulnerabilityTest extends IProjectOperations with IProjectHelpers {
+  import NameHashingVulnerabilityTest._
+  private val On = true
+  private val Off = false
+  private val errorTypes = Array(SdtConstants.ProblemMarkerId, IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER)
+
+  @Test def shouldCorrectlyBuildProjectForAllPossibleSettingsOfNameHashingFlag(): Unit = {
+    givenCleanWorkspaceForProjects(project)
+
+    whenNameHashingIs(Off)(thenThereIsNoErrors)
+
+    whenNameHashingIs(On)(thenThereIsNoErrors)
+  }
+
+  private def thenThereIsNoErrors: Unit = {
+    val errors = markersMessages(findProjectProblemMarkers(project, errorTypes: _*).toList)
+    Assert.assertTrue("no error expected: " + errors.mkString(", "), errors.isEmpty)
+  }
+
+  private def whenNameHashingIs(isOn: Boolean)(then: => Unit): Unit = {
+    val nameHashingProperty = SettingConverterUtil.convertNameToProperty(ScalaPluginSettings.nameHashing.name)
+    project.storage.setValue(nameHashingProperty, isOn)
+    workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, new NullProgressMonitor)
+    workspace.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor)
+    then
+  }
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/NestedProjectsTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/NestedProjectsTest.scala
@@ -96,7 +96,7 @@ class NestedProjectsTest {
 
       val nestedErrors = scalaProject.underlying.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE)
       val errors = SDTTestUtils.markersMessages(nestedErrors.toList)
-      assertEquals("One error in nested project " + errors, 1, errors.length)
+      assertEquals("Two errors in nested project " + errors, 2, errors.length)
     } finally
       SDTTestUtils.changeContentOfFile(unitIFile, saved)
   }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalaProjectDependedOnJavaProjectTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalaProjectDependedOnJavaProjectTest.scala
@@ -1,0 +1,75 @@
+package org.scalaide.core.sbtbuilder
+
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.runtime.IPath
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.core.JavaCore
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+import org.scalaide.core.IScalaProject
+import org.scalaide.core.SdtConstants
+import org.scalaide.core.testsetup.Bdd
+import org.scalaide.core.testsetup.Bdd.jProjectToIProject
+import org.scalaide.core.testsetup.Bdd.sProjectToIProject
+import org.scalaide.core.testsetup.Before
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.scalaide.core.testsetup.SDTTestUtils.SrcPathOutputEntry
+import org.scalaide.core.testsetup.SDTTestUtils.addToClasspath
+import org.scalaide.core.testsetup.SDTTestUtils.createJavaProjectInWorkspace
+import org.scalaide.core.testsetup.SDTTestUtils.createProjectInWorkspace
+import org.scalaide.util.eclipse.EclipseUtils
+import ScalaProjectDependedOnJavaProjectTest.projectJ
+import ScalaProjectDependedOnJavaProjectTest.projectS
+import org.eclipse.jdt.core.compiler.IProblem
+import org.eclipse.core.resources.IProject
+import org.eclipse.jdt.core.IClasspathEntry
+
+object ScalaProjectDependedOnJavaProjectTest extends Before {
+  import org.scalaide.core.testsetup.SDTTestUtils._
+  val projectJName = "scalaDependedOnJavaJ"
+  val projectSName = "scalaDependedOnJavaS"
+  var projectJ: IJavaProject = _
+  var projectS: IScalaProject = _
+  val bundleName = "org.scala-ide.sdt.core.tests"
+
+  private def withSrcOutputStructure(project: IProject, jProject: IJavaProject): Seq[IClasspathEntry] = {
+    val mainSourceFolder = project.getFolder("/src/main")
+    val mainOutputFolder = project.getFolder("/target/main")
+    Seq(JavaCore.newSourceEntry(
+      jProject.getPackageFragmentRoot(mainSourceFolder).getPath,
+      Array[IPath](),
+      jProject.getPackageFragmentRoot(mainOutputFolder).getPath))
+  }
+
+  @BeforeClass def setup(): Unit = {
+    initializeProjects(bundleName, Seq(projectJName, projectSName)) {
+      projectJ = createJavaProjectInWorkspace(projectJName, withSrcOutputStructure)
+      projectS = createProjectInWorkspace(projectSName, withSrcOutputStructure _)
+      addToClasspath(projectS, JavaCore.newProjectEntry(projectJ.getProject.getFullPath, false))
+    }
+  }
+
+  @AfterClass def cleanup(): Unit = {
+    EclipseUtils.workspaceRunnableIn(EclipseUtils.workspaceRoot.getWorkspace) { _ =>
+      projectS.underlying.delete( /* force = */ true, /* monitor = */ null)
+      projectJ.getProject.delete( /* force = */ true, /* monitor = */ null)
+    }
+  }
+}
+
+class ScalaProjectDependedOnJavaProjectTest extends Bdd with SDTTestUtils {
+  import ScalaProjectDependedOnJavaProjectTest._
+  import Bdd._
+
+  @Test def shouldCorrectlyBuildScalaProjectWhichDependsOnJavaOne(): Unit = {
+    givenCleanWorkspaceForProjects(projectJ, projectS)
+
+    buildWorkspace()
+
+    val errors = markersMessages(findProjectProblemMarkers(projectS.underlying, SdtConstants.ProblemMarkerId).toList)
+
+    Assert.assertTrue("what's up?: " + errors.mkString(", "), errors.isEmpty)
+  }
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalaProjectDependedOnJavaProjectTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalaProjectDependedOnJavaProjectTest.scala
@@ -1,7 +1,8 @@
 package org.scalaide.core.sbtbuilder
 
-import org.eclipse.core.resources.IResource
+import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.IPath
+import org.eclipse.jdt.core.IClasspathEntry
 import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.core.JavaCore
 import org.junit.AfterClass
@@ -10,29 +11,26 @@ import org.junit.BeforeClass
 import org.junit.Test
 import org.scalaide.core.IScalaProject
 import org.scalaide.core.SdtConstants
-import org.scalaide.core.testsetup.Bdd
-import org.scalaide.core.testsetup.Bdd.jProjectToIProject
-import org.scalaide.core.testsetup.Bdd.sProjectToIProject
-import org.scalaide.core.testsetup.Before
-import org.scalaide.core.testsetup.SDTTestUtils
-import org.scalaide.core.testsetup.SDTTestUtils.SrcPathOutputEntry
+import org.scalaide.core.testsetup.IProjectHelpers
+import org.scalaide.core.testsetup.IProjectOperations
 import org.scalaide.core.testsetup.SDTTestUtils.addToClasspath
+import org.scalaide.core.testsetup.SDTTestUtils.buildWorkspace
 import org.scalaide.core.testsetup.SDTTestUtils.createJavaProjectInWorkspace
 import org.scalaide.core.testsetup.SDTTestUtils.createProjectInWorkspace
+import org.scalaide.core.testsetup.SDTTestUtils.findProjectProblemMarkers
+import org.scalaide.core.testsetup.SDTTestUtils.markersMessages
 import org.scalaide.util.eclipse.EclipseUtils
+
 import ScalaProjectDependedOnJavaProjectTest.projectJ
 import ScalaProjectDependedOnJavaProjectTest.projectS
-import org.eclipse.jdt.core.compiler.IProblem
-import org.eclipse.core.resources.IProject
-import org.eclipse.jdt.core.IClasspathEntry
 
-object ScalaProjectDependedOnJavaProjectTest extends Before {
+object ScalaProjectDependedOnJavaProjectTest extends IProjectOperations {
   import org.scalaide.core.testsetup.SDTTestUtils._
-  val projectJName = "scalaDependedOnJavaJ"
-  val projectSName = "scalaDependedOnJavaS"
-  var projectJ: IJavaProject = _
-  var projectS: IScalaProject = _
-  val bundleName = "org.scala-ide.sdt.core.tests"
+  private val projectJName = "scalaDependedOnJavaJ"
+  private val projectSName = "scalaDependedOnJavaS"
+  private var projectJ: IJavaProject = _
+  private var projectS: IScalaProject = _
+  private val bundleName = "org.scala-ide.sdt.core.tests"
 
   private def withSrcOutputStructure(project: IProject, jProject: IJavaProject): Seq[IClasspathEntry] = {
     val mainSourceFolder = project.getFolder("/src/main")
@@ -59,17 +57,16 @@ object ScalaProjectDependedOnJavaProjectTest extends Before {
   }
 }
 
-class ScalaProjectDependedOnJavaProjectTest extends Bdd with SDTTestUtils {
+class ScalaProjectDependedOnJavaProjectTest extends IProjectOperations with IProjectHelpers {
   import ScalaProjectDependedOnJavaProjectTest._
-  import Bdd._
 
   @Test def shouldCorrectlyBuildScalaProjectWhichDependsOnJavaOne(): Unit = {
     givenCleanWorkspaceForProjects(projectJ, projectS)
 
     buildWorkspace()
 
-    val errors = markersMessages(findProjectProblemMarkers(projectS.underlying, SdtConstants.ProblemMarkerId).toList)
+    val errors = markersMessages(findProjectProblemMarkers(projectS, SdtConstants.ProblemMarkerId).toList)
 
-    Assert.assertTrue("what's up?: " + errors.mkString(", "), errors.isEmpty)
+    Assert.assertTrue("no error expected: " + errors.mkString(", "), errors.isEmpty)
   }
 }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/IProjectHelpers.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/IProjectHelpers.scala
@@ -1,0 +1,83 @@
+package org.scalaide.core.testsetup
+
+import java.io.File
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.IJavaProject
+import org.junit.Assert
+import org.scalaide.core.IScalaProject
+import org.scalaide.util.eclipse.EclipseUtils
+
+import SDTTestUtils.enableAutoBuild
+import SDTTestUtils.getErrorMessages
+import SDTTestUtils.sourceWorkspaceLoc
+import SDTTestUtils.workspace
+
+/**
+ * Collects implicits playing with `IProject` object
+ */
+trait IProjectHelpers {
+  implicit def jProjectToIProject(project: IJavaProject): IProject = project.getProject
+  implicit def sProjectToIProject(project: IScalaProject): IProject = project.underlying
+}
+
+/**
+ * Collects operations done on 'IScalaProject' and 'IJavaProject' instances like creation, cleaning,
+ * deleting.
+ */
+trait IProjectOperations {
+  import SDTTestUtils._
+
+  /**
+   *  Runs clean build on given projects. Usually used just before test execution. Example:
+   *  {{{
+   *  class SomeTest extends IProjectOperations {
+   *    import SomeTest._
+   *
+   *    @Test def shouldShowHowToUseGivenCleanMethod(): Unit = {
+   *      givenCleanWorkspaceForProject(myProject.underlying)
+   *
+   *      // when
+   *      // then
+   *    }
+   *  }
+   *  }}}
+   */
+  def givenCleanWorkspaceForProjects(projects: IProject*): Unit = {
+    workspace.build(IncrementalProjectBuilder.CLEAN_BUILD, new NullProgressMonitor)
+    projects.foreach { project =>
+      Assert.assertTrue(getErrorMessages(project).isEmpty)
+    }
+  }
+
+  /**
+   *  Prepares workspace with projects resources. Usually used in test companion object in setup method
+   *  annotated with `@BeforeClass`. Example:
+   *  {{{
+   *  object SomeTest extends IProjectOperation {
+   *    import SDTTestUtils._
+   *    private var project: IScalaProject = _
+   *
+   *    @BeforeClass def setup(): Unit = {
+   *      initializeProjects("bundleName", Seq("projectName")) {
+   *        project = createProjectInWorkspace("projectName", withSrcRootOnly)
+   *      }
+   *    }
+   *  }
+   *  }}}
+   */
+  def initializeProjects(bundleName: String, projectNames: Seq[String])(postInit: => Unit): Unit = {
+    enableAutoBuild(false)
+    projectNames.foreach { name =>
+      EclipseUtils.workspaceRunnableIn(workspace) { monitor =>
+        val wspaceLoc = workspace.getRoot.getLocation
+        val src = new File(sourceWorkspaceLoc(bundleName).toFile().getAbsolutePath + File.separatorChar + name)
+        val dst = new File(wspaceLoc.toFile().getAbsolutePath + File.separatorChar + name)
+        FileUtils.copyDirectory(src, dst)
+      }
+    }
+    postInit
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/nameHashingVulnerability/src/main/acme/AcmeMain.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/nameHashingVulnerability/src/main/acme/AcmeMain.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeMain {
+  def bar = "5"
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/nameHashingVulnerability/src/test/acme/AcmeTest.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/nameHashingVulnerability/src/test/acme/AcmeTest.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeTest {
+  def baz = "3"
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scalaDependedOnJavaJ/src/main/acme/Acme.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scalaDependedOnJavaJ/src/main/acme/Acme.java
@@ -1,0 +1,7 @@
+package acme;
+
+class Acme {
+  public int bar() {
+    return 5;
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scalaDependedOnJavaS/src/main/acme/AcmeMain.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scalaDependedOnJavaS/src/main/acme/AcmeMain.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeMain {
+  def foo = (new Acme).bar
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/EclipseBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/EclipseBuildManager.scala
@@ -5,6 +5,7 @@ import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.SubMonitor
 import sbt.inc.IncOptions
 import sbt.inc.Analysis
+import java.io.File
 
 /**
  * Abstraction which exposes sbt compiler to eclipse.
@@ -29,6 +30,12 @@ trait EclipseBuildManager {
 
   /** Gives back the latest dependencies analysis done by underlying compiler. */
   def latestAnalysis(incOptions: => IncOptions): Analysis
+
+  /**
+   * Finds build manager which built given file
+   * @return `Option[EclipseBuildManager]` when found or `None` otherwise
+   */
+  def buildManagerOf(outputFile: File): Option[EclipseBuildManager]
 }
 
 /** Keeps collected analysis persistently in store. This store is exposed outdoor. */

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -182,8 +182,13 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
   }
 
   // take by-name argument because we need incOptions only when we have a cache miss
-  def latestAnalysis(incOptions: => IncOptions): Analysis =
+  override def latestAnalysis(incOptions: => IncOptions): Analysis =
     Option(cached.get) flatMap (ref => Option(ref.get)) getOrElse setCached(IC.readAnalysis(cacheFile, incOptions))
+
+  /**
+   * Knows nothing about output files.
+   */
+  override def buildManagerOf(outputFile: File): Option[EclipseBuildManager] = None
 
   /** Inspired by IC.compile
    *

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ProjectsDependentSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ProjectsDependentSbtBuildManager.scala
@@ -1,5 +1,7 @@
 package org.scalaide.core.internal.project
 
+import java.io.File
+
 import scala.tools.nsc.Settings
 
 import org.eclipse.core.resources.IFile
@@ -9,11 +11,13 @@ import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.IScalaProject
 import org.scalaide.core.SdtConstants
 import org.scalaide.core.internal.builder.BuildProblemMarker
+import org.scalaide.core.internal.builder.EclipseBuildManager
 import org.scalaide.core.internal.builder.zinc.EclipseSbtBuildManager
 import org.scalaide.ui.internal.preferences.ScalaPluginSettings
 import org.scalaide.util.internal.SettingConverterUtil
 
-/** Build manager which compiles sources without dividing on scopes.
+/**
+ * Build manager which compiles sources without dividing on scopes.
  *  Refer to [[CompileScope]]
  */
 class ProjectsDependentSbtBuildManager(project: IScalaProject, settings: Settings)
@@ -39,5 +43,9 @@ class ProjectsDependentSbtBuildManager(project: IScalaProject, settings: Setting
       project.underlying.deleteMarkers(SdtConstants.ProblemMarkerId, true, IResource.DEPTH_INFINITE)
       super.build(addedOrUpdated, removed, pm)
     }
+  }
+
+  override def buildManagerOf(outputFile: File): Option[EclipseBuildManager] = project.sourceOutputFolders.collectFirst {
+    case (_, outputFolder) if outputFolder.getLocation.toFile == outputFile => this
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/SbtScopesBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/SbtScopesBuildManager.scala
@@ -1,7 +1,6 @@
 package org.scalaide.core.internal.project
 
 import scala.tools.nsc.Settings
-
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResource
@@ -15,9 +14,9 @@ import org.scalaide.core.internal.builder.EclipseBuildManager
 import org.scalaide.core.internal.project.scopes.BuildScopeUnit
 import org.scalaide.ui.internal.preferences.ScalaPluginSettings
 import org.scalaide.util.internal.SettingConverterUtil
-
 import sbt.inc.Analysis
 import sbt.inc.IncOptions
+import java.io.File
 
 /** Manages of source compilation for all scopes.
  *  Refer to [[CompileScope]]
@@ -84,9 +83,10 @@ class SbtScopesBuildManager(val owningProject: IScalaProject, managerSettings: S
     }
   }
 
-  override def latestAnalysis(incOptions: => IncOptions): Analysis = {
-    Analysis.merge(buildScopeUnits.map { _.latestAnalysis(incOptions) })
-  }
+  override def latestAnalysis(incOptions: => IncOptions): Analysis = Analysis.Empty
+
+  override def buildManagerOf(outputFile: File): Option[EclipseBuildManager] =
+    buildScopeUnits.find { _.buildManagerOf(outputFile).nonEmpty }
 }
 
 private case class ScopeUnitWithProjectsInError(owner: BuildScopeUnit, projectsInError: Seq[IProject])


### PR DESCRIPTION
Compilation error regression in 4.1-RC1: Cannot resolve imports to Java classes in some context.
Assembla ticket #1002456
Description:
There is pure java project A and depended scala project B.
Eclipse compiler doesn't compile java sources of A so that B is full of errors in places where depends on output of A.