### PR TITLE
Move key binding for expression evaluator to different key

### DIFF
--- a/org.scala-ide.sdt.debug.expression/plugin.xml
+++ b/org.scala-ide.sdt.debug.expression/plugin.xml
@@ -35,7 +35,7 @@
             commandId="org.scalaide.debug.handler.RunSelectionInExpressionEvaluator"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             contextId="scala.tools.eclipse.scalaEditorScope"
-            sequence="M1+M2+Z"/>
+            sequence="M1+M2+K"/>
     </extension>
 	
     <extension


### PR DESCRIPTION
CTRL-SHIFT-Z invokes already the redo functionality.

Other key bindings that are mentioned in the ticket are not changed
because they don't seem to override anything.

Fixes #1002459