### PR TITLE
Make codebase compatible with Java6

### DIFF
--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/hcr/HotCodeReplaceTest.scala
@@ -49,7 +49,7 @@ private object HotCodeReplaceTest {
       case Success(value) => value
       case Failure(e) =>
         // New exception to have informative stack trace.
-        throw new AssertionError("Unexpected message(s). Check the chained exception(s) for more information.", e)
+        throw new IllegalStateException("Unexpected message(s). Check the chained exception(s) for more information.", e)
     }
 
     override def notify(publisher: Publisher[HCRResult], event: HCRResult): Unit = event match {


### PR DESCRIPTION
The constructor of AssertionError that takes two parameters was
introduced in Java7. The constructor of IllegalStateException however is
available in Java6 and should fit all our needs.

------

This PR is needed, since uber-build runs only with Java6 and after the introduction of `-Xfatal-warnings`, the code did no longer compile. The only reason why the code compiled at all, was because the compiler implicitly converted the two parameters to a `Tuple2` and passed it to a constructor that expected a single parameter of type `Any`: *facepalm*