### PR TITLE
Set UTF-8 as default charset in test workspaces

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
@@ -95,6 +95,7 @@ object SDTTestUtils extends HasLogger {
       val project = workspace.getRoot.getProject(name)
       project.create(null)
       project.open(null)
+      project.setDefaultCharset("UTF-8", /*progressMonitor =*/ null)
       JavaCore.create(project)
     }
     ScalaPlugin().getScalaProject(workspace.getRoot.getProject(name))


### PR DESCRIPTION
This is required as otherwise on Windows default `CP-1250` is used and some
tests (CompletionTests in particular) fails.

I tested it on my machine and all tests pass both in maven and in eclipse.