### PR TITLE
Enables test for java var-arg constructors

### DIFF
--- a/org.scala-ide.sdt.debug.expression.tests/src/org/scalaide/debug/internal/expression/features/NewKeywordTest.scala
+++ b/org.scala-ide.sdt.debug.expression.tests/src/org/scalaide/debug/internal/expression/features/NewKeywordTest.scala
@@ -51,11 +51,9 @@ class NewKeywordTest extends BaseIntegrationTest(NewKeywordTest) {
     eval("new LibClassWithVararg(1, 2)", "LibClassWithVararg(List(1, 2))", "debug.LibClassWithVararg")
   }
 
-  // TODO - Toolbox cannot typecheck java vararg constructors https://issues.scala-lang.org/browse/SI-9212
-  // If this test fails it means Toolbox is fixed, yay! (or some other exception is thrown)
-  @Test(expected = classOf[ReflectiveCompilationFailure])
+  @Test
   def javaVarArgConstructor(): Unit = {
-    eval("new JavaVarArg()", "JavaVarArg()", "debug.JavaVarArg")
+    eval("new JavaVarArg()", "JavaVarArg([])", "debug.JavaVarArg")
     eval("new JavaVarArg(1)", "JavaVarArg([1])", "debug.JavaVarArg")
     eval("new JavaVarArg(1, 2)", "JavaVarArg([1, 2])", "debug.JavaVarArg")
   }


### PR DESCRIPTION
This will pass only after scala/scala#4545 is merged.