### PR TITLE
Use OverlayPreferenceStore to handle correct UI semantics

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/AutoEdit.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/AutoEdit.scala
@@ -114,4 +114,12 @@ case class AutoEditSetting(
   name: String,
   description: String,
   partitions: Set[String] = Set()
-) extends ExtensionSetting
+) extends ExtensionSetting {
+
+  /**
+   * An unique ID that identifies the configuration value of this auto edit. The
+   * configuration is a set of key-value pairs that can be specified by users to
+   * configure further behavior of the auto edit.
+   */
+  def configId: String = s"$id.config"
+}


### PR DESCRIPTION
In the preference page, there are several buttons that configure how any
chances should be propagated to the underlying preference store. When
Cancel is clicked, no changes should be propagated. When Apply and Save
are both clicked, the changes should only be propagated once. We use the
predefined class `OverlayPreferenceStore` to handle these semantics. It
only writes back its key-value pairs when the users asks for it and
doesn't write back anything that has not changed.

The `OverlayPreferenceStore` is relatively inconvenient to use because
one has to specify which keys should be cached by it. It would be
better if it would cache and write back everything. Furthermore, there
is no automatic read on the underlying preference store when the key is
not specified. This makes the creation of such an overlay store
cumbersome. Nevertheless, it is still better than the hand-rolled
solution that was used before.

This fixes both the `AutoEditsPreferencePage` and the
`SaveActionsPreferencePage`.

Fixes #1002487