### PR TITLE
Resolve execution conflict between surround selection and close pair

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/AutoEdits.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/AutoEdits.scala
@@ -30,7 +30,8 @@ object AutoEdits {
     fullyQualifiedName[SurroundSelectionWithString] → SurroundSelectionWithStringSetting,
     fullyQualifiedName[SurroundSelectionWithParentheses] → SurroundSelectionWithParenthesesSetting,
     fullyQualifiedName[SurroundSelectionWithBraces] → SurroundSelectionWithBracesSetting,
-    fullyQualifiedName[SurroundSelectionWithBrackets] → SurroundSelectionWithBracketsSetting
+    fullyQualifiedName[SurroundSelectionWithBrackets] → SurroundSelectionWithBracketsSetting,
+    fullyQualifiedName[SurroundSelectionWithAngleBrackets] → SurroundSelectionWithAngleBracketsSetting
   )
 
   /**

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseAngleBracket.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseAngleBracket.scala
@@ -16,6 +16,7 @@ trait CloseAngleBracket extends CloseMatchingPair {
 
   override def opening = '<'
   override def closing = '>'
+  override def surroundSelectionSetting = SurroundSelectionWithAngleBracketsSetting
 
   override def setting = CloseBracketSetting
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseBracket.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseBracket.scala
@@ -17,6 +17,7 @@ trait CloseBracket extends CloseMatchingPair {
 
   override def opening = '['
   override def closing = ']'
+  override def surroundSelectionSetting = SurroundSelectionWithBracketsSetting
 
   override def setting = CloseBracketSetting
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseCurlyBrace.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseCurlyBrace.scala
@@ -19,6 +19,7 @@ trait CloseCurlyBrace extends CloseMatchingPair {
 
   override def opening = '{'
   override def closing = '}'
+  override def surroundSelectionSetting = SurroundSelectionWithBracesSetting
 
   override def setting = CloseCurlyBraceSetting
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseMatchingPair.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseMatchingPair.scala
@@ -2,6 +2,7 @@ package org.scalaide.extensions
 package autoedits
 
 import org.eclipse.jface.text.IRegion
+import org.scalaide.core.IScalaPlugin
 import org.scalaide.util.eclipse.RegionUtils._
 
 /** Functionality for all auto edits that should handle matching pairs. */
@@ -12,6 +13,7 @@ trait CloseMatchingPair extends AutoEdit {
 
   def opening: Char
   def closing: Char
+  def surroundSelectionSetting: AutoEditSetting
 
   def singleLinkedPos(pos: Int): Seq[Seq[(Int, Int)]] =
     Seq(Seq((pos, 0)))
@@ -25,7 +27,7 @@ trait CloseMatchingPair extends AutoEdit {
    */
   def autoClosingRequired(offset: Int): Boolean = {
 
-    /**
+    /*
      * Searches for all pairing elements leftwards, starting at `startPosition`
      * (inclusive) and ending at `endPosition` (inclusive). If a matching pair
      * is found, the elements of this pair are not returned. The only elements
@@ -51,7 +53,7 @@ trait CloseMatchingPair extends AutoEdit {
       loop(startPosition, Nil).reverse
     }
 
-    /**
+    /*
      * In contrast to [[searchPairElemsLeftwards]] this searches for elements
      * rightwards, starting at `startPosition` (inclusive) and ending at
      * `endPosition` (exclusive). If a matching pair is found, the elements of
@@ -81,7 +83,10 @@ trait CloseMatchingPair extends AutoEdit {
     val lineInfo = document.lineInformationOfOffset(offset)
     val lineAfterCaret = document.textRange(offset, lineInfo.end)
 
-    if (lineAfterCaret.isEmpty) true
+    if (IScalaPlugin().getPreferenceStore.getBoolean(surroundSelectionSetting.id))
+      false
+    else if (lineAfterCaret.isEmpty)
+      true
     else {
       val elemsLeft = searchPairElemsLeftwards(offset-1, lineInfo.start)
       val elemsRight = searchPairElemsRightwards(offset, lineInfo.end)

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseParenthesis.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseParenthesis.scala
@@ -16,6 +16,7 @@ trait CloseParenthesis extends CloseMatchingPair {
 
   override def opening = '('
   override def closing = ')'
+  override def surroundSelectionSetting = SurroundSelectionWithParenthesesSetting
 
   override def setting = CloseParenthesisSetting
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseString.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseString.scala
@@ -3,6 +3,7 @@ package autoedits
 
 import org.eclipse.jdt.ui.text.IJavaPartitions
 import org.eclipse.jface.text.IDocument
+import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.lexical.ScalaPartitions
 import org.scalaide.core.text.TextChange
 
@@ -45,7 +46,9 @@ trait CloseString extends AutoEdit {
     document.textRangeOpt(offset-1, offset+1) exists (Set("{}", "[]", "()", "<>", "\"\"")(_))
 
   def autoClosingRequired(offset: Int): Boolean =
-    if (offset < document.length)
+    if (IScalaPlugin().getPreferenceStore.getBoolean(SurroundSelectionWithStringSetting.id))
+      false
+    else if (offset < document.length)
       !ch(-1, '"') && (Character.isWhitespace(document(offset)) || isNested(offset))
     else
       !ch(-1, '"')

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundSelection.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundSelection.scala
@@ -1,9 +1,7 @@
 package org.scalaide.extensions
 package autoedits
 
-import org.scalaide.core.text.Add
-import org.scalaide.core.text.Replace
-import org.scalaide.util.eclipse.RegionUtils._
+import org.scalaide.core.text.TextChange
 
 object SurroundSelectionWithStringSetting extends AutoEditSetting(
   id = ExtensionSetting.fullyQualifiedName[SurroundSelectionWithString],
@@ -25,8 +23,14 @@ object SurroundSelectionWithBracesSetting extends AutoEditSetting(
 
 object SurroundSelectionWithBracketsSetting extends AutoEditSetting(
   id = ExtensionSetting.fullyQualifiedName[SurroundSelectionWithBrackets],
-  name = "Surround selection with [brackets]",
-  description = "Automatically surrounds a selection with brackets when an opening bracket is typed."
+  name = "Surround selection with [square] brackets",
+  description = "Automatically surrounds a selection with square brackets when an opening square bracket is typed."
+)
+
+object SurroundSelectionWithAngleBracketsSetting extends AutoEditSetting(
+  id = ExtensionSetting.fullyQualifiedName[SurroundSelectionWithAngleBrackets],
+  name = "Surround selection with <angle> brackets",
+  description = "Automatically surrounds a selection with angle brackets when an opening angle bracket is typed."
 )
 
 trait SurroundSelection extends AutoEdit {
@@ -34,13 +38,10 @@ trait SurroundSelection extends AutoEdit {
   def opening: String
   def closing: String
 
-  def perform() = {
+  override def perform() = {
     check(textChange) {
-      case Add(start, o) if o == opening ⇒
-        subcheck(textSelection) {
-          case sel if sel.length > 0 ⇒
-            Replace(sel.start, sel.end, opening + sel.getText + closing)
-        }
+      case c @ TextChange(start, end, o) if end > start && o == opening ⇒
+        Some(TextChange(start, end, opening + document.textRange(start, end) + closing))
     }
   }
 }
@@ -67,4 +68,10 @@ trait SurroundSelectionWithBrackets extends SurroundSelection {
   override def opening = "["
   override def closing = "]"
   override def setting = SurroundSelectionWithBracketsSetting
+}
+
+trait SurroundSelectionWithAngleBrackets extends SurroundSelection {
+  override def opening = "<"
+  override def closing = ">"
+  override def setting = SurroundSelectionWithAngleBracketsSetting
 }


### PR DESCRIPTION
The problem was that when both surround selection and the close pair
auto edit were enabled, one of them is preferred over the other. To
solve this conflict some priority had to be introduced. Right now an
easy was is chosen - the close pair auto edits ensure that the surround
selection auto edits are not enabled.

Furthermore, `SurroundSelectionWithAngleBrackets` had to be introduced
to allow the corresponding close pair auto edit to check if it exists.

Fixes #1002488