### PR TITLE
Replace Application with App in code template

### DIFF
--- a/org.scala-ide.sdt.core/templates/default-templates.xml
+++ b/org.scala-ide.sdt.core/templates/default-templates.xml
@@ -15,7 +15,7 @@
   description="application object"
   id="scala.templates.app"
   context="org.scala-ide.sdt.core.templates" enabled="true"
->object ${name} extends Application {
+>object ${name} extends App {
   ${line_selection}${cursor}
 }</template>
 <template name="arr"


### PR DESCRIPTION
The second part of the ticket could not yet be fixed. Our template
engine does not correctly replace the `${line_selection}` part. It inserts
the selected code but does not remove the selection, which leads to a
duplicated code section.

Re #1002503