### PR TITLE
Transition to sbt 0.13.8. Fix for #1002486

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -27,6 +27,8 @@ import org.scalaide.core.pc.PresentationCompilerTest
 import org.scalaide.core.project.DirectoryScalaInstallationTest
 import org.scalaide.core.project.ScalaInstallationTest
 import org.scalaide.core.sbtbuilder.DeprecationWarningsTests
+import org.scalaide.core.sbtbuilder.JavaDependsOnScalaBothAreOkTest
+import org.scalaide.core.sbtbuilder.JavaDependsOnScalaTest
 import org.scalaide.core.sbtbuilder.MultiScalaVersionTest
 import org.scalaide.core.sbtbuilder.MultipleErrorsTest
 import org.scalaide.core.sbtbuilder.NameHashingVulnerabilityTest
@@ -114,6 +116,8 @@ import org.scalaide.util.internal.eclipse.TextSelectionTest
     classOf[ScalaJavaDepWhenJavaIsWrongTest],
     classOf[ScopeCompileTest],
     classOf[ScalaProjectDependedOnJavaProjectTest],
-    classOf[NameHashingVulnerabilityTest]
+    classOf[NameHashingVulnerabilityTest],
+    classOf[JavaDependsOnScalaTest],
+    classOf[JavaDependsOnScalaBothAreOkTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/JavaDependsOnScalaBothAreOkTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/JavaDependsOnScalaBothAreOkTest.scala
@@ -1,0 +1,67 @@
+package org.scalaide.core
+package sbtbuilder
+
+import org.junit.BeforeClass
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.junit.Assert._
+import org.junit.Test
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.resources.IMarker
+
+object JavaDependsOnScalaBothAreOkTest extends testsetup.TestProjectSetup("javaDependsOnScalaBothAreOk") {
+  @BeforeClass def setup(): Unit = {
+    SDTTestUtils.enableAutoBuild(false)
+  }
+}
+
+class JavaDependsOnScalaBothAreOkTest {
+  import JavaDependsOnScalaBothAreOkTest._
+
+  @Test def shouldCreateProjectFromOkJavaAndSpoilAndFixIt(): Unit = {
+    val TypeBMustImplementFoo = 1
+    cleanProject()
+    import SDTTestUtils._
+
+    val aClass = compilationUnit("main/A.scala")
+    val bClass = compilationUnit("main/B.java")
+    def rebuildAndCollectProblems(): List[IMarker] = {
+      project.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor)
+      getProblemMarkers(aClass, bClass)
+    }
+
+    step("first compile scala and dependent java classes") {
+      val problems = rebuildAndCollectProblems()
+      assertTrue("No build error expected, got: " + markersMessages(problems), problems.isEmpty)
+    }
+
+    step("then extends java B with abstract A") {
+      changeContentOfFile(bClass.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], changed_main_B)
+      val problems = rebuildAndCollectProblems()
+      assertTrue("One build error expected, got: " + markersMessages(problems), problems.length == TypeBMustImplementFoo)
+    }
+
+    step("and then give body to 'foo' in abstract A") {
+      changeContentOfFile(aClass.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], changed_main_A)
+      val problems = rebuildAndCollectProblems()
+      assertTrue("No build error expected, got: " + markersMessages(problems), problems.isEmpty)
+    }
+  }
+
+  private def step(description: String)(runInStep: => Unit): Unit = runInStep
+
+  lazy val changed_main_A = """
+package main
+
+abstract class A {
+  def foo(s: String): Unit = {}
+}
+"""
+  lazy val changed_main_B = """
+package main;
+
+public class B extends A {
+}
+"""
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/JavaDependsOnScalaTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/JavaDependsOnScalaTest.scala
@@ -1,0 +1,68 @@
+package org.scalaide.core
+package sbtbuilder
+
+import org.junit.BeforeClass
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.junit.Assert._
+import org.junit.Test
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.resources.IMarker
+
+object JavaDependsOnScalaTest extends testsetup.TestProjectSetup("javaDependsOnScala") {
+  @BeforeClass def setup(): Unit = {
+    SDTTestUtils.enableAutoBuild(false)
+  }
+}
+
+class JavaDependsOnScalaTest {
+  import JavaDependsOnScalaTest._
+
+  @Test def shouldCreateProjectFromWrongJavaAndSpoilAndFixScalaClass(): Unit = {
+    val TypeBMustImplementFoo = 1
+    cleanProject()
+    import SDTTestUtils._
+
+    val aClass = compilationUnit("main/A.scala")
+    val initiallyWrongAclass = slurpAndClose(project.underlying.getFile("src/main/A.scala").getContents)
+    val bClass = compilationUnit("main/B.java")
+    def rebuildAndCollectProblems(): List[IMarker] = {
+      project.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor)
+      getProblemMarkers(aClass, bClass)
+    }
+
+    step("first compile scala and dependent java classes") {
+      val problems = rebuildAndCollectProblems()
+      assertTrue("One build error expected, got: " + markersMessages(problems), problems.length == TypeBMustImplementFoo)
+    }
+
+    step("then fix scala class") {
+      changeContentOfFile(aClass.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], changed_main_A)
+      val problems = rebuildAndCollectProblems()
+      assertTrue("No build error expected, got: " + markersMessages(problems), problems.isEmpty)
+    }
+
+    step("and then flaw scala class again") {
+      changeContentOfFile(aClass.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], initiallyWrongAclass)
+      val problems = rebuildAndCollectProblems()
+      assertTrue("One build error expected, got: " + markersMessages(problems), problems.length == TypeBMustImplementFoo)
+    }
+
+    step("finally fix scala class") {
+      changeContentOfFile(aClass.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], changed_main_A)
+      val problems = rebuildAndCollectProblems()
+      assertTrue("No build error expected, got: " + markersMessages(problems), problems.isEmpty)
+    }
+  }
+
+  private def step(description: String)(runInStep: => Unit): Unit = runInStep
+
+  lazy val changed_main_A = """
+package main
+
+abstract class A {
+  def foo(s: String): Unit = {}
+}
+"""
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>javaDependsOnScala</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/src/main/A.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/src/main/A.scala
@@ -1,0 +1,5 @@
+package main
+
+abstract class A {
+  def foo(s: String): Unit //= {}
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/src/main/B.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScala/src/main/B.java
@@ -1,0 +1,5 @@
+package main;
+
+public class B extends A {
+}
+

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>javaDependsOnScalaBothAreOk</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/src/main/A.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/src/main/A.scala
@@ -1,0 +1,5 @@
+package main
+
+abstract class A {
+  def foo(s: String): Unit
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/src/main/B.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/javaDependsOnScalaBothAreOk/src/main/B.java
@@ -1,0 +1,5 @@
+package main;
+
+public class B {
+}
+

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -17,14 +17,21 @@ import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.OperationCanceledException
 import org.eclipse.core.runtime.Path
 import org.eclipse.core.runtime.SubMonitor
+import org.eclipse.jdt.core.IJavaModelMarker
 import org.scalaide.core.IScalaInstallation
 import org.scalaide.core.IScalaProject
+import org.scalaide.core.SdtConstants
 import org.scalaide.core.internal.builder.BuildProblemMarker
+import org.scalaide.core.internal.builder.CachedAnalysisBuildManager
+import org.scalaide.core.internal.builder.EclipseBuildManager
+import org.scalaide.core.internal.builder.TaskManager
 import org.scalaide.logging.HasLogger
 import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.SbtUtils
+import org.scalaide.util.internal.Suppress.DeprecatedWarning.AggressiveCompile
+import org.scalaide.util.internal.Suppress.DeprecatedWarning.aggressivelyCompile
 
-import sbt.compiler.AggressiveCompile
+import sbt.Logger.xlog2Log
 import sbt.compiler.CompileFailed
 import sbt.compiler.IC
 import sbt.inc.Analysis
@@ -33,6 +40,7 @@ import sbt.inc.SourceInfo
 import xsbti.F0
 import xsbti.Logger
 import xsbti.compile.CompileProgress
+import xsbti.compile.JavaCompiler
 
 /** An Eclipse builder using the Sbt engine.
  *
@@ -207,8 +215,8 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
     compilers match {
       case Right(comps) =>
         import comps._
-        agg(scalac, javac, options.sources, classpath, output, in.cache, SbtUtils.m2o(in.progress), scalacOptions, javacOptions, aMap,
-          defClass, sbtReporter, order, skip = false, in.incOptions)(log)
+        aggressivelyCompile(agg)(log)(scalac, javac, options.sources, classpath, output, in.cache, SbtUtils.m2o(in.progress),
+          scalacOptions, javacOptions, aMap, defClass, sbtReporter, order, /* skip = */ false, in.incOptions)
       case Left(errors) =>
         sbtReporter.log(SbtUtils.NoPosition, errors, xsbti.Severity.Error)
         throw CompilerInterfaceFailed

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
@@ -17,6 +17,7 @@ import xsbti.compile.Output
 import xsbti.Logger
 import org.scalaide.core.internal.builder.JDTBuilderFacade
 import org.scalaide.core.IScalaPlugin
+import xsbti.Reporter
 
 /** Eclipse Java compiler interface, used by the SBT builder.
  *  This class forwards to the internal Eclipse Java compiler, using
@@ -26,7 +27,7 @@ class JavaEclipseCompiler(p: IProject, monitor: SubMonitor) extends JavaCompiler
 
   override def project = p
 
-  def compile(sources: Array[File], classpath: Array[File], output: Output, options: Array[String], log: Logger): Unit = {
+  override def compile(sources: Array[File], classpath: Array[File], output: Output, options: Array[String], log: Logger): Unit = {
     val scalaProject = IScalaPlugin().getScalaProject(project)
 
     val allSourceFiles = scalaProject.allSourceFiles()
@@ -52,4 +53,7 @@ class JavaEclipseCompiler(p: IProject, monitor: SubMonitor) extends JavaCompiler
       refresh()
     }
   }
+
+  override def compileWithReporter(sources: Array[File], classpath: Array[File], output: Output, options: Array[String], reporter: Reporter, log: Logger): Unit =
+    compile(sources, classpath, output, options, log)
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/scopes/BuildScopeUnit.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/scopes/BuildScopeUnit.scala
@@ -93,7 +93,7 @@ private case class ScopeFilesToCompile(toCompile: Set[IFile] => Set[IFile], owni
     run = forever
     toCompile(owningProject.allSourceFiles)
   }
-  private def forever(sources: Set[IFile]): Set[IFile] = toCompile(sources) ++ resetJavaMarkers(getValidJavaSourcesOfThisScope)
+  private def forever(sources: Set[IFile]): Set[IFile] = toCompile(sources) ++ getValidJavaSourcesOfThisScope
 
   def apply(sources: Set[IFile]): Set[IFile] = run(sources)
 
@@ -101,10 +101,5 @@ private case class ScopeFilesToCompile(toCompile: Set[IFile] => Set[IFile], owni
     val Dot = 1
     toCompile(owningProject.allSourceFiles
       .filter { _.getLocation.getFileExtension == SdtConstants.JavaFileExtn.drop(Dot) })
-  }
-
-  private def resetJavaMarkers(javaFiles: Set[IFile]): Set[IFile] = {
-    javaFiles.foreach { _.deleteMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE) }
-    javaFiles
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/Suppress.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/Suppress.scala
@@ -1,13 +1,13 @@
 package org.scalaide.util.internal
 
 import java.io.PrintStream
-
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.jdt.core.IClassFile
 import org.eclipse.jdt.core.ICodeAssist
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.core.WorkingCopyOwner
 import org.eclipse.jdt.internal.core.Openable
+import java.io.File
 
 /**
  * This type exists only to suppress warnings of scalac. One should try to not
@@ -68,6 +68,8 @@ object Suppress {
     def `Console.setErr`(out: PrintStream): Unit =
       Console.setErr(out)
 
+    type AggressiveCompile = sbt.compiler.AggressiveCompile
+    def aggressivelyCompile(agg: AggressiveCompile)(implicit log: sbt.Logger) = agg.apply _
   }
   object DeprecatedWarning extends DeprecatedWarning
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <!-- Scala 2.10.x -->
     <scala210.version>2.10.5</scala210.version>
     <!-- Scala 2.11.x -->
-    <scala211.version>2.11.7-SNAPSHOT</scala211.version>
+    <scala211.version>2.11.8-SNAPSHOT</scala211.version>
     <scala211.binary.version>2.11</scala211.binary.version>
     <scala211.scala-xml.version>1.0.3</scala211.scala-xml.version>
     <scala211.scala-parser-combinators.version>1.0.3</scala211.scala-parser-combinators.version>
@@ -86,7 +86,7 @@
     <version.suffix>Select a Scala profile</version.suffix>
     <jdt.core.version.range>Select an Eclipse profile</jdt.core.version.range>
     <version.tag>local</version.tag>
-    <sbt.version>0.13.6</sbt.version>
+    <sbt.version>0.13.8</sbt.version>
 
     <!-- the repos containing the Scala dependencies -->
     <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-${scala.short.version}x</repo.scala-refactoring>
@@ -133,7 +133,7 @@
         <scala.minor.version>2.12</scala.minor.version>
         <version.suffix>2_12</version.suffix>
         <!-- TODO: remove snapshot version when a tag compatible with Scala 2.12 is available -->
-        <sbt.version>0.13.7-SNAPSHOT</sbt.version>
+        <sbt.version>0.13.8-SNAPSHOT</sbt.version>
 
       </properties>
     </profile>


### PR DESCRIPTION
This PR contains two functionalities:
1. it finishes a move from sbt 0.13.6 to 0.13.8. This transition does not include the change of deprecated AggressiveCompile to recommended IC or MixedAnalyzingCompiler. This part will be covered with separate ticket.
2. there was quiet hope that new sbt version solves assembla ticket 1002486. Unfortunately it's not and therefore EclipseSbtBuildManager needs to compile selected java files again with Eclipse Java Compiler after sbt work. This part got a test as well and empty (skip compilation function) method for verification.