### PR TITLE
Remove key binding for expression evaluator

### DIFF
--- a/org.scala-ide.sdt.debug.expression/plugin.xml
+++ b/org.scala-ide.sdt.debug.expression/plugin.xml
@@ -30,13 +30,6 @@
             name="Send Selection to Scala Expression Evaluator"/>
     </extension>
          
-    <extension point="org.eclipse.ui.bindings">
-        <key
-            commandId="org.scalaide.debug.handler.RunSelectionInExpressionEvaluator"
-            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            contextId="scala.tools.eclipse.scalaEditorScope"
-            sequence="M1+M2+K"/>
-    </extension>
 	
     <extension
         point="org.eclipse.ui.handlers">


### PR DESCRIPTION
It conflicts with the key binding for "find previous"

Fixes #1002509