### PR TITLE
Close matching pair when no text selection exists

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseMatchingPair.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseMatchingPair.scala
@@ -82,8 +82,9 @@ trait CloseMatchingPair extends AutoEdit {
 
     val lineInfo = document.lineInformationOfOffset(offset)
     val lineAfterCaret = document.textRange(offset, lineInfo.end)
+    val forwardToSurroundSelectionAutoEdit = IScalaPlugin().getPreferenceStore.getBoolean(surroundSelectionSetting.id) && textSelection.length > 0
 
-    if (IScalaPlugin().getPreferenceStore.getBoolean(surroundSelectionSetting.id))
+    if (forwardToSurroundSelectionAutoEdit)
       false
     else if (lineAfterCaret.isEmpty)
       true

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseString.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/CloseString.scala
@@ -6,6 +6,7 @@ import org.eclipse.jface.text.IDocument
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.lexical.ScalaPartitions
 import org.scalaide.core.text.TextChange
+import org.scalaide.util.eclipse.RegionUtils._
 
 object CloseStringSetting extends AutoEditSetting(
   id = ExtensionSetting.fullyQualifiedName[CloseString],
@@ -45,11 +46,14 @@ trait CloseString extends AutoEdit {
   def isNested(offset: Int) =
     document.textRangeOpt(offset-1, offset+1) exists (Set("{}", "[]", "()", "<>", "\"\"")(_))
 
-  def autoClosingRequired(offset: Int): Boolean =
-    if (IScalaPlugin().getPreferenceStore.getBoolean(SurroundSelectionWithStringSetting.id))
+  def autoClosingRequired(offset: Int): Boolean = {
+    val forwardToSurroundSelectionAutoEdit = IScalaPlugin().getPreferenceStore.getBoolean(SurroundSelectionWithStringSetting.id) && textSelection.length > 0
+
+    if (forwardToSurroundSelectionAutoEdit)
       false
     else if (offset < document.length)
       !ch(-1, '"') && (Character.isWhitespace(document(offset)) || isNested(offset))
     else
       !ch(-1, '"')
+  }
 }


### PR DESCRIPTION
Obviously, when no text selection exists the "surround selection" auto
edits have nothing to do, therefore we shouldn't forward to them.

Fixes #1002513