### PR TITLE
Upgrade sbt to 0.13.8

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -17,14 +17,21 @@ import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.OperationCanceledException
 import org.eclipse.core.runtime.Path
 import org.eclipse.core.runtime.SubMonitor
+import org.eclipse.jdt.core.IJavaModelMarker
 import org.scalaide.core.IScalaInstallation
 import org.scalaide.core.IScalaProject
+import org.scalaide.core.SdtConstants
 import org.scalaide.core.internal.builder.BuildProblemMarker
+import org.scalaide.core.internal.builder.CachedAnalysisBuildManager
+import org.scalaide.core.internal.builder.EclipseBuildManager
+import org.scalaide.core.internal.builder.TaskManager
 import org.scalaide.logging.HasLogger
 import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.SbtUtils
+import org.scalaide.util.internal.Suppress.DeprecatedWarning.AggressiveCompile
+import org.scalaide.util.internal.Suppress.DeprecatedWarning.aggressivelyCompile
 
-import sbt.compiler.AggressiveCompile
+import sbt.Logger.xlog2Log
 import sbt.compiler.CompileFailed
 import sbt.compiler.IC
 import sbt.inc.Analysis
@@ -33,6 +40,7 @@ import sbt.inc.SourceInfo
 import xsbti.F0
 import xsbti.Logger
 import xsbti.compile.CompileProgress
+import xsbti.compile.JavaCompiler
 
 /** An Eclipse builder using the Sbt engine.
  *
@@ -207,8 +215,8 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
     compilers match {
       case Right(comps) =>
         import comps._
-        agg(scalac, javac, options.sources, classpath, output, in.cache, SbtUtils.m2o(in.progress), scalacOptions, javacOptions, aMap,
-          defClass, sbtReporter, order, skip = false, in.incOptions)(log)
+        aggressivelyCompile(agg)(log)(scalac, javac, options.sources, classpath, output, in.cache, SbtUtils.m2o(in.progress),
+          scalacOptions, javacOptions, aMap, defClass, sbtReporter, order, /* skip = */ false, in.incOptions)
       case Left(errors) =>
         sbtReporter.log(SbtUtils.NoPosition, errors, xsbti.Severity.Error)
         throw CompilerInterfaceFailed

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
@@ -17,6 +17,7 @@ import xsbti.compile.Output
 import xsbti.Logger
 import org.scalaide.core.internal.builder.JDTBuilderFacade
 import org.scalaide.core.IScalaPlugin
+import xsbti.Reporter
 
 /** Eclipse Java compiler interface, used by the SBT builder.
  *  This class forwards to the internal Eclipse Java compiler, using
@@ -26,7 +27,7 @@ class JavaEclipseCompiler(p: IProject, monitor: SubMonitor) extends JavaCompiler
 
   override def project = p
 
-  def compile(sources: Array[File], classpath: Array[File], output: Output, options: Array[String], log: Logger): Unit = {
+  override def compile(sources: Array[File], classpath: Array[File], output: Output, options: Array[String], log: Logger): Unit = {
     val scalaProject = IScalaPlugin().getScalaProject(project)
 
     val allSourceFiles = scalaProject.allSourceFiles()
@@ -52,4 +53,7 @@ class JavaEclipseCompiler(p: IProject, monitor: SubMonitor) extends JavaCompiler
       refresh()
     }
   }
+
+  override def compileWithReporter(sources: Array[File], classpath: Array[File], output: Output, options: Array[String], reporter: Reporter, log: Logger): Unit =
+    compile(sources, classpath, output, options, log)
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -131,7 +131,7 @@ class SbtInputs(installation: IScalaInstallation,
         val cpOptions = new ClasspathOptions(false, false, false, autoBoot = false, filterLibrary = false)
         new Compilers[AnalyzingCompiler] {
           def javac = new JavaEclipseCompiler(project.underlying, javaMonitor)
-          def scalac = IC.newScalaCompiler(scalaInstance, compilerInterface.toFile, cpOptions, logger)
+          def scalac = IC.newScalaCompiler(scalaInstance, compilerInterface.toFile, cpOptions)
         }
     }
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/Suppress.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/Suppress.scala
@@ -1,13 +1,13 @@
 package org.scalaide.util.internal
 
 import java.io.PrintStream
-
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.jdt.core.IClassFile
 import org.eclipse.jdt.core.ICodeAssist
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.core.WorkingCopyOwner
 import org.eclipse.jdt.internal.core.Openable
+import java.io.File
 
 /**
  * This type exists only to suppress warnings of scalac. One should try to not
@@ -68,6 +68,8 @@ object Suppress {
     def `Console.setErr`(out: PrintStream): Unit =
       Console.setErr(out)
 
+    type AggressiveCompile = sbt.compiler.AggressiveCompile
+    def aggressivelyCompile(agg: AggressiveCompile)(implicit log: sbt.Logger) = agg.apply _
   }
   object DeprecatedWarning extends DeprecatedWarning
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <!-- Scala 2.10.x -->
     <scala210.version>2.10.5</scala210.version>
     <!-- Scala 2.11.x -->
-    <scala211.version>2.11.7-SNAPSHOT</scala211.version>
+    <scala211.version>2.11.8-SNAPSHOT</scala211.version>
     <scala211.binary.version>2.11</scala211.binary.version>
     <scala211.scala-xml.version>1.0.3</scala211.scala-xml.version>
     <scala211.scala-parser-combinators.version>1.0.3</scala211.scala-parser-combinators.version>
@@ -86,7 +86,7 @@
     <version.suffix>Select a Scala profile</version.suffix>
     <jdt.core.version.range>Select an Eclipse profile</jdt.core.version.range>
     <version.tag>local</version.tag>
-    <sbt.version>0.13.6</sbt.version>
+    <sbt.version>0.13.8</sbt.version>
 
     <!-- the repos containing the Scala dependencies -->
     <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-${scala.short.version}x</repo.scala-refactoring>
@@ -133,7 +133,7 @@
         <scala.minor.version>2.12</scala.minor.version>
         <version.suffix>2_12</version.suffix>
         <!-- TODO: remove snapshot version when a tag compatible with Scala 2.12 is available -->
-        <sbt.version>0.13.7-SNAPSHOT</sbt.version>
+        <sbt.version>0.13.8-SNAPSHOT</sbt.version>
 
       </properties>
     </profile>


### PR DESCRIPTION
It finishes a move from sbt 0.13.6 to 0.13.8. This transition does not
include the change of deprecated AggressiveCompile to recommended IC or
MixedAnalyzingCompiler. This part will be covered by a separate ticket.

Fixes #1002481
Fixes #1002493