### PR TITLE
Skip expensive buildStructure calls when `NO_AST` and no `resolveBind…

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
@@ -115,8 +115,11 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
 
     // don't rerun this expensive operation unless necessary
     if (!isConsistent()) {
-      val info = createElementInfo.asInstanceOf[OpenableElementInfo]
-      openWhenClosed(info, true, monitor)
+      if (astLevel != ICompilationUnit.NO_AST && resolveBindings) {
+        val info = createElementInfo.asInstanceOf[OpenableElementInfo]
+        openWhenClosed(info, true, monitor)
+      } else
+        logger.info(s"Skipped `makeConsistent` with resolveBindings: $resolveBindings and astLevel: $astLevel")
     }
     null
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
@@ -96,13 +96,18 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
     super.forceReconcile()
   }
 
+  /**
+   * We cut short this call since reconciliation is performed through the usual mechanism in the
+   * editor. Calls arriving here come from the JDT, for instance from the breadcrumb view, and end
+   * up doing expensive computation on the UI thread.
+   *
+   * @see #1002412
+   */
   override def reconcile(
       astLevel : Int,
       reconcileFlags : Int,
       workingCopyOwner : WorkingCopyOwner,
       monitor : IProgressMonitor) : org.eclipse.jdt.core.dom.CompilationUnit = {
-    /* This explicit call to super matters, presumably exercised
-      through AspectJ. See #1002016. */
     null
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
@@ -103,7 +103,7 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
       monitor : IProgressMonitor) : org.eclipse.jdt.core.dom.CompilationUnit = {
     /* This explicit call to super matters, presumably exercised
       through AspectJ. See #1002016. */
-    super.reconcile(ICompilationUnit.NO_AST, reconcileFlags, workingCopyOwner, monitor)
+    null
   }
 
   override def makeConsistent(


### PR DESCRIPTION
…ings` are needed.

This code path is taken by `Save`, on the UI thread, and
slow build structure can block the UI for several seconds while saving.

In order to not lose functionality, the structure is now built after each reconciliation. It should be fast (the whole file was already type-checked), and on a background thread.

These changes interfere with the JDT interactions so it'd be great to get some feedback from real-world usage.

Fixed #1002412