### PR TITLE
Fix #1002518

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/AutoEdits.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/extensions/AutoEdits.scala
@@ -10,12 +10,8 @@ object AutoEdits {
   val autoEditData: Seq[(String, AutoEditSetting)] = Seq(
     fullyQualifiedName[ConvertToUnicode] → ConvertToUnicodeSetting,
     fullyQualifiedName[SmartSemicolonInsertion] → SmartSemicolonInsertionSetting,
-    fullyQualifiedName[CloseCurlyBrace] → CloseCurlyBraceSetting,
     fullyQualifiedName[JumpOverClosingCurlyBrace] → JumpOverClosingCurlyBraceSetting,
     fullyQualifiedName[RemoveCurlyBracePair] → RemoveCurlyBracePairSetting,
-    fullyQualifiedName[CloseParenthesis] → CloseParenthesisSetting,
-    fullyQualifiedName[CloseBracket] → CloseBracketSetting,
-    fullyQualifiedName[CloseAngleBracket] → CloseAngleBracketSetting,
     fullyQualifiedName[RemoveParenthesisPair] → RemoveParenthesisPairSetting,
     fullyQualifiedName[CreateMultiplePackageDeclarations] → CreateMultiplePackageDeclarationsSetting,
     fullyQualifiedName[ApplyTemplate] → ApplyTemplateSetting,
@@ -31,7 +27,11 @@ object AutoEdits {
     fullyQualifiedName[SurroundSelectionWithParentheses] → SurroundSelectionWithParenthesesSetting,
     fullyQualifiedName[SurroundSelectionWithBraces] → SurroundSelectionWithBracesSetting,
     fullyQualifiedName[SurroundSelectionWithBrackets] → SurroundSelectionWithBracketsSetting,
-    fullyQualifiedName[SurroundSelectionWithAngleBrackets] → SurroundSelectionWithAngleBracketsSetting
+    fullyQualifiedName[SurroundSelectionWithAngleBrackets] → SurroundSelectionWithAngleBracketsSetting,
+    fullyQualifiedName[CloseCurlyBrace] → CloseCurlyBraceSetting,
+    fullyQualifiedName[CloseParenthesis] → CloseParenthesisSetting,
+    fullyQualifiedName[CloseBracket] → CloseBracketSetting,
+    fullyQualifiedName[CloseAngleBracket] → CloseAngleBracketSetting
   )
 
   /**


### PR DESCRIPTION
Reorder auto-edits to give priority to more specific actions. Close parentheis/braces/etc is the most generic, fallback type of action.