### PR TITLE
A few fixes to surround block auto-edit.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/autoedits/SurroundBlockTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/autoedits/SurroundBlockTest.scala
@@ -226,4 +226,32 @@ class SurroundBlockTest extends AutoEditTests {
       }
     }
     """ after curlyBrace
+
+  @Test
+  def add_no_brace_before_empty_line_with_comments() = """
+    test("") ^
+
+    // This tests whether file input stream remembers what files were seen before
+    // the master failure and uses them again to process a large window operation.
+    test("recovery with file input stream") {
+    """ becomes """
+    test("") {^
+
+    // This tests whether file input stream remembers what files were seen before
+    // the master failure and uses them again to process a large window operation.
+    test("recovery with file input stream") {
+    """ after curlyBrace
+
+  @Test
+  def add_brace_inline_else() = """
+    if (x > 0) ^
+      true
+    else
+      false
+    """ becomes """
+    if (x > 0) {^
+      true
+    } else
+      false
+    """ after curlyBrace
 }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/autoedits/SurroundBlockTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/autoedits/SurroundBlockTest.scala
@@ -254,4 +254,34 @@ class SurroundBlockTest extends AutoEditTests {
     } else
       false
     """ after curlyBrace
+
+  @Test
+  def add_brace_inline_catch() = """
+    try ^
+      throw null
+    catch {
+      case _ => ()
+    }
+    """ becomes """
+    try {^
+      throw null
+    } catch {
+      case _ => ()
+    }
+    """ after curlyBrace
+
+  @Test
+  def add_brace_inline_finally() = """
+    try ^
+      throw null
+    finally {
+      ()
+    }
+    """ becomes """
+    try {^
+      throw null
+    } finally {
+      ()
+    }
+    """ after curlyBrace
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundBlock.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundBlock.scala
@@ -45,6 +45,7 @@ trait SurroundBlock extends AutoEdit {
   override def setting = SurroundBlockSetting
 
   override def perform() = {
+    val elseLikeTokens = Set(Tokens.ELSE, Tokens.CATCH, Tokens.FINALLY)
     check(textChange) {
       case Add(start, "{") =>
         surroundLocation(start) map {
@@ -52,7 +53,7 @@ trait SurroundBlock extends AutoEdit {
             val sep = System.getProperty("line.separator")
             val indent = " " * indentLen
 
-            val change = if (token.tokenType == Tokens.ELSE)
+            val change = if (elseLikeTokens(token.tokenType))
               Replace(start, pos + indentLen, s"{${document.textRange(start, pos)}$indent} ")
             else
               Replace(start, pos, s"{${document.textRange(start, pos)}$indent}$sep")
@@ -62,9 +63,9 @@ trait SurroundBlock extends AutoEdit {
   }
 
   /**
-   * Returns the position where the closing curly brace should be inserted and
-   * the indentation of the line where the opening curly brace is inserted into
-   * the document.
+   * Returns a triple with the position where the closing curly brace should be inserted,
+   * the indentation of the line where the opening curly brace is inserted into the document
+   * and the first token after the insertion point.
    *
    * In case no insertion position could be found, `None` is returned.
    */


### PR DESCRIPTION
- stop at comment blocks
- don’t include empty lines in the surround block
- properly treat `else` 

Fix #1002515
Fix #1002519