### PR TITLE
Also treat block comments/scaladoc as comments

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/autoedits/SurroundBlockTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/autoedits/SurroundBlockTest.scala
@@ -243,6 +243,26 @@ class SurroundBlockTest extends AutoEditTests {
     """ after curlyBrace
 
   @Test
+  def add_no_brace_before_empty_line_with_block_comments() = """
+    test("") ^
+
+    /**
+     * This tests whether file input stream remembers what files were seen before
+     * the master failure and uses them again to process a large window operation.
+     */
+    test("recovery with file input stream") {
+    """ becomes """
+    test("") {^
+
+    /**
+     * This tests whether file input stream remembers what files were seen before
+     * the master failure and uses them again to process a large window operation.
+     */
+    test("recovery with file input stream") {
+    """ after curlyBrace
+
+
+  @Test
   def add_brace_inline_else() = """
     if (x > 0) ^
       true

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundBlock.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundBlock.scala
@@ -87,8 +87,7 @@ trait SurroundBlock extends AutoEdit {
 
         if (t.tokenType == RBRACE
              || t.tokenType == VARID
-             || t.tokenType == LINE_COMMENT
-             || t.tokenType == COMMENTS
+             || COMMENTS.contains(t.tokenType)
              || (Tokens.KEYWORDS contains t.tokenType)) {
           val line = document.lineInformationOfOffset(t.offset+offset)
           val indent = indentLenOfLine(line)


### PR DESCRIPTION
Fix #1002515 (again).

@sschaef I missed a case...