### PR TITLE
Improve async debugger

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/FieldEditors.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/FieldEditors.scala
@@ -1,0 +1,77 @@
+package org.scalaide.ui.internal.preferences
+
+import org.eclipse.jface.preference.FieldEditor
+import org.eclipse.swt.SWT
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Control
+import org.eclipse.ui.IWorkbench
+import org.eclipse.ui.IWorkbenchPreferencePage
+import org.eclipse.ui.dialogs.PropertyPage
+
+import net.miginfocom.layout.AC
+import net.miginfocom.layout.CC
+import net.miginfocom.layout.LC
+import net.miginfocom.swt.MigLayout
+
+/**
+ * Contains common definitions for preference and property pages that want to
+ * display field editors.
+ */
+trait FieldEditors extends PropertyPage with IWorkbenchPreferencePage {
+
+  private var _isWorkbenchPage = false
+
+  protected var allEnableDisableControls = Set[Control]()
+  protected val fieldEditors = collection.mutable.ListBuffer[FieldEditor]()
+
+  def isWorkbenchPage: Boolean =
+    _isWorkbenchPage
+
+  def isWorkbenchPage_=(isWorkbenchPage: Boolean): Unit =
+    _isWorkbenchPage = isWorkbenchPage
+
+  def addNewFieldEditorWrappedInComposite[T <: FieldEditor](parent: Composite)(f: Composite ⇒ T): T = {
+    val composite = new Composite(parent, SWT.NONE)
+    val fieldEditor = f(composite)
+
+    fieldEditor.setPreferenceStore(getPreferenceStore)
+    fieldEditor.load
+
+    if (isWorkbenchPage)
+      composite.setLayoutData(new CC().grow.wrap)
+    else
+      composite.setLayoutData(new CC().spanX(2).grow.wrap)
+
+    fieldEditor
+  }
+
+  def mkMainControl(parent: Composite)(f: Composite ⇒ Unit): Composite = {
+    val control = new Composite(parent, SWT.NONE)
+    val rowConstraints = if (isWorkbenchPage)
+      new AC().index(0).grow(0).index(1).grow
+    else
+      new AC().index(0).grow(0).index(1).grow(0).index(2).grow(0).index(3).grow
+
+    control.setLayout(new MigLayout(new LC().insetsAll("0").fill, new AC(), rowConstraints))
+
+    f(control)
+    allEnableDisableControls foreach { _.setEnabled(true) }
+    control
+  }
+
+  override def performDefaults() = {
+    super.performDefaults()
+    fieldEditors.foreach(_.loadDefault)
+  }
+
+  override def performOk() = {
+    super.performOk()
+    fieldEditors.foreach(_.store)
+    true
+  }
+
+  override def init(workbench: IWorkbench): Unit = {
+    isWorkbenchPage = true
+  }
+
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/FieldEditors.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/FieldEditors.scala
@@ -1,12 +1,24 @@
 package org.scalaide.ui.internal.preferences
 
+import scala.collection.mutable.ListBuffer
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.ProjectScope
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.internal.ui.preferences.PreferencesMessages
 import org.eclipse.jface.preference.FieldEditor
+import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.swt.SWT
+import org.eclipse.swt.widgets.Button
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.swt.widgets.Control
+import org.eclipse.swt.widgets.Label
+import org.eclipse.swt.widgets.Link
 import org.eclipse.ui.IWorkbench
 import org.eclipse.ui.IWorkbenchPreferencePage
+import org.eclipse.ui.dialogs.PreferencesUtil
 import org.eclipse.ui.dialogs.PropertyPage
+import org.scalaide.util.eclipse.SWTUtils._
 
 import net.miginfocom.layout.AC
 import net.miginfocom.layout.CC
@@ -19,16 +31,21 @@ import net.miginfocom.swt.MigLayout
  */
 trait FieldEditors extends PropertyPage with IWorkbenchPreferencePage {
 
-  private var _isWorkbenchPage = false
+  protected final var isWorkbenchPage: Boolean = false
+  protected final var allEnableDisableControls: Set[Control] = Set()
+  protected final val fieldEditors: ListBuffer[FieldEditor] = ListBuffer()
 
-  protected var allEnableDisableControls = Set[Control]()
-  protected val fieldEditors = collection.mutable.ListBuffer[FieldEditor]()
+  def useProjectSpecifcSettingsKey: String
 
-  def isWorkbenchPage: Boolean =
-    _isWorkbenchPage
+  def initUnderlyingPreferenceStore(pluginId: String, pluginPrefStore: IPreferenceStore): Unit = {
+    setPreferenceStore(getElement match {
+      case project: IProject     ⇒ new PropertyStore(new ProjectScope(project), pluginId)
+      case project: IJavaProject ⇒ new PropertyStore(new ProjectScope(project.getProject), pluginId)
+      case _                     ⇒ pluginPrefStore
+    })
+  }
 
-  def isWorkbenchPage_=(isWorkbenchPage: Boolean): Unit =
-    _isWorkbenchPage = isWorkbenchPage
+  def pageId: String
 
   def addNewFieldEditorWrappedInComposite[T <: FieldEditor](parent: Composite)(f: Composite ⇒ T): T = {
     val composite = new Composite(parent, SWT.NONE)
@@ -54,8 +71,34 @@ trait FieldEditors extends PropertyPage with IWorkbenchPreferencePage {
 
     control.setLayout(new MigLayout(new LC().insetsAll("0").fill, new AC(), rowConstraints))
 
+    if (!isWorkbenchPage) {
+      val projectSpecificButton = new Button(control, SWT.CHECK | SWT.WRAP)
+      projectSpecificButton.setText("Enable project specific settings")
+      projectSpecificButton.setSelection(getPreferenceStore.getBoolean(useProjectSpecifcSettingsKey))
+      projectSpecificButton.addSelectionListener { () ⇒
+        val enabled = projectSpecificButton.getSelection
+        getPreferenceStore.setValue(useProjectSpecifcSettingsKey, enabled)
+        allEnableDisableControls foreach { _.setEnabled(enabled) }
+      }
+      projectSpecificButton.setLayoutData(new CC)
+
+      val link = new Link(control, SWT.NONE)
+      link.setText("<a>"+PreferencesMessages.PropertyAndPreferencePage_useworkspacesettings_change+"</a>")
+      link.addSelectionListener { () ⇒
+        PreferencesUtil.createPreferenceDialogOn(getShell, pageId, Array(pageId), null).open()
+      }
+      link.setLayoutData(new CC().alignX("right").wrap)
+
+      val horizontalLine = new Label(control, SWT.SEPARATOR | SWT.HORIZONTAL)
+      horizontalLine.setLayoutData(new CC().spanX(2).grow.wrap)
+    }
+
     f(control)
-    allEnableDisableControls foreach { _.setEnabled(true) }
+
+    if (!isWorkbenchPage) {
+      val enabled = getPreferenceStore.getBoolean(useProjectSpecifcSettingsKey)
+      allEnableDisableControls foreach { _.setEnabled(enabled) }
+    }
     control
   }
 

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -76,7 +76,7 @@
       <page
             category="org.scalaide.ui.preferences.debug"
             class="org.scalaide.debug.internal.preferences.AsyncDebuggerPreferencePage"
-            id="org.scalaide.ui.preferences.debug"
+            id="org.scalaide.ui.preferences.debug.async"
             name="Async Debugger">
       </page>
    </extension>
@@ -187,5 +187,13 @@
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+F5">
       </key>
+   </extension>
+   <extension
+         point="org.eclipse.ui.propertyPages">
+      <page
+            class="org.scalaide.debug.internal.preferences.AsyncDebuggerPreferencePage"
+            id="org.scalaide.ui.preferences.debug.async"
+            name="Scala Async Debugger">
+      </page>
    </extension>
 </plugin>

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -122,14 +122,21 @@
    <extension
          point="org.eclipse.ui.commands">
       <command
-            id="org.scala-ide.sdt.debug.stepMessageOut"
+            categoryId="org.scalaide.debug"
+            id="org.scalaide.debug.async.stepMessageOut"
             name="Step Message Out">
       </command>
       <command
+            categoryId="org.scalaide.debug"
             description="Break execution when a message is sent to dead letters"
-            id="org.scala-ide.sdt.debug.stopOnDeadLetters"
+            id="org.scalaide.debug.async.stopOnDeadLetters"
             name="Break on DeadLetter">
       </command>
+      <category
+            description="Scala Debugger category"
+            id="org.scalaide.debug"
+            name="Scala Debugger">
+      </category>
    </extension>
    <extension
          point="org.eclipse.ui.menus">

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -142,20 +142,17 @@
          point="org.eclipse.ui.menus">
       <menuContribution
             allPopups="false"
-            locationURI="toolbar:org.eclipse.ui.main.toolbar">
-         <toolbar
-               id="org.eclipse.debug.ui.debugActionSet">
-            <command
-                  commandId="org.scala-ide.sdt.debug.stepMessageOut"
-                  icon="icons/bang.png"
-                  label="Step Message Out"
-                  style="push"
-                  tooltip="Step until a message is received">
-               <visibleWhen
-                     checkEnabled="true">
-               </visibleWhen>
-            </command>
-         </toolbar>
+            locationURI="toolbar:org.scala-ide.sdt.debug.asyncView">
+         <command
+               commandId="org.scala-ide.sdt.debug.stepMessageOut"
+               icon="icons/bang.png"
+               label="Step Message Out"
+               style="push"
+               tooltip="Step until a message is received">
+            <visibleWhen
+                  checkEnabled="true">
+            </visibleWhen>
+         </command>
       </menuContribution>
       <menuContribution
             allPopups="false"

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -120,19 +120,72 @@
       </contextViewBinding>
    </extension>
    <extension
+         point="org.eclipse.ui.commands">
+      <command
+            id="org.scala-ide.sdt.debug.stepMessageOut"
+            name="Step Message Out">
+      </command>
+      <command
+            description="Break execution when a message is sent to dead letters"
+            id="org.scala-ide.sdt.debug.stopOnDeadLetters"
+            name="Break on DeadLetter">
+      </command>
+   </extension>
+   <extension
          point="org.eclipse.ui.menus">
       <menuContribution
             allPopups="false"
             locationURI="toolbar:org.eclipse.ui.main.toolbar">
          <toolbar
                id="org.eclipse.debug.ui.debugActionSet">
+            <command
+                  commandId="org.scala-ide.sdt.debug.stepMessageOut"
+                  icon="icons/bang.png"
+                  label="Step Message Out"
+                  style="push"
+                  tooltip="Step until a message is received">
+               <visibleWhen
+                     checkEnabled="true">
+               </visibleWhen>
+            </command>
          </toolbar>
       </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="toolbar:org.eclipse.debug.ui.BreakpointView">
+          <command
+                commandId="org.scala-ide.sdt.debug.stopOnDeadLetters"
+                icon="icons/envelope-blue.png"
+                label="Break on Dead Letters"
+                style="toggle"
+                tooltip="Break when a message arrives in dead letters">
+          </command>
+      </menuContribution>
+   </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="org.scalaide.debug.internal.command.StepMessageOut"
+            commandId="org.scala-ide.sdt.debug.stepMessageOut">
+      </handler>
+      <handler
+            class="org.scalaide.debug.internal.command.BreakOnDeadLettersAction"
+            commandId="org.scala-ide.sdt.debug.stopOnDeadLetters">
+      </handler>
    </extension>
    <extension
          point="org.scala-ide.sdt.core.scalaHoverDebugOverride">
       <overrider
             hoverFactoryClass="org.scalaide.debug.internal.editor.TextHoverFactory">
       </overrider>
+   </extension>
+   <extension
+         point="org.eclipse.ui.bindings">
+      <key
+            commandId="org.scala-ide.sdt.debug.stepMessageOut"
+            contextId="org.eclipse.debug.ui.debugging"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M2+F5">
+      </key>
    </extension>
 </plugin>

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/RetainedStackManager.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/RetainedStackManager.scala
@@ -3,7 +3,6 @@ package org.scalaide.debug.internal.async
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters.asScalaBufferConverter
-import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.mutable
 import scala.util.Success
 import scala.util.Try
@@ -20,8 +19,6 @@ import com.sun.jdi.StackFrame
 import com.sun.jdi.ThreadReference
 import com.sun.jdi.event.BreakpointEvent
 import com.sun.jdi.event.ClassPrepareEvent
-
-import RetainedStackManager.OrdinalNotSet
 
 /**
  * Installs breakpoints in key places and collect stack frames.

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/RetainedStackManager.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/RetainedStackManager.scala
@@ -8,9 +8,11 @@ import scala.util.Success
 import scala.util.Try
 
 import org.scalaide.debug.internal.BaseDebuggerActor
+import org.scalaide.debug.internal.ScalaDebugPlugin
 import org.scalaide.debug.internal.model.JdiRequestFactory
 import org.scalaide.debug.internal.model.ScalaDebugTarget
 import org.scalaide.debug.internal.model.ScalaValue
+import org.scalaide.debug.internal.preferences.AsyncDebuggerPreferencePage
 import org.scalaide.logging.HasLogger
 
 import com.sun.jdi.ObjectReference
@@ -94,13 +96,12 @@ class RetainedStackManager(debugTarget: ScalaDebugTarget) extends HasLogger {
     }
   }
 
-  private val programPoints = List(
-    AsyncProgramPoint("scala.concurrent.Future$", "apply", 0),
-    AsyncProgramPoint("scala.concurrent.package$", "future", 0),
-    AsyncProgramPoint("play.api.libs.iteratee.Cont$", "apply", 0),
-    AsyncProgramPoint("akka.actor.LocalActorRef", "$bang", 0),
-    AsyncProgramPoint("akka.actor.RepointableActorRef", "$bang", 0),
-    AsyncProgramPoint("scala.actors.InternalReplyReactor$class", "$bang", 1))
+  private val programPoints = {
+    val app = ScalaDebugPlugin.plugin.getPreferenceStore.getString(AsyncDebuggerPreferencePage.AsyncProgramPoints)
+    app.split(AsyncDebuggerPreferencePage.DataDelimiter).map(_.split(",")).map {
+      case Array(className, methodName, paramIdx) ⇒ AsyncProgramPoint(className, methodName, paramIdx.toInt)
+    }.toList
+  }
 
   /** Return the saved stackframes for the given future body (if any). */
   def getStackFrameForFuture(future: ObjectReference, messageOrdinal: Int): Option[AsyncStackTrace] =

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/StepMessageOut.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/StepMessageOut.scala
@@ -1,0 +1,131 @@
+package org.scalaide.debug.internal.async
+
+import org.scalaide.debug.internal.BaseDebuggerActor
+import org.scalaide.debug.internal.model.ScalaDebugTarget
+import org.scalaide.debug.internal.model.ScalaThread
+import org.scalaide.debug.internal.model.JdiRequestFactory
+import org.eclipse.debug.core.DebugEvent
+import com.sun.jdi.event.BreakpointEvent
+import org.scalaide.logging.HasLogger
+import com.sun.jdi.ObjectReference
+import com.sun.jdi.request.EventRequest
+import com.sun.jdi.event.StepEvent
+import com.sun.jdi.request.StepRequest
+
+case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) extends HasLogger {
+
+  private var watchedMessage: Option[ObjectReference] = None
+
+  val programSends = List(
+    AsyncProgramPoint("akka.actor.RepointableActorRef", "$bang", 0),
+    AsyncProgramPoint("akka.actor.LocalActorRef", "$bang", 0),
+    AsyncProgramPoint("scala.actors.InternalReplyReactor$class", "$bang", 1))
+
+  val programReceives = List(
+    AsyncProgramPoint("akka.actor.ActorCell", "receiveMessage", 0))
+
+  private var sendRequests = Set[EventRequest]()
+  private var receiveRequests = Set[EventRequest]()
+  private var stepRequests = Set[EventRequest]()
+  private var steps = 0
+
+  def step(): Unit = {
+    sendRequests = programSends.flatMap(AsyncUtils.installMethodBreakpoint(debugTarget, _, internalActor, thread.threadRef)).toSet
+    receiveRequests = programReceives.flatMap(AsyncUtils.installMethodBreakpoint(debugTarget, _, internalActor)).toSet
+    internalActor.start()
+    // CLIENT_REQUEST seems to be the only event that correctly updates the UI
+    thread.resumeFromScala(DebugEvent.CLIENT_REQUEST)
+  }
+
+  object internalActor extends BaseDebuggerActor {
+    private def interceptMessage(ev: BreakpointEvent): Boolean = {
+      // only intercept messages going out from the current thread and frame (no messages sent by methods below us)
+      println(s"GENERAL SEND: ${ev.thread.frame(0).getArgumentValues()} THREAD: ${ev.thread.name()} looking for thread: ${thread.threadRef.name}: ${ev.thread == thread.threadRef}")
+      if (sendRequests(ev.request)) {
+        println("? intercept send: " + ev.thread.frame(0).getArgumentValues())
+        true
+      } else false
+    }
+
+    private def isReceiveHandler(loc: com.sun.jdi.Location): Boolean = {
+      val typeName = loc.declaringType().name
+      (loc.method().name().contains("applyOrElse")
+        && !typeName.startsWith("akka"))
+    }
+
+    override protected def behavior = {
+      case breakpointEvent: BreakpointEvent if interceptMessage(breakpointEvent) =>
+        val app = breakpointEvent.request().getProperty("app").asInstanceOf[AsyncProgramPoint]
+        val topFrame = breakpointEvent.thread().frame(0)
+        val args = topFrame.getArgumentValues()
+        logger.debug(s"MESSAGE OUT intercepted: topFrame arguments: $args")
+        watchedMessage = Option(args.get(app.paramIdx).asInstanceOf[ObjectReference])
+
+        reply(false) // don't suspend this thread
+
+      case breakpointEvent: BreakpointEvent if receiveRequests(breakpointEvent.request()) =>
+        val app = breakpointEvent.request().getProperty("app").asInstanceOf[AsyncProgramPoint]
+        val topFrame = breakpointEvent.thread().frame(0)
+        val args = topFrame.getArgumentValues()
+        logger.debug(s"receive intercepted: topFrame arguments: $args")
+        val msg = Option(args.get(app.paramIdx).asInstanceOf[ObjectReference])
+        if (watchedMessage == msg) {
+          logger.debug(s"MESSAGE IN! $msg")
+          deleteSendRequests()
+
+          val targetThread = debugTarget.getScalaThread(breakpointEvent.thread())
+          targetThread foreach { thread =>
+            val stepReq = JdiRequestFactory.createStepRequest(StepRequest.STEP_LINE, StepRequest.STEP_INTO, thread)
+            stepReq.enable()
+            stepRequests = Set(stepReq)
+            debugTarget.eventDispatcher.setActorFor(this, stepReq)
+            steps = 0
+          }
+        }
+        reply(false)
+
+      case stepEvent: StepEvent if isReceiveHandler(stepEvent.location) =>
+        disable()
+        poison()
+        logger.debug(s"Suspending thread ${stepEvent.thread.name()}")
+        // most likely the breakpoint was hit on a different thread than the one we started with, so we find it here
+        debugTarget.getScalaThread(stepEvent.thread()).foreach(_.suspendedFromScala(DebugEvent.BREAKPOINT))
+        reply(true) // suspend here!
+
+      case stepEvent: StepEvent if steps >= 20 =>
+        disable()
+        poison()
+        logger.debug(s"Giving up on stepping after 15 steps")
+        reply(false)
+
+      case stepEvent: StepEvent =>
+        steps += 1
+        logger.debug(s"Step $steps: ${stepEvent.location.declaringType}.${stepEvent.location.method}")
+        reply(false) // resume VM
+      case _ => reply(false)
+    }
+
+    private def deleteSendRequests(): Unit = {
+      val eventDispatcher = debugTarget.eventDispatcher
+      val eventRequestManager = debugTarget.virtualMachine.eventRequestManager
+
+      for (request <- sendRequests) {
+        request.disable()
+        eventDispatcher.unsetActorFor(request)
+        eventRequestManager.deleteEventRequest(request)
+      }
+      sendRequests = Set()
+    }
+
+    private def disable(): Unit = {
+      val eventDispatcher = debugTarget.eventDispatcher
+      val eventRequestManager = debugTarget.virtualMachine.eventRequestManager
+
+      for (request <- sendRequests ++ receiveRequests ++ stepRequests) {
+        request.disable()
+        eventDispatcher.unsetActorFor(request)
+        eventRequestManager.deleteEventRequest(request)
+      }
+    }
+  }
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/command/StepMessageOut.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/command/StepMessageOut.scala
@@ -1,0 +1,33 @@
+package org.scalaide.debug.internal.command
+
+import org.eclipse.core.commands.IHandler
+import org.eclipse.debug.core.commands.ITerminateHandler
+import org.eclipse.core.commands.AbstractHandler
+import org.eclipse.core.commands.ExecutionEvent
+import org.eclipse.debug.ui.DebugUITools
+import org.eclipse.ui.handlers.HandlerUtil
+import org.eclipse.jface.viewers.IStructuredSelection
+import org.scalaide.debug.internal.model.ScalaStackFrame
+
+class StepMessageOut extends AbstractHandler {
+  override def execute(event: ExecutionEvent): Object = {
+    val window = HandlerUtil.getActiveWorkbenchWindow(event)
+    val service = DebugUITools.getDebugContextManager().getContextService(window)
+    val selection = service.getActiveContext()
+
+    selection match {
+      case se: IStructuredSelection =>
+        se.getFirstElement() match {
+          case ssf: ScalaStackFrame =>
+            ssf.thread.stepMessageOut()
+          case _ =>
+        }
+      case _ =>
+    }
+    null
+  }
+
+  override def setEnabled(context: Object): Unit = ()
+
+  override def isEnabled() = true
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
@@ -8,6 +8,7 @@ import org.eclipse.debug.core.model.IStackFrame
 import org.eclipse.debug.core.model.IThread
 import org.scalaide.debug.internal.BaseDebuggerActor
 import org.scalaide.debug.internal.JDIUtil._
+import org.scalaide.debug.internal.async.StepMessageOut
 import org.scalaide.debug.internal.command.ScalaStep
 import org.scalaide.debug.internal.command.ScalaStepInto
 import org.scalaide.debug.internal.command.ScalaStepOver
@@ -67,6 +68,10 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
     for (head <- stackFrames.headOption) {
       wrapJDIException("Exception while performing `step return`") { ScalaStepReturn(head).step() }
     }
+  }
+
+  def stepMessageOut(): Unit = {
+    (new StepMessageOut(getDebugTarget, this)).step
   }
 
   // Members declared in org.eclipse.debug.core.model.ISuspendResume

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/AsyncDebuggerPreferencePage.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/AsyncDebuggerPreferencePage.scala
@@ -17,9 +17,12 @@ import org.scalaide.ui.internal.preferences.FieldEditors
 class AsyncDebuggerPreferencePage extends FieldEditors {
   import AsyncDebuggerPreferencePage._
 
-  setPreferenceStore(ScalaDebugPlugin.plugin.getPreferenceStore)
+  override def createContents(parent: Composite): Control = {
+    initUnderlyingPreferenceStore(ScalaDebugPlugin.id, ScalaDebugPlugin.plugin.getPreferenceStore)
+    mkMainControl(parent)(createEditors)
+  }
 
-  override def createContents(parent: Composite): Control = mkMainControl(parent) { control ⇒
+  def createEditors(control: Composite): Unit = {
     fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent ⇒
       new ListEditor(FadingPackages, "Define all package names that should be faded:", parent) {
 
@@ -56,7 +59,9 @@ class AsyncDebuggerPreferencePage extends FieldEditors {
     }
 
     fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent ⇒
-      new ColorFieldEditor(FadingColor, "Color of faded packages:", parent)
+      new ColorFieldEditor(FadingColor, "Color of faded packages:", parent) {
+        allEnableDisableControls += getColorSelector.getButton
+      }
     }
 
     fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent ⇒
@@ -98,6 +103,10 @@ class AsyncDebuggerPreferencePage extends FieldEditors {
       }
     }
   }
+
+  override def useProjectSpecifcSettingsKey = UseProjectSpecificSettingsKey
+
+  override def pageId = PageId
 }
 
 object AsyncDebuggerPreferencePage {
@@ -106,6 +115,8 @@ object AsyncDebuggerPreferencePage {
   val AsyncProgramPoints = "org.scalaide.debug.async.programPoints"
   /** The delimiter that separates the data that is entered in the UI. */
   val DataDelimiter = ";"
+  val UseProjectSpecificSettingsKey = "org.scalaide.debug.async.useProjectSpecificSettings"
+  val PageId = "org.scalaide.ui.preferences.debug.async"
 }
 
 class AsyncDebuggerPreferencesInitializer extends AbstractPreferenceInitializer {

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/AsyncDebuggerPreferencePage.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/preferences/AsyncDebuggerPreferencePage.scala
@@ -1,37 +1,111 @@
 package org.scalaide.debug.internal.preferences
 
-import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer
-import org.eclipse.jface.preference.ColorFieldEditor
-import org.eclipse.jface.preference.FieldEditorPreferencePage
-import org.eclipse.jface.preference.StringFieldEditor
-import org.eclipse.swt.layout.GridLayout
-import org.eclipse.ui.IWorkbench
-import org.eclipse.ui.IWorkbenchPreferencePage
-import org.scalaide.debug.internal.ScalaDebugPlugin
+import scala.util.Try
 
-class AsyncDebuggerPreferencePage extends FieldEditorPreferencePage(FieldEditorPreferencePage.GRID) with IWorkbenchPreferencePage {
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer
+import org.eclipse.jface.dialogs.IInputValidator
+import org.eclipse.jface.dialogs.InputDialog
+import org.eclipse.jface.preference.ColorFieldEditor
+import org.eclipse.jface.preference.ListEditor
+import org.eclipse.jface.window.Window
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Control
+import org.eclipse.swt.widgets.Display
+import org.scalaide.debug.internal.ScalaDebugPlugin
+import org.scalaide.ui.internal.preferences.FieldEditors
+
+class AsyncDebuggerPreferencePage extends FieldEditors {
   import AsyncDebuggerPreferencePage._
 
   setPreferenceStore(ScalaDebugPlugin.plugin.getPreferenceStore)
 
-  override def createFieldEditors(): Unit = {
-    val c = getFieldEditorParent
-    c.setLayout(new GridLayout(1, false))
+  override def createContents(parent: Composite): Control = mkMainControl(parent) { control ⇒
+    fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent ⇒
+      new ListEditor(FadingPackages, "Define all package names that should be faded:", parent) {
 
-    val fp = new StringFieldEditor(FadingPackages, "Comma separated list of packages that should be faded: ", c)
-    addField(fp)
+        getDownButton.setVisible(false)
+        getUpButton.setVisible(false)
 
-    val color = new ColorFieldEditor(FadingColor, "Color of faded packages:", c)
-    addField(color)
+        allEnableDisableControls += getListControl(parent)
+        allEnableDisableControls += getButtonBoxControl(parent)
+
+        override def createList(items: Array[String]) = items.mkString(DataDelimiter)
+
+        override def parseString(stringList: String) = stringList.split(DataDelimiter)
+
+        override def getNewInputObject(): String = {
+
+          val dlg = new InputDialog(
+              Display.getCurrent().getActiveShell(),
+              "",
+              "Enter a new package name:",
+              "",
+              new IInputValidator {
+                override def isValid(text: String) =
+                  if (!text.contains(DataDelimiter))
+                    null
+                  else
+                    "Text contains invalid characters."
+              })
+          if (dlg.open() == Window.OK)
+            dlg.getValue()
+          else
+            null
+        }
+      }
+    }
+
+    fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent ⇒
+      new ColorFieldEditor(FadingColor, "Color of faded packages:", parent)
+    }
+
+    fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent ⇒
+      new ListEditor(AsyncProgramPoints, "Define the Async Program Points (entry points for the \"jump to next message\" functionality):", parent) {
+
+        getDownButton.setVisible(false)
+        getUpButton.setVisible(false)
+
+        allEnableDisableControls += getListControl(parent)
+        allEnableDisableControls += getButtonBoxControl(parent)
+
+        override def createList(items: Array[String]) = items.mkString(DataDelimiter)
+
+        override def parseString(stringList: String) = stringList.split(DataDelimiter)
+
+        override def getNewInputObject(): String = {
+          val dlg = new InputDialog(
+              Display.getCurrent().getActiveShell(),
+              "",
+              "Enter a new Async Program Point. It consists of a comma separated" +
+              " three tuple, where the first element is the class name, the second" +
+              " element is the name of the method and the last element is the index" +
+              " of the parameter:",
+              "",
+              new IInputValidator {
+                override def isValid(text: String) = {
+                  val elems = text.split(DataDelimiter, -1)
+                  if (elems.size == 3 && elems.forall(_.nonEmpty) && !text.contains(DataDelimiter) && Try(elems(2).toInt).isSuccess)
+                    null
+                  else
+                    "Entered value is not a three tuple or contains invalid characters."
+                }
+              })
+          if (dlg.open() == Window.OK)
+            dlg.getValue()
+          else
+            null
+        }
+      }
+    }
   }
-
-  override def init(workbench: IWorkbench): Unit = {}
-
 }
 
 object AsyncDebuggerPreferencePage {
   val FadingPackages = "org.scalaide.debug.async.fadingPackages"
   val FadingColor = "org.scalaide.debug.async.fadingColor"
+  val AsyncProgramPoints = "org.scalaide.debug.async.programPoints"
+  /** The delimiter that separates the data that is entered in the UI. */
+  val DataDelimiter = ";"
 }
 
 class AsyncDebuggerPreferencesInitializer extends AbstractPreferenceInitializer {
@@ -40,8 +114,18 @@ class AsyncDebuggerPreferencesInitializer extends AbstractPreferenceInitializer 
   override def initializeDefaultPreferences(): Unit = {
     val store = ScalaDebugPlugin.plugin.getPreferenceStore
 
-    store.setDefault(FadingPackages, "scala.,akka.,play.")
+    store.setDefault(FadingPackages, Seq("scala.", "akka.", "play.").mkString(DataDelimiter))
     store.setDefault(FadingColor, "191,191,191")
+
+    val app = Seq(
+      "scala.concurrent.Future$,apply,0",
+      "scala.concurrent.package$,future,0",
+      "play.api.libs.iteratee.Cont$,apply,0",
+      "akka.actor.LocalActorRef,$bang,0",
+      "akka.actor.RepointableActorRef,$bang,0",
+      "scala.actors.InternalReplyReactor$class,$bang,1"
+    ).mkString(DataDelimiter)
+    store.setDefault(AsyncProgramPoints, app)
   }
 
 }


### PR DESCRIPTION
- Re-enables the disabled "step to next message" feature
- Adds preference page to allow users to configure async program points
- Allow debugger commands to have key combinations (no default key combinations set, since it is difficult to find one that works on all systems)
- Move "step to next message" icon to async view toolbar