### PR TITLE
Remove dependency to VMHelper

### DIFF
--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerForLaunchDelegate.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerForLaunchDelegate.scala
@@ -3,11 +3,11 @@ package org.scalaide.debug.internal.launching
 import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.jdt.launching.AbstractJavaLaunchConfigurationDelegate
 import org.eclipse.jdt.launching.IVMRunner
-import org.eclipse.pde.internal.launching.launcher.VMHelper
+import org.eclipse.jdt.launching.JavaRuntime
 
 trait ScalaDebuggerForLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
   override def getVMRunner(configuration: ILaunchConfiguration, mode: String): IVMRunner = {
-    val vm = VMHelper.createLauncher(configuration)
+    val vm = JavaRuntime.computeVMInstall(configuration)
     new StandardVMScalaDebugger(vm)
   }
 }

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaEclipseApplicationLaunchConfigurationDelegate.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaEclipseApplicationLaunchConfigurationDelegate.scala
@@ -3,7 +3,7 @@ package org.scalaide.debug.internal.launching
 import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.jdt.launching.IVMRunner
 import org.scalaide.ew.launcher.EquinoxWeavingApplicationLaunchConfiguration
-import org.eclipse.pde.internal.launching.launcher.VMHelper
+import org.eclipse.jdt.launching.JavaRuntime
 
 /**
  * Launch configuration delegate starting Scala applications with the Scala debugger.
@@ -11,7 +11,7 @@ import org.eclipse.pde.internal.launching.launcher.VMHelper
 class ScalaEclipseApplicationLaunchConfigurationDelegate extends EquinoxWeavingApplicationLaunchConfiguration {
 
   override def getVMRunner(configuration: ILaunchConfiguration, mode: String): IVMRunner = {
-    val vm = VMHelper.createLauncher(configuration)
+    val vm = JavaRuntime.computeVMInstall(configuration)
     new StandardVMScalaDebugger(vm)
   }
 


### PR DESCRIPTION
This class is part of a package in PDE, which we do not want to rely on
since it is only available when PDE is installed in Eclipse.

Fixes #1002538