### PR TITLE
Build Scopes Configuration

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -41,6 +41,7 @@ import org.scalaide.core.sbtbuilder.ScalaJavaDepTest
 import org.scalaide.core.sbtbuilder.ScalaJavaDepTicket_1000607Test
 import org.scalaide.core.sbtbuilder.ScalaJavaDepWhenJavaIsWrongTest
 import org.scalaide.core.sbtbuilder.ScalaProjectDependedOnJavaProjectTest
+import org.scalaide.core.sbtbuilder.ScopeCompileConfigurationTest
 import org.scalaide.core.sbtbuilder.ScopeCompileTest
 import org.scalaide.core.sbtbuilder.TodoBuilderTest
 import org.scalaide.core.semantic.HighlightingTestsSuite
@@ -118,6 +119,7 @@ import org.scalaide.util.internal.eclipse.TextSelectionTest
     classOf[ScalaProjectDependedOnJavaProjectTest],
     classOf[NameHashingVulnerabilityTest],
     classOf[JavaDependsOnScalaTest],
-    classOf[JavaDependsOnScalaBothAreOkTest]
+    classOf[JavaDependsOnScalaBothAreOkTest],
+    classOf[ScopeCompileConfigurationTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScopeCompileConfigurationTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScopeCompileConfigurationTest.scala
@@ -1,0 +1,80 @@
+package org.scalaide.core.sbtbuilder
+
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.IPath
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.IJavaModelMarker
+import org.eclipse.jdt.core.JavaCore
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+import org.scalaide.core.IScalaProject
+import org.scalaide.core.SdtConstants
+import org.scalaide.core.testsetup.IProjectHelpers
+import org.scalaide.core.testsetup.IProjectOperations
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.scalaide.ui.internal.preferences.PropertyStore
+import org.eclipse.ui.preferences.ScopedPreferenceStore
+
+object ScopeCompileConfigurationTest extends IProjectOperations {
+  import org.scalaide.core.testsetup.SDTTestUtils._
+  private val projectName = "scopeConfiguration"
+  private var project: IScalaProject = _
+  private val bundleName = "org.scala-ide.sdt.core.tests"
+  private val errorTypes = Array(SdtConstants.ProblemMarkerId, IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER)
+
+  private val withSrcOutputStructure: SrcPathOutputEntry = (project, jProject) => {
+    val macrosSourceFolder = project.getFolder("/src/macros")
+    val macrosAsMainSourceFolder = project.getFolder("/src/macros-as-main")
+    val mainSourceFolder = project.getFolder("/src/main")
+    val testSourceFolder = project.getFolder("/src/test")
+    val integrationSourceFolder = project.getFolder("/src/integration")
+    val macrosOutputFolder = project.getFolder("/target/macros")
+    val macrosAsMainOutputFolder = project.getFolder("/target/macros-as-main")
+    val mainOutputFolder = project.getFolder("/target/main")
+    val testOutputFolder = project.getFolder("/target/test")
+    val integrationOutputFolder = project.getFolder("/target/integration")
+    val srcOuts = List(
+      macrosSourceFolder -> macrosOutputFolder,
+      macrosAsMainSourceFolder -> macrosAsMainOutputFolder,
+      mainSourceFolder -> mainOutputFolder,
+      testSourceFolder -> testOutputFolder,
+      integrationSourceFolder -> integrationOutputFolder)
+    srcOuts.map {
+      case (src, out) => JavaCore.newSourceEntry(
+        jProject.getPackageFragmentRoot(src).getPath,
+        Array[IPath](),
+        jProject.getPackageFragmentRoot(out).getPath)
+    }
+  }
+
+  @BeforeClass def setup(): Unit = {
+    initializeProjects(bundleName, Seq(projectName)) {
+      project = createProjectInWorkspace(projectName, withSrcOutputStructure)
+      val storage = project.storage.asInstanceOf[ScopedPreferenceStore]
+      storage.setValue("src/integration", "tests")
+      storage.setValue("src/macros-as-main", "main")
+      storage.save()
+    }
+  }
+
+  @AfterClass def cleanup(): Unit = {
+    SDTTestUtils.deleteProjects(project)
+  }
+}
+
+class ScopeCompileConfigurationTest extends IProjectOperations with IProjectHelpers {
+  import org.scalaide.core.testsetup.SDTTestUtils._
+  import ScopeCompileConfigurationTest._
+
+  @Test def shouldCorrectlyBuildProject(): Unit = {
+    givenCleanWorkspaceForProjects(project)
+
+    workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor)
+    val expectedNoError =
+      markersMessages(findProjectProblemMarkers(project, errorTypes: _*).toList)
+
+    Assert.assertTrue("See what's wrong: " + expectedNoError.mkString(", "), 0 == expectedNoError.length)
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/integration/acme/AcmeIntegration.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/integration/acme/AcmeIntegration.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeIntegration {
+  def integrate = "4" + (new AcmeTest).baz
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/macros-as-main/acme/AcmeMacrosAsMain.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/macros-as-main/acme/AcmeMacrosAsMain.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeMacrosAsMain {
+  def foobar = (new AcmeMacro).foo + (new AcmeMain).bar
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/macros/acme/AcmeMacro.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/macros/acme/AcmeMacro.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeMacro {
+  def foo = "5"
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/main/acme/AcmeMain.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/main/acme/AcmeMain.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeMain {
+  def bar = "5" + (new AcmeMacro).foo
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/test/acme/AcmeTest.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scopeConfiguration/src/test/acme/AcmeTest.scala
@@ -1,0 +1,5 @@
+package acme
+
+class AcmeTest {
+  def baz = "3" + (new AcmeMacrosAsMain).foobar
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/CompileScope.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/CompileScope.scala
@@ -1,6 +1,7 @@
 package org.scalaide.core.internal.project
 
 import java.io.File.separator
+
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.Path
 
@@ -40,7 +41,7 @@ import org.eclipse.core.runtime.Path
  * Scala->Compiler preferences menu. If this flag is not set then compilation process
  * falls to old approach implemented in [[ProjectsDependentSbtBuildManager]].
  */
-trait CompileScope {
+sealed trait CompileScope {
 
   /** Can be human readable name. */
   def name: String
@@ -77,4 +78,8 @@ case object CompileTestsScope extends CompileScope {
   override def isValidSourcePath(path: IPath): Boolean = isInPath(path, default, play)
   private val default = toIPath(s"src${separator}test")
   private val play = toIPath("test")
+}
+
+object CompileScope {
+  def scopesInCompileOrder: Seq[CompileScope] = Seq(CompileMacrosScope, CompileMainScope, CompileTestsScope)
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScopesSettings.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ScopesSettings.scala
@@ -1,0 +1,36 @@
+package org.scalaide.ui.internal.preferences
+
+import scala.tools.nsc.Settings
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.runtime.IPath
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.project.CompileScope
+import org.scalaide.ui.internal.preferences.IDESettings.Box
+
+object ScopesSettings extends Settings {
+  val TabTitle = "Scopes Settings"
+  private val NamePrefix = "-"
+  private val EmptyString = ""
+
+  private def choices = CompileScope.scopesInCompileOrder.map { _.name }.toList
+
+  private def makeSettings(project: IProject): List[Settings#Setting] = {
+    ScalaPlugin().asScalaProject(project).map { scalaProject =>
+      scalaProject.sourceFolders.map { srcFolder =>
+        val srcFolderRelativeToProject = srcFolder.makeRelativeTo(project.getLocation)
+        val srcName = makeKey(srcFolderRelativeToProject)
+        ChoiceSetting(srcName, helpArg = EmptyString, descr = EmptyString, choices, findDefaultScope(srcFolderRelativeToProject))
+      }
+    }.getOrElse(Nil).toList.sortBy { _.name }
+  }
+
+  def makeKey(srcFolderRelativeToProject: IPath): String =
+    NamePrefix + srcFolderRelativeToProject.segments.mkString("/")
+
+  private def findDefaultScope(srcFolderRelativeToProject: IPath): String =
+    CompileScope.scopesInCompileOrder.find { _.isValidSourcePath(srcFolderRelativeToProject) }.get.name
+
+  def buildScopesSettings(project: Option[IProject]): Box =
+    if (project.isEmpty) Box(TabTitle, Nil) else Box(TabTitle, makeSettings(project.get))
+}


### PR DESCRIPTION
There are 3 build scopes defined: macros, main and tests. Up to now
there was a convention how source folders were assigned to particular
scope. This commit adds a configuration which allows Scala IDE user to
assign the particular source folder to required scope via 'Scopes
Settings' tab in 'Scala Compiler' preference page.
Known limitation: when project's 'Properties' is open and user adds
new source folder in 'Java Build Path -> Source' the 'Properties'
popup window must be reopened to make visible newly added source path
in 'Scala Compiler -> Scope Settings'.