### PR TITLE
Bang operator not working

### DIFF
--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -142,17 +142,20 @@
          point="org.eclipse.ui.menus">
       <menuContribution
             allPopups="false"
-            locationURI="toolbar:org.scala-ide.sdt.debug.asyncView">
-         <command
-               commandId="org.scala-ide.sdt.debug.stepMessageOut"
-               icon="icons/bang.png"
-               label="Step Message Out"
-               style="push"
-               tooltip="Step until a message is received">
-            <visibleWhen
-                  checkEnabled="true">
-            </visibleWhen>
-         </command>
+            locationURI="toolbar:org.eclipse.ui.main.toolbar">
+         <toolbar
+               id="org.eclipse.debug.ui.debugActionSet">
+            <command
+                  commandId="org.scalaide.debug.async.stepMessageOut"
+                  icon="icons/bang.png"
+                  label="Step Message Out"
+                  style="push"
+                  tooltip="Step until a message is received">
+               <visibleWhen
+                     checkEnabled="true">
+               </visibleWhen>
+            </command>
+         </toolbar>
       </menuContribution>
       <menuContribution
             allPopups="false"
@@ -170,7 +173,7 @@
          point="org.eclipse.ui.handlers">
       <handler
             class="org.scalaide.debug.internal.command.StepMessageOut"
-            commandId="org.scala-ide.sdt.debug.stepMessageOut">
+            commandId="org.scalaide.debug.async.stepMessageOut">
       </handler>
       <handler
             class="org.scalaide.debug.internal.command.BreakOnDeadLettersAction"
@@ -243,7 +246,7 @@
    <extension
          point="org.eclipse.ui.bindings">
       <key
-            commandId="org.scala-ide.sdt.debug.stepMessageOut"
+            commandId="org.scalaide.debug.async.stepMessageOut"
             contextId="org.eclipse.debug.ui.debugging"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M2+F5">

--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -142,20 +142,17 @@
          point="org.eclipse.ui.menus">
       <menuContribution
             allPopups="false"
-            locationURI="toolbar:org.eclipse.ui.main.toolbar">
-         <toolbar
-               id="org.eclipse.debug.ui.debugActionSet">
-            <command
-                  commandId="org.scalaide.debug.async.stepMessageOut"
-                  icon="icons/bang.png"
-                  label="Step Message Out"
-                  style="push"
-                  tooltip="Step until a message is received">
-               <visibleWhen
-                     checkEnabled="true">
-               </visibleWhen>
-            </command>
-         </toolbar>
+            locationURI="toolbar:org.eclipse.debug.ui.DebugView">
+         <command
+               commandId="org.scalaide.debug.async.stepMessageOut"
+               icon="icons/bang.png"
+               label="Step Message Out"
+               style="push"
+               tooltip="Step until a message is received">
+            <visibleWhen
+                  checkEnabled="true">
+            </visibleWhen>
+         </command>
       </menuContribution>
       <menuContribution
             allPopups="false"


### PR DESCRIPTION
There are two things fixed in this commit:
- command ids didn't reflect the id in command definition
- command must be associated with debug context
To explain the second it is enough to look at `StepMessageOut` class.
The first element of selection must be `ScalaStackFrame` and continue
action should run debugging further. In buggy solution the first element
of selection is `AsyncStackFrame` and action does not continue debugging.