### PR TITLE
Step Message Out enhancement

### DIFF
--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/AsyncUtils.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/AsyncUtils.scala
@@ -1,6 +1,6 @@
 package org.scalaide.debug.internal.async
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.asScalaBufferConverter
 
 import org.scalaide.debug.internal.model.JdiRequestFactory
 import org.scalaide.debug.internal.model.ScalaDebugTarget
@@ -8,27 +8,28 @@ import org.scalaide.logging.HasLogger
 import org.scalaide.util.internal.Suppress
 
 import com.sun.jdi.Method
-
 import com.sun.jdi.ReferenceType
 import com.sun.jdi.ThreadReference
 import com.sun.jdi.request.BreakpointRequest
 
 object AsyncUtils extends HasLogger {
+  val AsyncProgramPointKey = "app"
+  val RequestOwnerKey = "requestOwner"
 
-  def findAsyncProgramPoint(app: AsyncProgramPoint, tpe: ReferenceType): Option[Method] = {
-    def isAsyncProgramPoint(m: Method): Boolean =
-      !m.isAbstract() &&
-        m.name().startsWith(app.methodName) &&
-        !m.name().contains("$default") &&
-        m.declaringType().name() == app.className
+  def findAsyncProgramPoint(app: AsyncProgramPoint, tpe: ReferenceType): Option[Method] =
+    tpe.allMethods().asScala.find(isAsyncProgramPoint(app))
 
-    tpe.allMethods().asScala.find(isAsyncProgramPoint)
-  }
+  def isAsyncProgramPoint(app: AsyncProgramPoint)(m: Method): Boolean =
+    !m.isAbstract() &&
+      m.name().startsWith(app.methodName) &&
+      !m.name().contains("$default") &&
+      m.declaringType().name() == app.className
 
   def installMethodBreakpoint(
     debugTarget: ScalaDebugTarget,
     app: AsyncProgramPoint,
     actor: Suppress.DeprecatedWarning.Actor,
+    requestOwner: Option[String] = None,
     threadRef: ThreadReference = null): Seq[BreakpointRequest] = {
 
     for {
@@ -37,11 +38,11 @@ object AsyncUtils extends HasLogger {
     } yield {
       val req = JdiRequestFactory.createMethodEntryBreakpoint(method, debugTarget)
       debugTarget.eventDispatcher.setActorFor(actor, req)
-      req.putProperty("app", app)
+      req.putProperty(AsyncProgramPointKey, app)
+      requestOwner.foreach { req.putProperty(RequestOwnerKey, _) }
       if (threadRef ne null)
         req.addThreadFilter(threadRef)
       req.enable()
-
       logger.debug(s"Installed method breakpoint for ${method.declaringType()}.${method.name}")
       req
     }

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/StepMessageOut.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/StepMessageOut.scala
@@ -1,113 +1,168 @@
 package org.scalaide.debug.internal.async
 
+import java.util.UUID
+
+import scala.collection.JavaConverters
+
 import org.eclipse.debug.core.DebugEvent
 import org.scalaide.debug.internal.BaseDebuggerActor
+import org.scalaide.debug.internal.async.AsyncUtils.AsyncProgramPointKey
+import org.scalaide.debug.internal.async.AsyncUtils.RequestOwnerKey
+import org.scalaide.debug.internal.async.AsyncUtils.installMethodBreakpoint
+import org.scalaide.debug.internal.async.AsyncUtils.isAsyncProgramPoint
 import org.scalaide.debug.internal.model.JdiRequestFactory
 import org.scalaide.debug.internal.model.ScalaDebugTarget
 import org.scalaide.debug.internal.model.ScalaThread
 import org.scalaide.logging.HasLogger
 
+import com.sun.jdi.Field
 import com.sun.jdi.ObjectReference
+import com.sun.jdi.StringReference
+import com.sun.jdi.ThreadReference
 import com.sun.jdi.event.BreakpointEvent
+import com.sun.jdi.event.Event
 import com.sun.jdi.event.StepEvent
 import com.sun.jdi.request.EventRequest
 import com.sun.jdi.request.StepRequest
 
 case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) extends HasLogger {
-
+  private val StepMessageOut = "StepMessageOut" + UUID.randomUUID.toString
+  private val IsSearchingReceiveMethodKey = "search"
   private var watchedMessage: Option[ObjectReference] = None
-
+  private var watchedActor: String = _
   val programSends = List(
     AsyncProgramPoint("akka.actor.RepointableActorRef", "$bang", 0),
     AsyncProgramPoint("akka.actor.LocalActorRef", "$bang", 0),
     AsyncProgramPoint("scala.actors.InternalReplyReactor$class", "$bang", 1))
-
   val programReceives = List(
     AsyncProgramPoint("akka.actor.ActorCell", "receiveMessage", 0))
-
-  private var sendRequests = Set[EventRequest]()
-  private var receiveRequests = Set[EventRequest]()
+  private var receiveRequest: Option[EventRequest] = None
   private var stepRequests = Set[EventRequest]()
   private var steps = 0
+  private val depth = thread.getScalaStackFrames.size
+  private val line = thread.getTopStackFrame().getLineNumber()
+  private val Halt = true
+  private val Continue = false
 
   def step(): Unit = {
-    sendRequests = programSends.flatMap(AsyncUtils.installMethodBreakpoint(debugTarget, _, internalActor, thread.threadRef)).toSet
-    internalActor.start()
-    // CLIENT_REQUEST seems to be the only event that correctly updates the UI
+    subordinate.start()
+    subordinate.establishRequestToStopInTellMethod()
     thread.resumeFromScala(DebugEvent.CLIENT_REQUEST)
   }
 
-  object internalActor extends BaseDebuggerActor {
-    private def interceptMessage(ev: BreakpointEvent): Boolean = {
-      // only intercept messages going out from the current thread and frame (no messages sent by methods below us)
-      println(s"GENERAL SEND: ${ev.thread.frame(0).getArgumentValues()} THREAD: ${ev.thread.name()} looking for thread: ${thread.threadRef.name}: ${ev.thread == thread.threadRef}")
-      if (sendRequests(ev.request)) {
-        println("? intercept send: " + ev.thread.frame(0).getArgumentValues())
-        true
-      } else false
-    }
-
+  object subordinate extends BaseDebuggerActor {
+    import scala.collection.JavaConverters._
     private def isReceiveHandler(loc: com.sun.jdi.Location): Boolean =
       loc.method().name().contains("applyOrElse")
 
     override protected def behavior = {
-      case breakpointEvent: BreakpointEvent if interceptMessage(breakpointEvent) =>
-        val app = breakpointEvent.request().getProperty("app").asInstanceOf[AsyncProgramPoint]
-        val topFrame = breakpointEvent.thread().frame(0)
-        val args = topFrame.getArgumentValues()
-        logger.debug(s"MESSAGE OUT intercepted: topFrame arguments: $args")
-        watchedMessage = Option(args.get(app.paramIdx).asInstanceOf[ObjectReference])
-        receiveRequests = programReceives.flatMap(AsyncUtils.installMethodBreakpoint(debugTarget, _, internalActor)).toSet
-        deleteSendRequests()
-
-        reply(false) // don't suspend this thread
-
-      case breakpointEvent: BreakpointEvent if receiveRequests(breakpointEvent.request()) =>
-        val app = breakpointEvent.request().getProperty("app").asInstanceOf[AsyncProgramPoint]
+      case breakpointEvent: BreakpointEvent if isSearchingReceiveMethod(breakpointEvent) =>
         val topFrame = breakpointEvent.thread().frame(0)
         val args = topFrame.getArgumentValues()
         logger.debug(s"receive intercepted: topFrame arguments: $args")
+        val app = breakpointEvent.request().getProperty(AsyncProgramPointKey).asInstanceOf[AsyncProgramPoint]
         val msg = Option(args.get(app.paramIdx).asInstanceOf[ObjectReference])
-        if (watchedMessage == msg) {
+        if (watchedMessage == msg && watchedActor == actorPathValue(path(self(topFrame.thisObject())), breakpointEvent.thread)) {
           logger.debug(s"MESSAGE IN! $msg")
-          deleteReceiveRequests()
-
           val targetThread = debugTarget.getScalaThread(breakpointEvent.thread())
           targetThread foreach { thread =>
-            val stepReq = JdiRequestFactory.createStepRequest(StepRequest.STEP_LINE, StepRequest.STEP_INTO, thread)
-            stepReq.enable()
-            stepRequests = Set(stepReq)
-            debugTarget.eventDispatcher.setActorFor(this, stepReq)
-            steps = 0
+            deleteReceiveRequest()
+            establishRequestToStopInReceiveMethod(thread)
           }
         }
-        reply(false)
+        reply(Continue)
 
-      case stepEvent: StepEvent if isReceiveHandler(stepEvent.location) =>
-        disable()
-        poison()
+      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) && isReceiveHandler(stepEvent.location) =>
+        terminate()
         logger.debug(s"Suspending thread ${stepEvent.thread.name()}")
         // most likely the breakpoint was hit on a different thread than the one we started with, so we find it here
         debugTarget.getScalaThread(stepEvent.thread()).foreach(_.suspendedFromScala(DebugEvent.BREAKPOINT))
-        reply(true) // suspend here!
+        reply(Halt)
 
-      case stepEvent: StepEvent if steps >= 20 =>
-        disable()
-        poison()
+      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) && steps >= 20 =>
+        terminate()
         logger.debug(s"Giving up on stepping after 15 steps")
-        reply(false)
+        reply(Continue)
 
-      case stepEvent: StepEvent =>
+      case stepEvent: StepEvent if isSearchingTellMethod(stepEvent) =>
+        val decision = if (stepEvent.thread().frameCount() == depth && stepEvent.location().lineNumber() > line) {
+          logger.debug(s"Sending method not found. Leaving...")
+          terminate()
+          debugTarget.getScalaThread(stepEvent.thread()).foreach(_.suspendedFromScala(DebugEvent.BREAKPOINT))
+          Halt
+        } else {
+          val foundApp = programSends.find { isAsyncProgramPoint(_)(stepEvent.location.method) }
+          foundApp.map { app =>
+            deleteAllRequests()
+            val topFrame = stepEvent.thread().frame(0)
+            val args = topFrame.getArgumentValues()
+            logger.debug(s"MESSAGE OUT intercepted: topFrame arguments: $args")
+            watchedMessage = Option(args.get(app.paramIdx).asInstanceOf[ObjectReference])
+            watchedActor = actorPathValue(path(topFrame.thisObject()), thread.threadRef)
+            establishRequestToStopInReceiveMessageMethod()
+          }
+          Continue
+        }
+        reply(decision)
+
+      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) =>
         steps += 1
         logger.debug(s"Step $steps: ${stepEvent.location.declaringType}.${stepEvent.location.method}")
-        reply(false) // resume VM
-      case _ => reply(false)
+        reply(Continue)
+
+      case _ =>
+        reply(Continue)
+    }
+
+    private[async] def establishRequestToStopInTellMethod(): Unit = {
+      val stepIntoReq = JdiRequestFactory.createStepRequest(StepRequest.STEP_MIN, StepRequest.STEP_INTO, thread)
+      stepIntoReq.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD)
+      stepIntoReq.putProperty(AsyncProgramPointKey, programReceives)
+      stepIntoReq.putProperty(RequestOwnerKey, StepMessageOut)
+      stepIntoReq.enable()
+      stepRequests = Set(stepIntoReq)
+      debugTarget.eventDispatcher.setActorFor(this, stepIntoReq)
+    }
+
+    private def establishRequestToStopInReceiveMessageMethod(): Unit = {
+      receiveRequest = programReceives.flatMap(installMethodBreakpoint(debugTarget, _, this, Some(StepMessageOut))).headOption
+      receiveRequest.foreach { _.putProperty(IsSearchingReceiveMethodKey, true) }
+    }
+
+    private def establishRequestToStopInReceiveMethod(thread: ScalaThread): Unit = {
+      val stepReq = JdiRequestFactory.createStepRequest(StepRequest.STEP_LINE, StepRequest.STEP_INTO, thread)
+      stepReq.putProperty(RequestOwnerKey, StepMessageOut)
+      stepReq.putProperty(IsSearchingReceiveMethodKey, true)
+      stepReq.enable()
+      debugTarget.eventDispatcher.setActorFor(this, stepReq)
+      stepRequests = Set(stepReq)
+      steps = 0
+    }
+
+    private def isOwning(event: Event) = event.request.getProperty(RequestOwnerKey) == StepMessageOut
+
+    private def isSearchingReceiveMethod(event: Event) = event.request.getProperty(IsSearchingReceiveMethodKey) == true && isOwning(event)
+
+    private def isSearchingTellMethod(event: Event) = event.request.getProperty(IsSearchingReceiveMethodKey) != true && isOwning(event)
+
+    private def actorPathValue(actorPathObjRef: ObjectReference, threadRef: ThreadReference): String = {
+      val toStringMethod = actorPathObjRef.referenceType().methodsByName("toString", "()Ljava/lang/String;").asScala.head
+      actorPathObjRef.invokeMethod(threadRef, toStringMethod, Nil.asJava, ObjectReference.INVOKE_SINGLE_THREADED).asInstanceOf[StringReference].value()
+    }
+
+    private def path(actorRef: ObjectReference): ObjectReference = {
+      val pathField: Field = actorRef.referenceType().fieldByName("path")
+      actorRef.getValue(pathField).asInstanceOf[ObjectReference]
+    }
+
+    private def self(actorCell: ObjectReference): ObjectReference = {
+      val selfField = actorCell.referenceType().fieldByName("self")
+      actorCell.getValue(selfField).asInstanceOf[ObjectReference]
     }
 
     private def deleteRequests(reqs: Set[EventRequest]): Unit = {
       val eventDispatcher = debugTarget.eventDispatcher
       val eventRequestManager = debugTarget.virtualMachine.eventRequestManager
-
       for (request <- reqs) {
         request.disable()
         eventDispatcher.unsetActorFor(request)
@@ -115,17 +170,24 @@ case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) ex
       }
     }
 
-    private def deleteSendRequests(): Unit = {
-      deleteRequests(sendRequests)
-      sendRequests = Set()
+    private def deleteAllRequests(): Unit = {
+      deleteReceiveRequest()
+      deleteStepRequests()
     }
 
-    private def deleteReceiveRequests(): Unit = {
-      deleteRequests(receiveRequests)
-      receiveRequests = Set()
+    private def deleteStepRequests(): Unit = {
+      deleteRequests(stepRequests)
+      stepRequests = Set()
     }
 
-    private def disable(): Unit =
-      deleteRequests(sendRequests ++ receiveRequests ++ stepRequests)
+    private def deleteReceiveRequest(): Unit = {
+      deleteRequests(receiveRequest.toSet)
+      receiveRequest = None
+    }
+
+    private def terminate(): Unit = {
+      deleteAllRequests()
+      poison()
+    }
   }
 }


### PR DESCRIPTION
changes current 'first met launched' bang operation functionality
into stepping. So clicking on bang button causes:
 - step over in case when 'tell (bang)' method is not found in
   current line
 - run and stop in implemented 'receive' method otherwise