### PR TITLE
Fix tooltip message for 'var's

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/DeclarationPrinter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/compiler/DeclarationPrinter.scala
@@ -78,13 +78,21 @@ abstract class DeclarationPrinter extends HasLogger {
       else nonAccess + " " + access
     }
 
-    val name = if (sym.isConstructor) sym.owner.decodedName else sym.nameString
-    compose(
-      // TODO: Annotations
-      flagString(sym, flagMask & sym.flags),
-      if (showKind) sym.keyString else "",
-      sym.varianceString + name + infoString(seenAs) // don't force the symbol
-      )
+    val gsym= sym.getterIn(sym.owner)
+    def hasGetterSetter(sym:Symbol)= gsym != NoSymbol && sym.setterIn(sym.owner) != NoSymbol
+
+    if(hasGetterSetter(sym)){
+      compose("", "var",sym.localName.toString.trim+": "+gsym.tpe.resultType)
+    } else{
+
+       val name = if (sym.isConstructor) sym.owner.decodedName else sym.nameString
+       compose(
+         // TODO: Annotations
+         flagString(sym, flagMask & sym.flags),
+         if (showKind) sym.keyString else "",
+          sym.varianceString + name + infoString(seenAs) // don't force the symbol
+        )
+    }
   }
 
   /** Print the given type


### PR DESCRIPTION
Distinguish var from def by checking if the owner has both a setter and
a getter with the same name

Fix #1001007