### PR TITLE
Prevent NPE in SbtInputs

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -2,7 +2,7 @@ package org.scalaide.core.internal.builder.zinc
 
 import java.io.File
 import java.util.zip.ZipFile
-import scala.collection.JavaConverters.enumerationAsScalaIteratorConverter
+
 import org.eclipse.core.resources.IContainer
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.SubMonitor
@@ -11,9 +11,8 @@ import org.scalaide.core.IScalaProject
 import org.scalaide.core.internal.ScalaPlugin
 import org.scalaide.core.internal.project.ScalaInstallation.scalaInstanceForInstallation
 import org.scalaide.ui.internal.preferences
-import org.scalaide.ui.internal.preferences.ScalaPluginSettings.compileOrder
 import org.scalaide.util.internal.SettingConverterUtil
-import org.scalaide.util.internal.SettingConverterUtil.convertNameToProperty
+
 import sbt.ClasspathOptions
 import sbt.Logger.xlog2Log
 import sbt.classpath.ClasspathUtilities
@@ -25,16 +24,7 @@ import sbt.inc.ClassfileManager
 import sbt.inc.Locate
 import xsbti.Logger
 import xsbti.Maybe
-import xsbti.Reporter
 import xsbti.compile._
-import scala.tools.nsc.settings.SpecificScalaVersion
-import scala.tools.nsc.settings.ScalaVersion
-import java.net.URLClassLoader
-import org.scalaide.core.internal.project.ScalaInstallation.scalaInstanceForInstallation
-import org.scalaide.core.IScalaInstallation
-import org.scalaide.core.internal.ScalaPlugin
-import org.eclipse.core.resources.IContainer
-import org.eclipse.core.runtime.IPath
 
 /** Inputs-like class, but not implementing xsbti.compile.Inputs.
  *
@@ -83,17 +73,17 @@ class SbtInputs(installation: IScalaInstallation,
       case (_, out) => out.getRawLocation
     }
 
-    def classpath = (project.scalaClasspath.userCp ++ addToClasspath ++ outputFolders)
+    override def classpath = (project.scalaClasspath.userCp ++ addToClasspath ++ outputFolders)
       .distinct
       .map(_.toFile.getAbsoluteFile).toArray
 
-    def sources = sourceFiles.toArray
+    override def sources = sourceFiles.toArray
 
-    def output = new MultipleOutput {
+    override def output = new MultipleOutput {
       private def sourceOutputFolders =
         if (srcOutputs.nonEmpty) srcOutputs else project.sourceOutputFolders
 
-      def outputGroups = sourceOutputFolders.map {
+      override def outputGroups = sourceOutputFolders.map {
         case (src, out) => new MultipleOutput.OutputGroup {
           override def sourceDirectory = {
             val loc = src.getLocation
@@ -114,7 +104,7 @@ class SbtInputs(installation: IScalaInstallation,
     }
 
     // remove arguments not understood by build compiler
-    def options =
+    override def options =
       if (project.isUsingCompatibilityMode())
         project.scalacArguments.filter(buildCompilerOption).toArray
       else
@@ -124,13 +114,13 @@ class SbtInputs(installation: IScalaInstallation,
     private def buildCompilerOption(arg: String): Boolean =
       !arg.startsWith("-Xsource") && !(arg == "-Ymacro-expand:none")
 
-    def javacOptions = Array() // Not used.
+    override def javacOptions = Array() // Not used.
 
     import CompileOrder._
     import SettingConverterUtil.convertNameToProperty
     import preferences.ScalaPluginSettings.compileOrder
 
-    def order = project.storage.getString(convertNameToProperty(compileOrder.name)) match {
+    override def order = project.storage.getString(convertNameToProperty(compileOrder.name)) match {
       case "JavaThenScala" => JavaThenScala
       case "ScalaThenJava" => ScalaThenJava
       case _ => Mixed
@@ -149,8 +139,8 @@ class SbtInputs(installation: IScalaInstallation,
         // prevent Sbt from adding things to the (boot)classpath
         val cpOptions = new ClasspathOptions(false, false, false, autoBoot = false, filterLibrary = false)
         new Compilers[AnalyzingCompiler] {
-          def javac = new JavaEclipseCompiler(project.underlying, javaMonitor)
-          def scalac = IC.newScalaCompiler(scalaInstance, compilerInterface.toFile, cpOptions)
+          override def javac = new JavaEclipseCompiler(project.underlying, javaMonitor)
+          override def scalac = IC.newScalaCompiler(scalaInstance, compilerInterface.toFile, cpOptions)
         }
     }
   }
@@ -158,7 +148,7 @@ class SbtInputs(installation: IScalaInstallation,
 
 private[zinc] object Locator {
   val NoClass = new DefinesClass {
-    def apply(className: String) = false
+    override def apply(className: String) = false
   }
 
   def apply(f: File): DefinesClass =
@@ -170,7 +160,7 @@ private[zinc] object Locator {
       NoClass
 
   class DirectoryLocator(dir: File) extends DefinesClass {
-    def apply(className: String): Boolean = Locate.classFile(dir, className).isFile
+    override def apply(className: String): Boolean = Locate.classFile(dir, className).isFile
   }
 
   class JarLocator(jar: File) extends DefinesClass {
@@ -183,6 +173,6 @@ private[zinc] object Locator {
         zipFile.close()
     }
 
-    def apply(className: String): Boolean = entries.contains(className)
+    override def apply(className: String): Boolean = entries.contains(className)
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -95,8 +95,20 @@ class SbtInputs(installation: IScalaInstallation,
 
       def outputGroups = sourceOutputFolders.map {
         case (src, out) => new MultipleOutput.OutputGroup {
-          def sourceDirectory = src.getLocation.toFile
-          def outputDirectory = out.getLocation.toFile
+          override def sourceDirectory = {
+            val loc = src.getLocation
+            if (loc != null)
+              loc.toFile()
+            else
+              throw new IllegalStateException(s"The source folder location `$src` is invalid.")
+          }
+          override def outputDirectory = {
+            val loc = out.getLocation
+            if (loc != null)
+              loc.toFile()
+            else
+              throw new IllegalStateException(s"The output folder location `$out` is invalid.")
+          }
         }
       }.toArray
     }


### PR DESCRIPTION
`getLocation` can return null in case the underlying container is
invalid. However, I have no idea in which case it can become invalid,
therefore we just throw another exception instead of the NPE in order to
make it easier for users to find the problematic container.

Fixes #1002544