### PR TITLE
Fix non working fading packages feature in Async Debug View

### DIFF
--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/views/AsyncDebugView.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/views/AsyncDebugView.scala
@@ -215,7 +215,7 @@ class AsyncDebugView extends AbstractDebugView with IDebugContextListener with H
 
     def loadFadingPackages = {
       val pkgs = store.getString(AsyncDebuggerPreferencePage.FadingPackages)
-      pkgs.split(',').toSet
+      pkgs.split(AsyncDebuggerPreferencePage.DataDelimiter).toSet
     }
 
     def loadFadingColor = {


### PR DESCRIPTION
The delimiter sign has changed. We use the constant instead of the
broken hardcoded one.

Fixes #1002549