### PR TITLE
Wrap addImport in asyncExec

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/CompletionProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/CompletionProposal.scala
@@ -214,8 +214,11 @@ case class CompletionProposal(
         if (!needImport)
           Nil
         else {
-          val refactoring = new AddImportStatement { val global = compiler }
-          refactoring.addImport(scalaSourceFile.file, fullyQualifiedName)
+          import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
+          compiler.asyncExec {
+            val refactoring = new AddImportStatement { override val global = compiler }
+            refactoring.addImport(scalaSourceFile.file, fullyQualifiedName)
+          }.getOrElse(Nil)()
         }
 
       val applyLinkedMode =


### PR DESCRIPTION
It is interesting which API calls access the PC. I wouldn't have
thought that addImport needs access to it too, otherwise this bug may
never have seen the light of birth. Now it is gone and I have to think
once again how to develop an API that prevent such mistakes.

Fixes #1002565