### PR TITLE
Enables Expression Evaluator for remote debugging

### DIFF
--- a/org.scala-ide.sdt.debug/plugin.xml
+++ b/org.scala-ide.sdt.debug/plugin.xml
@@ -64,6 +64,16 @@
             sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer"
             type="org.eclipse.jdt.junit.launchconfig">
       </launchDelegate>
+      <launchDelegate
+            delegate="org.scalaide.debug.internal.launching.ScalaRemoteApplicationLaunchConfigurationDelegate"
+            delegateDescription="The Scala Remote Launcher supports debugging Scala applications"
+            id="scala.remote.new"
+            modes="debug"
+            name="Scala Remote"
+            sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector"
+            sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer"
+            type="org.eclipse.jdt.launching.remoteJavaApplication">
+      </launchDelegate>
     </extension>
    <extension
          point="org.eclipse.ui.preferencePages">

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaRemoteApplicationLaunchConfigurationDelegate.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaRemoteApplicationLaunchConfigurationDelegate.scala
@@ -1,0 +1,26 @@
+package org.scalaide.debug.internal.launching
+
+import java.util.{ Map => JMap }
+
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.debug.core.ILaunch
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.jdt.internal.launching.JavaRemoteApplicationLaunchConfigurationDelegate
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants
+import org.scalaide.core.internal.launching.ClasspathGetterForLaunchDelegate
+
+object ScalaRemoteApplicationLaunchConfigurationDelegate {
+  val DebugeeProjectClasspath = "DebugeeProjectClasspath"
+  val DebugeeProjectClasspathSeparator = ","
+}
+
+class ScalaRemoteApplicationLaunchConfigurationDelegate extends JavaRemoteApplicationLaunchConfigurationDelegate
+    with ClasspathGetterForLaunchDelegate {
+  import ScalaRemoteApplicationLaunchConfigurationDelegate._
+
+  override def launch(configuration: ILaunchConfiguration, mode: String, launch: ILaunch, monitor: IProgressMonitor): Unit = {
+    val argMap = configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_CONNECT_MAP, null.asInstanceOf[JMap[String, String]])
+    argMap.put(DebugeeProjectClasspath, getClasspath(configuration).mkString(DebugeeProjectClasspathSeparator))
+    super.launch(configuration, mode, launch, monitor)
+  }
+}

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/SocketConnectorScala.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/SocketConnectorScala.scala
@@ -82,5 +82,8 @@ trait SocketConnectorScala extends IVMConnector {
     arguments
   }
 
-
+  def extractProjectClasspath(params: Map[String, String]): Option[Seq[String]] = {
+    import ScalaRemoteApplicationLaunchConfigurationDelegate._
+    params.get(DebugeeProjectClasspath).map { _.split(DebugeeProjectClasspathSeparator).toSeq }
+  }
 }

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/StandardVMScalaDebugger.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/StandardVMScalaDebugger.scala
@@ -16,10 +16,10 @@ import com.sun.jdi.VirtualMachine
  */
 class StandardVMScalaDebugger(vm: IVMInstall) extends StandardVMDebugger(vm) {
 
-  override def createDebugTarget(unusedConfiguration: VMRunnerConfiguration, launch: ILaunch, unusedPort: Int, process: IProcess, virtualMachine: VirtualMachine): IDebugTarget = {
+  override def createDebugTarget(runnerConfiguration: VMRunnerConfiguration, launch: ILaunch, unusedPort: Int, process: IProcess, virtualMachine: VirtualMachine): IDebugTarget = {
     ScalaDebugTarget(virtualMachine, launch, process,
       allowDisconnect = false, allowTerminate = true,
-      classPath = Some(unusedConfiguration.getClassPath))
+      classPath = Some(runnerConfiguration.getClassPath))
   }
 
 }


### PR DESCRIPTION
The project classpath needs to be set for Debugger machine as well.
In other case it is not possible to evaluate instances on Debugger
side and send the output to Debugee machine.

Fixes #1002439