### PR TITLE
Do not use system default line delimiter by default

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/text/TextDocument.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/text/TextDocument.scala
@@ -2,7 +2,7 @@ package org.scalaide.core.internal.text
 
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.IRegion
-import org.eclipse.jface.text.Region
+import org.eclipse.jface.text.TextUtilities
 import org.scalaide.core.text.Document
 import org.scalaide.core.text.InternalDocument
 
@@ -76,6 +76,9 @@ class TextDocument(private val doc: IDocument) extends Document with InternalDoc
       Some(doc.getChar(length-1))
     else
       None
+
+  override def defaultLineDelimiter: String =
+    TextUtilities.getDefaultLineDelimiter(doc)
 
   override def toString(): String =
     text

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/text/Document.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/text/Document.scala
@@ -39,6 +39,15 @@ trait Document {
   def last: Char
 
   def lastOpt: Option[Char]
+
+  /**
+   * This is either the delimiter of the first line, the platform line delimiter
+   * if it is a legal line delimiter or the first one of the legal line
+   * delimiters. The default line delimiter should be used when performing
+   * document manipulations that span multiple lines. The legal line delimiters
+   * usually are "\r", "\n" and "\r\n".
+   */
+  def defaultLineDelimiter: String
 }
 
 private[core] trait InternalDocument extends Document {

--- a/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundBlock.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/extensions/autoedits/SurroundBlock.scala
@@ -52,13 +52,12 @@ trait SurroundBlock extends AutoEdit {
       case Add(start, "{") =>
         surroundLocation(start) map {
           case (pos, indentLen, token) =>
-            val sep = System.getProperty("line.separator")
             val indent = " " * indentLen
 
             val change = if (elseLikeTokens(token.tokenType))
               Replace(start, pos + indentLen, s"{${document.textRange(start, pos)}$indent} ")
             else
-              Replace(start, pos, s"{${document.textRange(start, pos)}$indent}$sep")
+              Replace(start, pos, s"{${document.textRange(start, pos)}$indent}${document.defaultLineDelimiter}")
             change.withCursorPos(start+1)
         }
     }


### PR DESCRIPTION
This one is not always correct. Instead, the legal line delimiters have
to be checked and one of them has to be chosen.

Fixes #1002567