### PR TITLE
Explicitly set empty extension name for backup files

### DIFF
--- a/set-versions.sh
+++ b/set-versions.sh
@@ -58,7 +58,7 @@ cat <<EOF
 !!!!
 !!!! This can be done with the following command:
 !!!!
-!!!!   ag "<old-version>" | awk -F ':' '{print $1}' | xargs sed -i 's/<old-version>/<new-version>/'
+!!!!   ag "<old-version>" | awk -F ':' '{print $1}' | xargs sed -i '' 's/<old-version>/<new-version>/'
 !!!!
 !!!! where <old-version> is the version of the previous release and <new-version> the version of the next release.
 !!!! ag is a tool similar to grep or ack, it is also called "The Silver Searcher": https://github.com/ggreer/the_silver_searcher


### PR DESCRIPTION
On Mac, this parameter is needed, otherwise an error is shown. See this
SO post for more information:

  http://stackoverflow.com/questions/4247068/sed-command-failing-on-mac-but-works-on-linux