### PR TITLE
Add option to preserve wildcard imports during organize imports

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
@@ -244,6 +244,7 @@ class OrganizeImports extends RefactoringExecutorWithoutWizard {
           case ExpandImports => List(refactoring.ExpandImports)
           case CollapseImports => List(refactoring.CollapseImports, refactoring.SortImportSelectors)
           case PreserveExistingGroups => Nil // this is not passed as an option
+          case PreserveWildcards => List(refactoring.ExpandImports)
         }
 
         val wildcards = refactoring.AlwaysUseWildcards(getWildcardImportsForProject(project).toSet)
@@ -263,7 +264,7 @@ class OrganizeImports extends RefactoringExecutorWithoutWizard {
         if(compilationUnitHasProblems) {
           // this is safer when there are problems in the compilation unit
           refactoring.Dependencies.RemoveUnneeded
-        } else if (organizationStrategy == PreserveExistingGroups) {
+        } else if (organizationStrategy == PreserveExistingGroups || organizationStrategy == PreserveWildcards) {
           // preserve the existing grouping of imports, but still remove all unneeded ones
           refactoring.Dependencies.RecomputeAndModify
         } else {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/OrganizeImportsPreferences.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/OrganizeImportsPreferences.scala
@@ -72,9 +72,10 @@ class OrganizeImportsPreferencesPage extends FieldEditors {
 
     fieldEditors += addNewFieldEditorWrappedInComposite(parent = control) { parent =>
       val options = Array(
-          Array("one import statement per importee", ExpandImports.toString),
-          Array("collapse into single import statement", CollapseImports.toString),
-          Array("preserve existing groups", PreserveExistingGroups.toString)
+          Array("One import statement per importee", ExpandImports.toString),
+          Array("Collapse into single import statement", CollapseImports.toString),
+          Array("Preserve existing groups", PreserveExistingGroups.toString),
+          Array("Preserve only wildcards; one import statement per importee otherwise", PreserveWildcards.toString)
       )
       new RadioGroupFieldEditor(expandCollapseKey, "Multiple imports from the same package or type:", 1, options, parent, true) {
         allEnableDisableControls += getRadioBoxControl(parent)
@@ -131,6 +132,7 @@ object OrganizeImportsPreferences extends Enumeration {
   val ExpandImports = Value("expand")
   val CollapseImports = Value("collapse")
   val PreserveExistingGroups = Value("preserve")
+  val PreserveWildcards = Value("preserveWildcards")
 
   val groupsKey         = "organizeimports.groups"
   val wildcardsKey      = "organizeimports.wildcards"
@@ -163,6 +165,7 @@ object OrganizeImportsPreferences extends Enumeration {
       case x if x == ExpandImports.toString => ExpandImports
       case x if x == CollapseImports.toString => CollapseImports
       case x if x == PreserveExistingGroups.toString => PreserveExistingGroups
+      case x if x == PreserveWildcards.toString => PreserveWildcards
     }
   }
 }


### PR DESCRIPTION
If I would have known that it is so easy to implement this, I would have
done it earlier. I don't know if anyone else needs this, but I
definitely need it. When I explicitly create a wildcard import, I do not
want that it gets expanded, otherwise I wouldn't have created a wildcard
import in the first place. The other option, which preserves everything,
is not what I want to use, since multi line imports definitely should be
expanded if they exist somewhere.

Fixes #1002574