### PR TITLE
Fix NPE in SbtInputs

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -75,7 +75,10 @@ class SbtInputs(installation: IScalaInstallation,
 
     override def classpath = (project.scalaClasspath.userCp ++ addToClasspath ++ outputFolders)
       .distinct
-      .map(_.toFile.getAbsoluteFile).toArray
+      .map { cp ⇒
+        val location = Option(cp.toFile).flatMap(f ⇒ Option(f.getAbsoluteFile))
+        location getOrElse (throw new IllegalStateException(s"The classpath location `$cp` is invalid."))
+      }.toArray
 
     override def sources = sourceFiles.toArray
 


### PR DESCRIPTION
An user found another NPE in SbtInputs. It is solved in the same way as
the previous NPE was solved. If a path is invalid an
IllegalStateException is thrown, which is a little bit better than a
NPE, which doesn't give any hints about the problem.

Fixes #1002577