### PR TITLE
Additional filtering for Step Out Message

### DIFF
--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/StepMessageOut.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/async/StepMessageOut.scala
@@ -3,9 +3,11 @@ package org.scalaide.debug.internal.async
 import java.util.UUID
 
 import scala.collection.JavaConverters
+import scala.util.Try
 
 import org.eclipse.debug.core.DebugEvent
 import org.scalaide.debug.internal.BaseDebuggerActor
+import org.scalaide.debug.internal.ScalaDebugPlugin
 import org.scalaide.debug.internal.async.AsyncUtils.AsyncProgramPointKey
 import org.scalaide.debug.internal.async.AsyncUtils.RequestOwnerKey
 import org.scalaide.debug.internal.async.AsyncUtils.installMethodBreakpoint
@@ -13,6 +15,7 @@ import org.scalaide.debug.internal.async.AsyncUtils.isAsyncProgramPoint
 import org.scalaide.debug.internal.model.JdiRequestFactory
 import org.scalaide.debug.internal.model.ScalaDebugTarget
 import org.scalaide.debug.internal.model.ScalaThread
+import org.scalaide.debug.internal.preferences.AsyncDebuggerPreferencePage
 import org.scalaide.logging.HasLogger
 
 import com.sun.jdi.Field
@@ -26,8 +29,12 @@ import com.sun.jdi.request.EventRequest
 import com.sun.jdi.request.StepRequest
 
 case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) extends HasLogger {
+  import org.scalaide.debug.internal.launching.ScalaDebuggerConfiguration._
+  import scala.collection.JavaConverters._
   private val StepMessageOut = "StepMessageOut" + UUID.randomUUID.toString
   private val IsSearchingReceiveMethodKey = "search"
+  private val StackTraceDepth = "StackTraceDepth"
+  private val StartLineNumber = "StartLineNumber"
   private var watchedMessage: Option[ObjectReference] = None
   private var watchedActor: String = _
   val programSends = List(
@@ -38,11 +45,13 @@ case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) ex
     AsyncProgramPoint("akka.actor.ActorCell", "receiveMessage", 0))
   private var receiveRequest: Option[EventRequest] = None
   private var stepRequests = Set[EventRequest]()
-  private var steps = 0
   private val depth = thread.getScalaStackFrames.size
   private val line = thread.getTopStackFrame().getLineNumber()
   private val Halt = true
   private val Continue = false
+  private val ProcessMailbox = 8
+  private[async] val stepOutNotStopInClasses =
+    debugTarget.getLaunch.getLaunchConfiguration.getAttribute(StepOutExcludePkgsOrClasses, List.empty[String].asJava).asScala
 
   def step(): Unit = {
     subordinate.start()
@@ -50,38 +59,57 @@ case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) ex
     thread.resumeFromScala(DebugEvent.CLIENT_REQUEST)
   }
 
+  private[async] def findThisType(stepEvent: StepEvent): String = {
+    val loc = stepEvent.location()
+    val declType = loc.declaringType().name()
+    Try {
+      val thisObject = stepEvent.thread().frame(0).thisObject()
+      if (thisObject ne null)
+        thisObject.referenceType().name()
+      else
+        declType
+    }.recover {
+      case e: Throwable =>
+        declType
+    }.get
+  }
+
   object subordinate extends BaseDebuggerActor {
     import scala.collection.JavaConverters._
-    private def isReceiveHandler(loc: com.sun.jdi.Location): Boolean =
-      loc.method().name().contains("applyOrElse")
+    private def isReceiveHandler(stepEvent: StepEvent): Boolean = {
+      val thisType = findThisType(stepEvent)
+      stepEvent.location.method.name.contains("applyOrElse") &&
+        !stepOutNotStopInClasses.exists { thisType.startsWith }
+    }
 
     override protected def behavior = {
       case breakpointEvent: BreakpointEvent if isSearchingReceiveMethod(breakpointEvent) =>
-        val topFrame = breakpointEvent.thread().frame(0)
+        val currentThread = breakpointEvent.thread
+        val topFrame = currentThread.frame(0)
         val args = topFrame.getArgumentValues()
         logger.debug(s"receive intercepted: topFrame arguments: $args")
         val app = breakpointEvent.request().getProperty(AsyncProgramPointKey).asInstanceOf[AsyncProgramPoint]
         val msg = Option(args.get(app.paramIdx).asInstanceOf[ObjectReference])
-        if (watchedMessage == msg && watchedActor == actorPathValue(path(self(topFrame.thisObject())), breakpointEvent.thread)) {
+        if (watchedMessage == msg && watchedActor == actorPathValue(path(self(topFrame.thisObject())), currentThread)) {
           logger.debug(s"MESSAGE IN! $msg")
-          val targetThread = debugTarget.getScalaThread(breakpointEvent.thread())
+          val targetThread = debugTarget.getScalaThread(currentThread)
           targetThread foreach { thread =>
             deleteReceiveRequest()
-            establishRequestToStopInReceiveMethod(thread)
+            establishRequestToStopInReceiveMethod(thread, currentThread.frameCount(), breakpointEvent.location().lineNumber())
           }
         }
         reply(Continue)
 
-      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) && isReceiveHandler(stepEvent.location) =>
+      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) && isReceiveHandler(stepEvent) =>
         terminate()
         logger.debug(s"Suspending thread ${stepEvent.thread.name()}")
         // most likely the breakpoint was hit on a different thread than the one we started with, so we find it here
         debugTarget.getScalaThread(stepEvent.thread()).foreach(_.suspendedFromScala(DebugEvent.BREAKPOINT))
         reply(Halt)
 
-      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) && steps >= 20 =>
+      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) && shouldStopSteppingForReceiveMethod(stepEvent) =>
         terminate()
-        logger.debug(s"Giving up on stepping after 15 steps")
+        logger.debug(s"Receive method not found. Leaving...")
         reply(Continue)
 
       case stepEvent: StepEvent if isSearchingTellMethod(stepEvent) =>
@@ -105,11 +133,6 @@ case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) ex
         }
         reply(decision)
 
-      case stepEvent: StepEvent if isSearchingReceiveMethod(stepEvent) =>
-        steps += 1
-        logger.debug(s"Step $steps: ${stepEvent.location.declaringType}.${stepEvent.location.method}")
-        reply(Continue)
-
       case _ =>
         reply(Continue)
     }
@@ -129,14 +152,22 @@ case class StepMessageOut(debugTarget: ScalaDebugTarget, thread: ScalaThread) ex
       receiveRequest.foreach { _.putProperty(IsSearchingReceiveMethodKey, true) }
     }
 
-    private def establishRequestToStopInReceiveMethod(thread: ScalaThread): Unit = {
+    private def establishRequestToStopInReceiveMethod(thread: ScalaThread, stackTraceDepth: Int, locationLine: Int): Unit = {
       val stepReq = JdiRequestFactory.createStepRequest(StepRequest.STEP_LINE, StepRequest.STEP_INTO, thread)
       stepReq.putProperty(RequestOwnerKey, StepMessageOut)
       stepReq.putProperty(IsSearchingReceiveMethodKey, true)
+      stepReq.putProperty(StackTraceDepth, stackTraceDepth)
+      stepReq.putProperty(StartLineNumber, locationLine)
       stepReq.enable()
       debugTarget.eventDispatcher.setActorFor(this, stepReq)
       stepRequests = Set(stepReq)
-      steps = 0
+    }
+
+    private def shouldStopSteppingForReceiveMethod(event: StepEvent) = {
+      val depth = event.request().getProperty(StackTraceDepth)
+      val startLine = event.request().getProperty(StartLineNumber).asInstanceOf[Int]
+      event.thread().frameCount() == depth && event.location().lineNumber() > startLine ||
+        event.thread().frameCount() < ProcessMailbox
     }
 
     private def isOwning(event: Event) = event.request.getProperty(RequestOwnerKey) == StepMessageOut

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerConfiguration.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerConfiguration.scala
@@ -2,4 +2,5 @@ package org.scalaide.debug.internal.launching
 
 object ScalaDebuggerConfiguration {
   val LaunchWithAsyncDebugger = "LaunchWithAsyncDebugger"
+  val StepOutExcludePkgsOrClasses = "StepOutExcludePkgsOrClasses"
 }

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerTab.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerTab.scala
@@ -1,5 +1,9 @@
 package org.scalaide.debug.internal.launching
 
+import scala.collection.JavaConverters
+import scala.util.Properties
+import scala.util.Try
+
 import org.eclipse.core.runtime.CoreException
 import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
@@ -8,6 +12,8 @@ import org.eclipse.debug.ui.AbstractLaunchConfigurationTab
 import org.eclipse.jface.dialogs.Dialog
 import org.eclipse.pde.internal.ui.IHelpContextIds
 import org.eclipse.swt.SWT
+import org.eclipse.swt.events.ModifyEvent
+import org.eclipse.swt.events.ModifyListener
 import org.eclipse.swt.events.SelectionAdapter
 import org.eclipse.swt.events.SelectionEvent
 import org.eclipse.swt.graphics.Image
@@ -15,26 +21,41 @@ import org.eclipse.swt.layout.GridData
 import org.eclipse.swt.layout.GridLayout
 import org.eclipse.swt.widgets.Button
 import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Text
 import org.eclipse.ui.PlatformUI
 import org.scalaide.ui.ScalaImages
-import ScalaDebuggerConfiguration.LaunchWithAsyncDebugger
-import scala.util.Try
 
 private class GeneralSettingsBlock(val tab: ScalaDebuggerTab) {
   import ScalaDebuggerConfiguration._
 
   private var globalAsyncDebuggerSwitchButton: Button = _
+  private var stepOutExcludePackages: Text = _
   val SettingsArea = "General Settings"
+  val StepMessageOutExcludePackages = "Define all package/class names where Step Out Message should NOT stop in"
+  val StepOutSettings = "Step Out Message Settings"
   val AsyncDebuggerGlobalSwitch = "Enable Async Stack Trace functionality"
+  val DataDelimiter = Properties.lineSeparator
 
   def createControl(parent: Composite): Unit = {
-    val group = SWTFactory.createGroup(parent, SettingsArea, 1, 1, GridData.FILL_HORIZONTAL)
-    globalAsyncDebuggerSwitchButton = SWTFactory.createCheckButton(group, AsyncDebuggerGlobalSwitch, null, false, 1)
+    val generalGroup = SWTFactory.createGroup(parent, SettingsArea, 1, 1, GridData.FILL_HORIZONTAL)
+    globalAsyncDebuggerSwitchButton = SWTFactory.createCheckButton(generalGroup, AsyncDebuggerGlobalSwitch, null, false, 1)
     globalAsyncDebuggerSwitchButton.addSelectionListener(new SelectionAdapter() {
       override def widgetSelected(e: SelectionEvent): Unit = {
-        tab.updateLaunchConfigurationDialog()
+        tab.scheduleUpdateJob()
       }
     })
+    generalGroup.pack()
+
+    val stepOutGroup = SWTFactory.createGroup(parent, StepOutSettings, 1, 1, GridData.FILL_HORIZONTAL)
+    SWTFactory.createLabel(stepOutGroup, StepMessageOutExcludePackages, 1)
+    stepOutExcludePackages = SWTFactory.createText(stepOutGroup,
+      SWT.MULTI | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL, 1, 100, 40, GridData.FILL_BOTH)
+    stepOutExcludePackages.addModifyListener(new ModifyListener() {
+      override def modifyText(me: ModifyEvent): Unit = {
+        tab.scheduleUpdateJob()
+      }
+    })
+    stepOutGroup.pack()
   }
 
   def setDefaults(configuration: ILaunchConfigurationWorkingCopy): Unit = {}
@@ -44,19 +65,27 @@ private class GeneralSettingsBlock(val tab: ScalaDebuggerTab) {
    * @param configuration the configuration to get attributes from
    * @throws CoreException if an error occurs getting an attribute
    */
-  def initializeFrom(configuration: ILaunchConfiguration): Unit =
+  def initializeFrom(configuration: ILaunchConfiguration): Unit = {
     globalAsyncDebuggerSwitchButton.setSelection(configuration.getAttribute(LaunchWithAsyncDebugger, false))
+    import scala.collection.JavaConverters._
+    stepOutExcludePackages.setText(configuration.getAttribute(StepOutExcludePkgsOrClasses,
+      List.empty[String].asJava).asScala.mkString(DataDelimiter))
+  }
 
   /**
    * Sets attributes on the configuration based on the current state of the UI elements
    * @param configuration configuration to modify
    */
-  def performApply(configuration: ILaunchConfigurationWorkingCopy): Unit =
+  def performApply(configuration: ILaunchConfigurationWorkingCopy): Unit = {
     if (globalAsyncDebuggerSwitchButton.getSelection()) {
       configuration.setAttribute(LaunchWithAsyncDebugger, true)
     } else {
       configuration.removeAttribute(LaunchWithAsyncDebugger)
     }
+    import scala.collection.JavaConverters._
+    configuration.setAttribute(StepOutExcludePkgsOrClasses,
+      stepOutExcludePackages.getText.split(DataDelimiter).filterNot { _.isEmpty }.toList.asJava)
+  }
 
   /**
    * @return a string error message or <code>null</code> if the block contents are valid
@@ -114,8 +143,8 @@ class ScalaDebuggerTab extends AbstractLaunchConfigurationTab {
   override def activated(workingCopy: ILaunchConfigurationWorkingCopy): Unit = {}
   override def deactivated(workingCopy: ILaunchConfigurationWorkingCopy): Unit = {}
 
-  override def updateLaunchConfigurationDialog(): Unit = {
+  override def scheduleUpdateJob(): Unit = {
     validateTab()
-    super.updateLaunchConfigurationDialog()
+    super.scheduleUpdateJob()
   }
 }

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerTab.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/ScalaDebuggerTab.scala
@@ -1,6 +1,7 @@
 package org.scalaide.debug.internal.launching
 
-import scala.collection.JavaConverters
+import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.util.Properties
 import scala.util.Try
 
@@ -67,7 +68,6 @@ private class GeneralSettingsBlock(val tab: ScalaDebuggerTab) {
    */
   def initializeFrom(configuration: ILaunchConfiguration): Unit = {
     globalAsyncDebuggerSwitchButton.setSelection(configuration.getAttribute(LaunchWithAsyncDebugger, false))
-    import scala.collection.JavaConverters._
     stepOutExcludePackages.setText(configuration.getAttribute(StepOutExcludePkgsOrClasses,
       List.empty[String].asJava).asScala.mkString(DataDelimiter))
   }
@@ -82,9 +82,8 @@ private class GeneralSettingsBlock(val tab: ScalaDebuggerTab) {
     } else {
       configuration.removeAttribute(LaunchWithAsyncDebugger)
     }
-    import scala.collection.JavaConverters._
     configuration.setAttribute(StepOutExcludePkgsOrClasses,
-      stepOutExcludePackages.getText.split(DataDelimiter).filterNot { _.isEmpty }.toList.asJava)
+      stepOutExcludePackages.getText.split(DataDelimiter).filter { _.nonEmpty }.toList.asJava)
   }
 
   /**


### PR DESCRIPTION
Problem: when `receive` method is wrapped by other `receive` method
the Step Out processing stops in first found `applyOrElse` method.
Example:
```
def receive = LoggingReceive {
  case msg => foo
}
```
so Step Out stops in implementation of LoggingReceive not in function
shown above.

Perscription:
In Launch Configuration in Scala Debug Tab filter for Step Out Message
functionality has been added. The `applyOrElse` from listed package/class
names are ignored if found (blacklisted).

fix #1002575