### PR TITLE
Do not apply cursor position translation twice

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
@@ -392,8 +392,7 @@ class ScalaSourceFileEditor
     override def documentPartitioning: String = getDocumentPartitioning()
 
     override def updateTextViewer(cursorPos: Int): Unit = {
-      val widgetCaret = modelOffset2WidgetOffset(cursorPos)
-      setSelectedRange(widgetCaret, 0)
+      setSelectedRange(cursorPos, 0)
     }
 
     override def smartBackspaceManager: SmartBackspaceManager =


### PR DESCRIPTION
`modelOffset2WidgetOffset` translates positions from the document to
positions of the shown widget, which may show folded regions. In these
cases the cursor was set to the wrong position. The problem was that the
translations happened twice. Once in the changed code and once in
`setSelectedRange`. By removing one translation, the wrong cursor
positions are sent to oblivion.

Fixes #1002579