### PR TITLE
Show ctors as `this` and not as `<init>` it outline view

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/OutlineModelTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/OutlineModelTest.scala
@@ -208,6 +208,18 @@ class OutlineModelTest {
       Assert.assertEquals("+++", textAt(rn, 2, 0))
     })
   }
+
+  @Test
+  def classCtor(): Unit = {
+    runTest("""package classCtor
+               class Test(val v: Int) {
+                 def this(v1: Int, v2: Int) = this(v1+v2)
+               }
+            """, rn => {
+      Assert.assertEquals("this(v1: Int, v2: Int)", textAt(rn, 1, 1))
+    })
+  }
+
   private def runTest(str: String, f: RootNode => Unit): Unit = {
     import OutlineModelTest._
     withCompiler { comp =>

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/outline/ModelBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/outline/ModelBuilder.scala
@@ -153,10 +153,15 @@ object ModelBuilder extends HasLogger {
       }
 
       def showName(name: Name, t: Tree) = {
-        if (src.content(t.pos.point) == '`')
-          "`" + name.decoded + "`"
-        else
-          name.decoded.split("\\.").reverse.head
+        t match {
+          case t: DefDef if t.name == nme.CONSTRUCTOR =>
+            "this"
+          case _ =>
+            if (src.content(t.pos.point) == '`')
+              "`" + name.decoded + "`"
+            else
+              name.decoded.split("\\.").reverse.head
+        }
       }
 
       def renderQualifier(sb: StringBuilder, t: Tree): Unit = {


### PR DESCRIPTION
Fix [#1002588](https://www.assembla.com/spaces/scala-ide/tickets/1002588-class-constructors-are-shown-as--lt-init-gt--in-outline-view)