### PR TITLE
Fix failing accessibility tests

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -394,7 +394,7 @@ class ScalaPresentationCompiler(private[compiler] val name: String, _settings: S
 
     val signature =
       if (sym.isMethod) {
-        declPrinter.defString(sym, flagMask = 0L, showKind = false)(tpe)
+        declPrinter.defString(sym, flagMask = 0L, showKind = false, showAccessor = false)(tpe)
       } else name
     val container = sym.owner.enclClass.fullName
 


### PR DESCRIPTION
The tests failed because the accessor was shown in the display string.
Removing the accessor was not as easy as I hoped. The problem was that
the private[x] keyword is not represented as a flag. The only way to
know that a symbol is private for a package is by checking if it has no
other visibility.  This meant that the already existing flag mask
couldn't be used, since the private keyword just couldn't be masked out.
How stupid.

I fixed it by adding another parameter `showAccessor`, which needs to be
set to false when the accessor shouldn't be shown. For public, protected
and normal private visibility it is also possible to mask the flags with
the `flagMask` parameter. Just not for private[x].