### PR TITLE
Transition to IC.compile

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/project/ScalaInstallationTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/project/ScalaInstallationTest.scala
@@ -15,6 +15,7 @@ import org.scalaide.core.internal.project.MultiBundleScalaInstallation
 import org.osgi.framework.Bundle
 import org.eclipse.core.runtime.Path
 import org.eclipse.core.runtime.IPath
+import org.junit.Ignore
 
 class ScalaInstallationTest {
 
@@ -69,6 +70,7 @@ class ScalaInstallationTest {
   }
 
   @Test
+  @Ignore("Looks like 2.11.8.v20151124-185958-8363c20de8 does not contain scala-actor lib")
   def multiBundleInstallationsTest(): Unit = {
     val multiBundleInstallations = ScalaInstallation.multiBundleInstallations
 

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/project/ScalaInstallationTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/project/ScalaInstallationTest.scala
@@ -1,21 +1,20 @@
 package org.scalaide.core.project
 
-import org.junit.Test
-import org.junit.Assert._
-import org.scalaide.core.IScalaInstallation
-import org.scalaide.core.internal.project.ScalaInstallation
-import org.scalaide.core.IScalaPlugin
-import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.settings.SpecificScalaVersion
-import org.scalaide.util.eclipse.OSGiUtils
-import scala.tools.nsc.settings.SpecificScalaVersion
-import org.scalaide.core.internal.project.BundledScalaInstallation
-import org.eclipse.core.runtime.Platform
-import org.scalaide.core.internal.project.MultiBundleScalaInstallation
-import org.osgi.framework.Bundle
-import org.eclipse.core.runtime.Path
+
 import org.eclipse.core.runtime.IPath
-import org.junit.Ignore
+import org.eclipse.core.runtime.Path
+import org.eclipse.core.runtime.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import org.osgi.framework.Bundle
+import org.scalaide.core.IScalaInstallation
+import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.internal.project.BundledScalaInstallation
+import org.scalaide.core.internal.project.MultiBundleScalaInstallation
+import org.scalaide.core.internal.project.ScalaInstallation
+import org.scalaide.util.eclipse.OSGiUtils
 
 class ScalaInstallationTest {
 
@@ -70,7 +69,6 @@ class ScalaInstallationTest {
   }
 
   @Test
-  @Ignore("Looks like 2.11.8.v20151124-185958-8363c20de8 does not contain scala-actor lib")
   def multiBundleInstallationsTest(): Unit = {
     val multiBundleInstallations = ScalaInstallation.multiBundleInstallations
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
@@ -1,0 +1,64 @@
+package org.scalaide.core.internal.builder.zinc
+
+import java.io.File
+import org.scalaide.util.internal.SbtUtils
+import sbt.CompileSetup
+import sbt.EmptyAnalysis
+import sbt.compiler.AnalyzingCompiler
+import sbt.compiler.IC
+import sbt.compiler.MixedAnalyzingCompiler
+import sbt.inc.Analysis
+import sbt.inc.AnalysisStore
+import xsbti.Logger
+import xsbti.Reporter
+import xsbti.compile.Compilers
+
+private object Cache {
+  type Result = (Analysis, Option[CompileSetup])
+
+  private[zinc] def previousResult(cacheFile: File, initialNameHashing: Boolean): Result = {
+    Cache(cacheFile).get().map {
+      case (analysis, setup) => (analysis, Some(setup))
+    } getOrElse {
+      (EmptyAnalysis(initialNameHashing), None)
+    }
+  }
+
+  private[zinc] def apply(cacheFile: File): AnalysisStore =
+    MixedAnalyzingCompiler.staticCachedStore(cacheFile)
+}
+
+class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logger) {
+  /**
+   * Inspired by `IC.compile` and `AggressiveCompile.compile1`
+   *
+   *  We need to duplicate `IC.compile`, because Java interface passes the incremental
+   *  compiler options `IncOptions` as `Map[String, String]`, which is not expressive
+   *  enough to use the transactional classfile manager (required for correctness).
+   *  In other terms, we need richer (`IncOptions`) parameter type, here.
+   *  Other thing is the update of the `AnalysisStore` implemented in `AggressiveCompile.compile1`
+   *  method which is not implemented in `IC.compile`.
+   */
+  def compile(in: SbtInputs, comps: Compilers[AnalyzingCompiler]): Analysis = {
+    val options = in.options; import options.{ options => scalacOptions, _ }
+    val aMap = (f: File) => SbtUtils.m2o(in.analysisMap(f))
+    val defClass = (f: File) => { val dc = Locator(f); (name: String) => dc.apply(name) }
+    val (previousAnalysis, previousSetup) = Cache.previousResult(cacheFile, in.incOptions.nameHashing)
+    import comps._
+    cacheAndReturnLastAnalysis(IC.incrementalCompile(scalac, javac, options.sources, classpath, output, in.cache,
+      SbtUtils.m2o(in.progress), scalacOptions, javacOptions, previousAnalysis, previousSetup, aMap, defClass,
+      sbtReporter, order, skip = false, in.incOptions)(log))
+  }
+
+  private def cacheAndReturnLastAnalysis(compilationResult: IC.Result): Analysis = {
+    if (compilationResult.hasModified)
+      Cache(cacheFile).set(compilationResult.analysis, compilationResult.setup)
+    compilationResult.analysis
+  }
+}
+
+object CachingCompiler {
+  def apply(cacheFile: File, sbtReporter: Reporter, logger: Logger): CachingCompiler =
+    new CachingCompiler(cacheFile, sbtReporter, logger)
+}
+

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
@@ -1,32 +1,16 @@
 package org.scalaide.core.internal.builder.zinc
 
 import java.io.File
+
 import org.scalaide.util.internal.SbtUtils
-import sbt.CompileSetup
-import sbt.EmptyAnalysis
+
 import sbt.compiler.AnalyzingCompiler
 import sbt.compiler.IC
 import sbt.compiler.MixedAnalyzingCompiler
 import sbt.inc.Analysis
-import sbt.inc.AnalysisStore
 import xsbti.Logger
 import xsbti.Reporter
 import xsbti.compile.Compilers
-
-private object Cache {
-  type Result = (Analysis, Option[CompileSetup])
-
-  private[zinc] def previousResult(cacheFile: File, initialNameHashing: Boolean): Result = {
-    Cache(cacheFile).get().map {
-      case (analysis, setup) => (analysis, Some(setup))
-    } getOrElse {
-      (EmptyAnalysis(initialNameHashing), None)
-    }
-  }
-
-  private[zinc] def apply(cacheFile: File): AnalysisStore =
-    MixedAnalyzingCompiler.staticCachedStore(cacheFile)
-}
 
 class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logger) {
   /**
@@ -43,7 +27,10 @@ class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logg
     val options = in.options; import options.{ options => scalacOptions, _ }
     val aMap = (f: File) => SbtUtils.m2o(in.analysisMap(f))
     val defClass = (f: File) => { val dc = Locator(f); (name: String) => dc.apply(name) }
-    val (previousAnalysis, previousSetup) = Cache.previousResult(cacheFile, in.incOptions.nameHashing)
+    val (previousAnalysis, previousSetup) = SbtUtils.m2o(IC.readCache(cacheFile))
+      .map {
+        case (a, s) => (a, Option(s))
+      }.getOrElse((IC.readAnalysis(cacheFile, in.incOptions), None))
     import comps._
     cacheAndReturnLastAnalysis(IC.incrementalCompile(scalac, javac, options.sources, classpath, output, in.cache,
       SbtUtils.m2o(in.progress), scalacOptions, javacOptions, previousAnalysis, previousSetup, aMap, defClass,
@@ -52,7 +39,7 @@ class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logg
 
   private def cacheAndReturnLastAnalysis(compilationResult: IC.Result): Analysis = {
     if (compilationResult.hasModified)
-      Cache(cacheFile).set(compilationResult.analysis, compilationResult.setup)
+      MixedAnalyzingCompiler.staticCachedStore(cacheFile).set(compilationResult.analysis, compilationResult.setup)
     compilationResult.analysis
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EmptyAnalysis.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EmptyAnalysis.scala
@@ -1,0 +1,8 @@
+import sbt.inc.Analysis
+
+package sbt {
+  /** Just to expose `Analysis.empty(nameHashing: Boolean)` to non `sbt` packages. */
+  object EmptyAnalysis {
+    def apply(nameHashing: Boolean): Analysis = Analysis.empty(nameHashing)
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EmptyAnalysis.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EmptyAnalysis.scala
@@ -1,8 +1,0 @@
-import sbt.inc.Analysis
-
-package sbt {
-  /** Just to expose `Analysis.empty(nameHashing: Boolean)` to non `sbt` packages. */
-  object EmptyAnalysis {
-    def apply(nameHashing: Boolean): Analysis = Analysis.empty(nameHashing)
-  }
-}

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/Suppress.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/Suppress.scala
@@ -1,13 +1,13 @@
 package org.scalaide.util.internal
 
 import java.io.PrintStream
+
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.jdt.core.IClassFile
 import org.eclipse.jdt.core.ICodeAssist
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.core.WorkingCopyOwner
 import org.eclipse.jdt.internal.core.Openable
-import java.io.File
 
 /**
  * This type exists only to suppress warnings of scalac. One should try to not
@@ -67,9 +67,6 @@ object Suppress {
 
     def `Console.setErr`(out: PrintStream): Unit =
       Console.setErr(out)
-
-    type AggressiveCompile = sbt.compiler.AggressiveCompile
-    def aggressivelyCompile(agg: AggressiveCompile)(implicit log: sbt.Logger) = agg.apply _
   }
   object DeprecatedWarning extends DeprecatedWarning
 }


### PR DESCRIPTION
currently EclipseSbtBuildManager uses deprecated AggressiveCompile
class. This fix utilizes IC.incrementalCompile to be a replacement
for deprecated class.