### PR TITLE
Refresh analysis store after build

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/EclipseBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/EclipseBuildManager.scala
@@ -41,8 +41,3 @@ trait EclipseBuildManager {
   /** Returns error markers on underlying resources. */
   def buildErrors: Set[IMarker]
 }
-
-/** Keeps collected analysis persistently in store. This store is exposed outdoor. */
-trait CachedAnalysisBuildManager extends EclipseBuildManager {
-  def analysisStore: IFile
-}


### PR DESCRIPTION
Scenario comes from one of customer who updates .cache-* by external
to Scala IDE tool (strictly by gradle build script but it does not
matter).
Scenario:
- open project in Scala IDE
- mimic external tool run by editing any of .cache-* file and change
  its content
- put some change to any scala file and build a project
- try Eclipse 'search'
Without the change error popup window is seen with information about
a loss of sync of .cache-* file (so asking about using F5 on project).
The suggested improvement assumes to refresh .cache-* files after
project build.

REMARK: No test unit, looks too hard to write, any suggestion to create welcomed