### PR TITLE
Don’t create a Scala reconciler for Scala files that are not part of a

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/EditorUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/EditorUtils.scala
@@ -136,7 +136,8 @@ object EditorUtils {
       case t: ISourceViewerEditor => t
     }
 
-  private def file(e: ITextEditor): Option[IFile] =
+  /** Return the associated IFile in this text editor, if any */
+  def file(e: ITextEditor): Option[IFile] =
     PartialFunction.condOpt(e.getEditorInput()) {
       case f: IFileEditorInput => f.getFile
     }


### PR DESCRIPTION
source folder.

This makes it easier to use the Scala editor on files like Sbt, or simple script examples (by not filling them up with error markers).

Ref #1002415