### PR TITLE
Hide quick fix entry from context menu

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
@@ -222,7 +222,12 @@ class ScalaSourceFileEditor
     }
 
     def fixBrokenGroups(): Unit = {
-      findJdtSourceMenuManager(menu.getItems) foreach { mm =>
+      val items = menu.getItems
+
+      // hide quick fix entry from menu since it invokes JDT quick fixes
+      items.find(_.getId == "QuickAssist").foreach(_.setVisible(false))
+
+      findJdtSourceMenuManager(items) foreach { mm =>
 
         val groups = groupMenuItemsByGroupId(mm.getItems)
 


### PR DESCRIPTION
The quick fix entry is contributed by JDT and is therefore broken since
it invokes only the JDT quick assists.

Fixes #1002523