### PR TITLE
Add update-site for scala-refactoring

### DIFF
--- a/org.scala-ide.p2-toolchain/pom.xml
+++ b/org.scala-ide.p2-toolchain/pom.xml
@@ -26,6 +26,7 @@
 <!-- TODO enable back when multiple bundles of Scala are supported -->
 <!--        <module>../org.scala-ide.scala210.build</module> -->
         <module>../org.scala-ide.scala211.build</module>
+        <module>../org.scala-ide.refactoring</module>
       </modules>
     </profile>
     <profile>

--- a/org.scala-ide.refactoring/org.scala-ide.refactoring.feature/build.properties
+++ b/org.scala-ide.refactoring/org.scala-ide.refactoring.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/org.scala-ide.refactoring/org.scala-ide.refactoring.feature/feature.xml
+++ b/org.scala-ide.refactoring/org.scala-ide.refactoring.feature/feature.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.scala-ide.refactoring.feature"
+      label="Scala IDE Refactoring"
+      version="4.4.0.qualifier"
+      provider-name="scala-ide.org"
+      plugin="org.scala-refactoring.library">
+
+   <description url="http://scala-ide.org">
+     scala-refactoring integration in Scala IDE
+   </description>
+
+   <copyright url="http://scala-lang.org/downloads/">
+     Copyright (c) 2002-2014 EPFL, Lausanne.
+All rights reserved.
+   </copyright>
+
+   <license url="http://scala-lang.org/downloads/license.html">
+      SCALA LICENSE
+
+Copyright (c) 2002-2010 EPFL, Lausanne, unless otherwise specified.
+All rights reserved.
+
+This software was developed by the Programming Methods Laboratory of the
+Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland.
+
+Permission to use, copy, modify, and distribute this software in source
+or binary form for any purpose with or without fee is hereby granted,
+provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the EPFL nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS&apos;&apos; AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+   </license>
+
+   <plugin
+         id="org.scala-refactoring.library"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>
+

--- a/org.scala-ide.refactoring/org.scala-ide.refactoring.feature/pom.xml
+++ b/org.scala-ide.refactoring/org.scala-ide.refactoring.feature/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.scala-ide</groupId>
+    <artifactId>org.scala-ide.refactoring</artifactId>
+    <version>4.4.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.scala-ide.refactoring.feature</artifactId>
+  <packaging>eclipse-feature</packaging>
+</project>
+

--- a/org.scala-ide.refactoring/org.scala-ide.refactoring.update-site/pom.xml
+++ b/org.scala-ide.refactoring/org.scala-ide.refactoring.update-site/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.scala-ide</groupId>
+    <artifactId>org.scala-ide.refactoring</artifactId>
+    <version>4.4.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.scala-ide.refactoring.update-site</artifactId>
+  <packaging>eclipse-update-site</packaging>
+</project>

--- a/org.scala-ide.refactoring/org.scala-ide.refactoring.update-site/site.xml
+++ b/org.scala-ide.refactoring/org.scala-ide.refactoring.update-site/site.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature url="features/org.scala-ide.refactoring.feature_0.0.0.jar" id="org.scala-ide.refactoring.feature" version="0.0.0">
+   </feature>
+</site>
+

--- a/org.scala-ide.refactoring/pom.xml
+++ b/org.scala-ide.refactoring/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.scala-ide</groupId>
+    <artifactId>org.scala-ide.p2-toolchain</artifactId>
+    <version>4.4.0-SNAPSHOT</version>
+    <relativePath>../org.scala-ide.p2-toolchain/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>org.scala-ide.refactoring</artifactId>
+  <description>The local p2 repo for scala-refactoring</description>
+  <packaging>pom</packaging>
+  <version>4.4.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-refactoring</groupId>
+      <artifactId>org.scala-refactoring.library_${scala.minor.version}</artifactId>
+      <version>${scala-refactoring.version}</version>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>scala-ide.refactoring.repo</id>
+      <name>Scala IDE refactoring repository</name>
+      <url>${repo.scala-refactoring}</url>
+      <snapshots>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <modules>
+    <module>org.scala-ide.refactoring.feature</module>
+    <module>org.scala-ide.refactoring.update-site</module>
+  </modules>
+
+</project>
+

--- a/org.scala-ide.sdt.build/pom.xml
+++ b/org.scala-ide.sdt.build/pom.xml
@@ -57,7 +57,7 @@
       <id>scala-refactoring</id>
       <name>Scala Refactoring p2 repository</name>
       <layout>p2</layout>
-      <url>${repo.scala-refactoring}</url>
+      <url>file:../org.scala-ide.refactoring/org.scala-ide.refactoring.update-site/target/site</url>
     </repository>
     <repository>
       <id>scalariform</id>

--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,10 @@
     <version.tag>local</version.tag>
     <sbt.version>0.13.8</sbt.version>
     <json-io.version>4.1.6</json-io.version>
+    <scala-refactoring.version>0.9.0-SNAPSHOT</scala-refactoring.version>
 
     <!-- the repos containing the Scala dependencies -->
-    <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-${scala.short.version}x</repo.scala-refactoring>
+    <repo.scala-refactoring>${repo.scala-ide.root}/scala-refactoring-lib</repo.scala-refactoring>
     <repo.scalariform>${repo.scala-ide.root}/scalariform-${scala.short.version}x</repo.scalariform>
     <repo.typesafe>https://proxy-ch.typesafe.com:8082/artifactory/ide-${scala.minor.version}</repo.typesafe>
 


### PR DESCRIPTION
Right now, the scala-refactoring repo contains an update-site, which is
used by the Scala IDE build. Since the update-site just clutters up the
scala-refactoring repo, the idea was to move the update-site to the
scala-ide repo. This way the scala-refactoring repo is easier to
understand. The scala-ide repo gets more complicated but we can hide all
of these artificial update sites in a sub directory instead of keeping
them in the root directory as it is done right now.

Another change that was required to make this up and running can be
found in the nightlies of scala-refactoring. So far a P2 update site was
published by our build server. This has changed in so far that a nightly
of the scala-refactoring library is published, which can also be
consumed by other people.