### PR TITLE
Introduces barrier for Hot Code Replacement

### DIFF
--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaThread.scala
@@ -204,6 +204,8 @@ abstract class ScalaThread private(target: ScalaDebugTarget, val threadRef: Thre
         val startFrameForStepInto = frames(frames.indexOf(frame) + 1)
         threadRef.popFrames(frame.stackFrame)
         stepIntoFrame(startFrameForStepInto)
+      } else {
+        logger.debug(s"cannot drop to frame at the moment when related to HCR is $relatedToHcr")
       }
     })
 


### PR DESCRIPTION
Scenario:
Hot Code Replacement feature in its flow calls
`ScalaHotCodeReplacementManager.doHotCodeReplace` method.
This method sets `ScalaDebugTarget.isPerformingHotCodeReplace` flag
which controls dropping stack trace top in `ScalaThread` instance
(see its `dropToFrameInternal`). And if more then one thread is doing
this action it happens sometimes that `ScalaThread.canDropToFrame`
does not allow for a drop. The root cause probably is the situation
when earlier thread set `isPerformingHotCodeReplace` flag to false
and later thread is just before `dropToFrameInternal`. The barrier
prevents this race condition.