### PR TITLE
Improves eclipse error marker messages

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/NonScalaSourceErrorMarkersTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/NonScalaSourceErrorMarkersTest.scala
@@ -1,0 +1,77 @@
+package org.scalaide.core
+package sbtbuilder
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IProjectDescription
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.junit.Assert
+import org.junit.Test
+import org.scalaide.core.SdtConstants
+import org.scalaide.ui.internal.preferences.ScalaPluginSettings
+import org.scalaide.util.internal.SettingConverterUtil
+
+import testsetup.Implicits
+import testsetup.SDTTestUtils
+
+class NonScalaSourceErrorMarkersTest {
+  import SDTTestUtils._
+  import Implicits.TestableProject
+
+  def addScalaNature(project: IProject) = natures(project) { description =>
+    SdtConstants.NatureId +: description.getNatureIds
+  }
+
+  private def natures(project: IProject)(newNatures: IProjectDescription => Array[String]): Unit = {
+    val description = project.getDescription
+    description.setNatureIds(newNatures(description))
+    project.setDescription(description, null)
+  }
+
+  def removeScalaNature(project: IProject) = natures(project) { description =>
+    description.getNatureIds.filter { _ != SdtConstants.NatureId }
+  }
+
+  def soThen(assertThat: => Unit): Unit = assertThat
+
+  @Test def shouldFindJavaErrorMarkerTooWhenScalaNatureOfAisOffAndOn(): Unit = {
+    val Seq(prjA, prjB, prjC) = createProjects("A", "B", "C")
+
+    try {
+      prjB dependsOnAndExports prjA
+      prjC onlyDependsOn prjB
+
+      val Seq(packA, packB, packC) = Seq(prjA, prjB, prjC).map(createSourcePackage("test"))
+
+      val unitA = packA.createCompilationUnit("A.scala", "trait A", true, null)
+      val unitB = packB.createCompilationUnit("B.scala", "class B extends A", true, null)
+      val unitC = packC.createCompilationUnit("C.scala", "class C extends B", true, null)
+
+      // set stopOnBuildErrors to true
+      val stopBuildOnErrors = SettingConverterUtil.convertNameToProperty(ScalaPluginSettings.stopBuildOnErrors.name)
+      IScalaPlugin().getPreferenceStore.setValue(stopBuildOnErrors, true)
+
+      // no errors
+      SDTTestUtils.workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null)
+      val unitsToWatch = Seq(unitA, unitB, unitC)
+      val errors = SDTTestUtils.getErrorMessages(unitsToWatch: _*)
+      Assert.assertEquals("No build errors", Seq(), errors)
+
+      def whenRemoveAndAddScalaNatureToA(): Unit = {
+        removeScalaNature(prjA.underlying)
+        SDTTestUtils.workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null)
+        addScalaNature(prjA.underlying)
+        SDTTestUtils.workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null)
+      }
+      whenRemoveAndAddScalaNatureToA()
+
+      soThen {
+        Assert.assertEquals("One error in A", Seq((2, "Syntax error on tokens, delete these tokens")), SDTTestUtils.getErrorMessages(prjA.underlying))
+        Assert.assertEquals("One error in B", Seq((2, """Project: "B" in scope: "main" not built due to errors in dependent project(s): A. Root error(s): Syntax error on tokens, delete these tokens""")), SDTTestUtils.getErrorMessages(prjB.underlying))
+        Assert.assertEquals("One error in C", Seq((2, """Project: "C" in scope: "main" not built due to errors in dependent project(s): B, A. Root error(s): Project: "B" in scope: "main" not built due to errors in dependent project(s): A. Root error(s): Syntax error on tokens, delete these tokens;Syntax error on tokens, delete these tokens""")),
+          SDTTestUtils.getErrorMessages(prjC.underlying))
+      }
+    } finally {
+      deleteProjects(prjA, prjB, prjC)
+    }
+  }
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ProjectDependenciesTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ProjectDependenciesTest.scala
@@ -1,38 +1,20 @@
 package org.scalaide.core
 package sbtbuilder
 
-import org.junit.Test
-import org.eclipse.jdt.core.IJavaProject
-import org.eclipse.jdt.core.IClasspathEntry
-import org.eclipse.jdt.core.JavaCore
-import org.junit.Assert
-import testsetup.SDTTestUtils
 import org.eclipse.core.resources.IncrementalProjectBuilder
-import org.scalaide.ui.internal.preferences.IDESettings
-import org.scalaide.ui.internal.preferences.CompilerSettings
-import org.eclipse.jdt.core.IPackageFragment
-import org.scalaide.util.internal.SettingConverterUtil
-import org.scalaide.ui.internal.preferences.ScalaPluginSettings
+import org.junit.Assert
+import org.junit.Test
 import org.scalaide.core.IScalaPlugin
-import org.eclipse.core.resources.IProject
+import org.scalaide.ui.internal.preferences.ScalaPluginSettings
+import org.scalaide.util.internal.SettingConverterUtil
+
+import testsetup.Implicits
+import testsetup.SDTTestUtils
 
 class ProjectDependenciesTest {
 
   import SDTTestUtils._
-
-  private implicit class TestableProject(from: IScalaProject) {
-    def dependsOnAndExports(dep: IScalaProject, exported: Boolean = true): Unit =
-      addToClasspath(from, JavaCore.newProjectEntry(dep.underlying.getFullPath, exported))
-
-    def onlyDependsOn(dep: IScalaProject) = dependsOnAndExports(dep, false)
-
-    def shouldDependOn(msg: String, deps: IScalaProject*): Unit = {
-      val expected = deps.map(_.underlying).sortBy(_.getName)
-      val computed = from.transitiveDependencies.sortBy(_.getName)
-      Assert.assertEquals(s"${msg.capitalize} for ${from.underlying.getName}", expected, computed)
-    }
-  }
-
+  import Implicits.TestableProject
 
   @Test def transitive_dependencies_more_complicated_tree(): Unit = {
     val allProj @ Seq(prjA, prjB, prjC, prjD, prjE, prjF, prjG) = createProjects("A", "B", "C", "D", "E", "F", "G")

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/Implicits.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/Implicits.scala
@@ -1,0 +1,23 @@
+package org.scalaide.core
+package testsetup
+
+import org.eclipse.jdt.core.JavaCore
+import org.junit.Assert
+import org.scalaide.core.IScalaProject
+
+object Implicits {
+  import SDTTestUtils._
+
+  implicit class TestableProject(from: IScalaProject) {
+    def dependsOnAndExports(dep: IScalaProject, exported: Boolean = true): Unit =
+      addToClasspath(from, JavaCore.newProjectEntry(dep.underlying.getFullPath, exported))
+
+    def onlyDependsOn(dep: IScalaProject) = dependsOnAndExports(dep, false)
+
+    def shouldDependOn(msg: String, deps: IScalaProject*): Unit = {
+      val expected = deps.map(_.underlying).sortBy(_.getName)
+      val computed = from.transitiveDependencies.sortBy(_.getName)
+      Assert.assertEquals(s"${msg.capitalize} for ${from.underlying.getName}", expected, computed)
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/SbtScopesBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/SbtScopesBuildManager.scala
@@ -2,6 +2,7 @@ package org.scalaide.core.internal.project
 
 import java.io.File
 
+import scala.annotation.migration
 import scala.tools.nsc.Settings
 
 import org.eclipse.core.resources.IFile
@@ -10,6 +11,7 @@ import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.SubMonitor
+import org.eclipse.jdt.core.IJavaModelMarker
 import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.IScalaProject
 import org.scalaide.core.SdtConstants
@@ -60,7 +62,11 @@ class SbtScopesBuildManager(val owningProject: IScalaProject, managerSettings: S
     }
   }
 
-  override def buildErrors: Set[IMarker] = buildScopeUnits.flatMap { _.buildErrors }.toSet
+  private def foundJavaMarkers = owningProject.underlying.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE)
+  private def foundGlobalScalaMarkers = owningProject.underlying.findMarkers(SdtConstants.ProblemMarkerId, true, IResource.DEPTH_ZERO)
+  override def buildErrors: Set[IMarker] = buildScopeUnits.flatMap { _.buildErrors }.toSet ++
+    foundJavaMarkers ++
+    foundGlobalScalaMarkers
   override def invalidateAfterLoad: Boolean = true
   override def clean(implicit monitor: IProgressMonitor): Unit = buildScopeUnits.foreach { _.clean }
   override def canTrackDependencies: Boolean = true


### PR DESCRIPTION
Root problems marker messages should propagate to dependent projects
as well. Up to now when marker comes from java or is not associated
with any source folder so it is not rewrite as a root cause. This commit
fixes the scenario.