### PR TITLE
Don't call `removeAll` if widget is disposed

### DIFF
--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/views/AsyncDebugView.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/views/AsyncDebugView.scala
@@ -84,7 +84,8 @@ class AsyncDebugView extends AbstractDebugView with IDebugContextListener with H
    */
   def clearDebugView(): Unit = {
     setInputSafely(null)
-    viewer.getTable.removeAll()
+    if (!viewer.getTable.isDisposed())
+      viewer.getTable.removeAll()
     currentFrame = None
   }
 


### PR DESCRIPTION
Fix #1002630