### PR TITLE
Fix early initialization bug in AbstractMemberProposal

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/abstractimpl/AbstractMemberProposal.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/quickassist/abstractimpl/AbstractMemberProposal.scala
@@ -16,13 +16,13 @@ object AbstractMemberProposal {
   def apply(global: IScalaPresentationCompiler)(abstrMethod: global.MethodSymbol, impl: global.ImplDef)(
     icu: Option[InteractiveCompilationUnit], addMethodTarget: AddMethodTarget) = {
 
-    new AbstractMemberProposal {
+    new {
       override val compiler: global.type = global
       override val targetSourceFile = icu
       override val abstractMethod = abstrMethod
       override val implDef = impl
       override val target = addMethodTarget
-    }
+    } with AbstractMemberProposal
   }
 }
 


### PR DESCRIPTION
In the previous commit that changed that file I did a change which is
reverted by this commit. I thought that `new { ... } with X` is
equivalent to `new X { ... }`, which is not the case. The former uses
early initialization in order to set values in the trait `X`, whereas
the latter just overrides the values.

Fix #1002642