### PR TITLE
 Allow users to specify the spacing around block imports

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/UserPreferencesFormatting.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/UserPreferencesFormatting.scala
@@ -3,6 +3,8 @@ package org.scalaide.refactoring.internal
 import scala.tools.refactoring.Refactoring
 import org.scalaide.core.internal.ScalaPlugin
 import org.scalaide.ui.internal.preferences.EditorPreferencePage
+import org.scalaide.core.internal.formatter.FormatterPreferences._
+import scalariform.formatter.preferences._
 
 /**
  * Enables passing the user's source formatting preferences to the refactoring library's
@@ -17,6 +19,14 @@ trait UserPreferencesFormatting {
    */
   trait FormattingOverrides {
     this: Refactoring =>
+
+    override val defaultIndentationStep: String = {
+      val p = ScalaPlugin().getPreferenceStore
+      val indentWithTabs = p.getBoolean(IndentWithTabs.eclipseKey)
+      val spaces = p.getInt(IndentSpaces.eclipseKey)
+
+      if (indentWithTabs) "\t" else " "*spaces
+    }
 
     override val spacingAroundMultipleImports: String = {
       val addSpaces = ScalaPlugin().getPreferenceStore.getBoolean(EditorPreferencePage.SPACES_AROUND_IMPORT_BLOCKS)

--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/UserPreferencesFormatting.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/UserPreferencesFormatting.scala
@@ -1,6 +1,8 @@
 package org.scalaide.refactoring.internal
 
 import scala.tools.refactoring.Refactoring
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.ui.internal.preferences.EditorPreferencePage
 
 /**
  * Enables passing the user's source formatting preferences to the refactoring library's
@@ -16,8 +18,9 @@ trait UserPreferencesFormatting {
   trait FormattingOverrides {
     this: Refactoring =>
 
-    override val spacingAroundMultipleImports: String = " "
-
-    // TODO: Create more overrides here and in the refactoring library.
+    override val spacingAroundMultipleImports: String = {
+      val addSpaces = ScalaPlugin().getPreferenceStore.getBoolean(EditorPreferencePage.SPACES_AROUND_IMPORT_BLOCKS)
+      if (addSpaces) " " else ""
+    }
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/EditorPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/EditorPreferencePage.scala
@@ -65,6 +65,9 @@ class EditorPreferencePage extends PreferencePage with IWorkbenchPreferencePage 
 
     val outline = group("Outline", base)
     checkBox(P_INITIAL_IMPORT_FOLD, "Fold import nodes by default", outline)
+
+    val refactoring = group("Refactoring", base)
+    checkBox(SPACES_AROUND_IMPORT_BLOCKS, "Add spaces around braces in multi-import block", refactoring)
 }
 
   private def group(text: String, parent: Composite): Group = {
@@ -119,6 +122,8 @@ object EditorPreferencePage {
   final val INDENT_GUIDE_COLOR = BASE + "indentGuideColor"
   final val P_ENABLE_HOF_COMPLETION = BASE + "completionAlwaysLambdas"
   final val P_INITIAL_IMPORT_FOLD = BASE + "initialImportFold"
+
+  final val SPACES_AROUND_IMPORT_BLOCKS = BASE + "spacesAroundImportBlocks"
 }
 
 class EditorPreferenceInitializer extends AbstractPreferenceInitializer {
@@ -145,5 +150,7 @@ class EditorPreferenceInitializer extends AbstractPreferenceInitializer {
     store.setDefault(INDENT_GUIDE_COLOR, "72,72,72")
 
     store.setDefault(P_INITIAL_IMPORT_FOLD, true)
+
+    store.setDefault(SPACES_AROUND_IMPORT_BLOCKS, true)
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/EditorPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/EditorPreferencePage.scala
@@ -104,26 +104,24 @@ class EditorPreferencePage extends PreferencePage with IWorkbenchPreferencePage 
 }
 
 object EditorPreferencePage {
-  private final val BASE = "scala.tools.eclipse.editor."
+  final val P_ENABLE_AUTO_CLOSING_COMMENTS = "scala.tools.eclipse.editor.autoClosingComments"
+  final val P_ENABLE_AUTO_ESCAPE_LITERALS = "scala.tools.eclipse.editor.autoEscapeLiterals"
+  final val P_ENABLE_AUTO_ESCAPE_SIGN = "scala.tools.eclipse.editor.autoEscapeSign"
+  final val P_ENABLE_AUTO_REMOVE_ESCAPED_SIGN = "scala.tools.eclipse.editor.autoRemoveEscapedSign"
+  final val P_ENABLE_AUTO_INDENT_ON_TAB = "scala.tools.eclipse.editor.autoIndent"
+  final val P_ENABLE_AUTO_INDENT_MULTI_LINE_STRING = "scala.tools.eclipse.editor.autoIndentMultiLineString"
+  final val P_ENABLE_AUTO_STRIP_MARGIN_IN_MULTI_LINE_STRING = "scala.tools.eclipse.editor.autoStringMarginInMultiLineString"
+  final val P_ENABLE_AUTO_BREAKING_COMMENTS = "scala.tools.eclipse.editor.autoBreakingComments"
 
-  final val P_ENABLE_AUTO_CLOSING_COMMENTS = BASE + "autoClosingComments"
-  final val P_ENABLE_AUTO_ESCAPE_LITERALS = BASE + "autoEscapeLiterals"
-  final val P_ENABLE_AUTO_ESCAPE_SIGN = BASE + "autoEscapeSign"
-  final val P_ENABLE_AUTO_REMOVE_ESCAPED_SIGN = BASE + "autoRemoveEscapedSign"
-  final val P_ENABLE_AUTO_INDENT_ON_TAB = BASE + "autoIndent"
-  final val P_ENABLE_AUTO_INDENT_MULTI_LINE_STRING = BASE + "autoIndentMultiLineString"
-  final val P_ENABLE_AUTO_STRIP_MARGIN_IN_MULTI_LINE_STRING = BASE + "autoStringMarginInMultiLineString"
-  final val P_ENABLE_AUTO_BREAKING_COMMENTS = BASE + "autoBreakingComments"
+  final val P_ENABLE_MARK_OCCURRENCES = "scala.tools.eclipse.editor.markOccurences"
+  final val P_SHOW_INFERRED_SEMICOLONS = "scala.tools.eclipse.editor.showInferredSemicolons"
 
-  final val P_ENABLE_MARK_OCCURRENCES = BASE + "markOccurences"
-  final val P_SHOW_INFERRED_SEMICOLONS = BASE + "showInferredSemicolons"
+  final val INDENT_GUIDE_ENABLE = "scala.tools.eclipse.editor.indentGuideEnable"
+  final val INDENT_GUIDE_COLOR = "scala.tools.eclipse.editor.indentGuideColor"
+  final val P_ENABLE_HOF_COMPLETION = "scala.tools.eclipse.editor.completionAlwaysLambdas"
+  final val P_INITIAL_IMPORT_FOLD = "scala.tools.eclipse.editor.initialImportFold"
 
-  final val INDENT_GUIDE_ENABLE = BASE + "indentGuideEnable"
-  final val INDENT_GUIDE_COLOR = BASE + "indentGuideColor"
-  final val P_ENABLE_HOF_COMPLETION = BASE + "completionAlwaysLambdas"
-  final val P_INITIAL_IMPORT_FOLD = BASE + "initialImportFold"
-
-  final val SPACES_AROUND_IMPORT_BLOCKS = BASE + "spacesAroundImportBlocks"
+  final val SPACES_AROUND_IMPORT_BLOCKS = "scala.tools.eclipse.editor.spacesAroundImportBlocks"
 }
 
 class EditorPreferenceInitializer extends AbstractPreferenceInitializer {


### PR DESCRIPTION
A new preference option is added to the Scala > Editor preference page,
which allows users to configure if they want to see spaces around a
block import. The default configuration is that the spaces are added,
because this is the behavior of scalariform (whose behavior is hardcoded
and can't be changed).

Fix #1001692