### PR TITLE
Add Mars profile for building

### DIFF
--- a/org.scala-ide.sdt.aspects/src-mars/scala/tools/eclipse/contribution/weaving/jdt/cfprovider/ClassFileProviderAspect.aj
+++ b/org.scala-ide.sdt.aspects/src-mars/scala/tools/eclipse/contribution/weaving/jdt/cfprovider/ClassFileProviderAspect.aj
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2005-2010 LAMP/EPFL
+ */
+// $Id$
+
+package scala.tools.eclipse.contribution.weaving.jdt.cfprovider;
+
+import java.util.HashSet;
+
+import org.eclipse.core.filebuffers.FileBuffers;
+import org.eclipse.core.filebuffers.ITextFileBuffer;
+import org.eclipse.core.filebuffers.ITextFileBufferManager;
+import org.eclipse.core.filebuffers.LocationKind;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.IImportDeclaration;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.search.TypeNameMatch;
+import org.eclipse.jdt.internal.compiler.CompilationResult;
+import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.ImportReference;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.env.IBinaryType;
+import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+import org.eclipse.jdt.internal.compiler.env.IGenericType;
+import org.eclipse.jdt.internal.compiler.env.ISourceImport;
+import org.eclipse.jdt.internal.compiler.env.ISourceType;
+import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
+import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
+import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
+import org.eclipse.jdt.internal.compiler.parser.Parser;
+import org.eclipse.jdt.internal.compiler.parser.SourceTypeConverter;
+import org.eclipse.jdt.internal.core.BinaryType;
+import org.eclipse.jdt.internal.core.ClassFile;
+import org.eclipse.jdt.internal.core.CompilationUnitElementInfo;
+import org.eclipse.jdt.internal.core.ImportDeclaration;
+import org.eclipse.jdt.internal.core.JavaElement;
+import org.eclipse.jdt.internal.core.BufferManager;
+import org.eclipse.jdt.internal.core.NameLookup;
+import org.eclipse.jdt.internal.core.Openable;
+import org.eclipse.jdt.internal.core.PackageFragment;
+import org.eclipse.jdt.internal.core.SearchableEnvironment;
+import org.eclipse.jdt.internal.core.SourceMapper;
+import org.eclipse.jdt.internal.core.SourceType;
+import org.eclipse.jdt.internal.core.SourceTypeElementInfo;
+import org.eclipse.jdt.internal.core.hierarchy.HierarchyResolver;
+import org.eclipse.jdt.internal.core.hierarchy.HierarchyType;
+import org.eclipse.jdt.internal.core.util.Util;
+import org.eclipse.jdt.internal.corext.util.OpenTypeHistory;
+import org.eclipse.jdt.internal.ui.filters.InnerClassFilesFilter;
+import org.eclipse.jdt.ui.SharedASTProvider;
+import org.eclipse.jface.viewers.Viewer;
+
+import scala.tools.eclipse.contribution.weaving.jdt.IScalaClassFile;
+import scala.tools.eclipse.contribution.weaving.jdt.IScalaElement;
+
+@SuppressWarnings("restriction")
+public privileged aspect ClassFileProviderAspect {
+
+  pointcut classFileCreations(PackageFragment parent, String name) : 
+    call(protected ClassFile.new(PackageFragment, String)) &&
+    within(org.eclipse.jdt..*) &&
+    args(parent, name);
+  
+  pointcut getTypeName(ClassFile cf) :
+    execution(public String ClassFile.getTypeName()) &&
+    target(cf);
+
+  // For 3.6
+  pointcut mapSource(ClassFile cf, SourceMapper mapper, IBinaryType info, IClassFile owner) :
+    execution(IBuffer ClassFile.mapSource(SourceMapper, IBinaryType, IClassFile)) &&
+    target(cf) &&
+    target(IScalaClassFile) &&
+    args(mapper, info, owner);
+
+  // For 3.5
+  pointcut mapSource2(ClassFile cf, SourceMapper mapper, IBinaryType info) :
+    execution(IBuffer ClassFile.mapSource(SourceMapper, IBinaryType)) &&
+    target(cf) &&
+    target(IScalaClassFile) &&
+    args(mapper, info);
+
+  pointcut getSourceFileName(BinaryType bt) :
+    execution(String BinaryType.getSourceFileName(IBinaryType)) &&
+    target(bt);
+  
+  pointcut select(Viewer viewer, Object parentElement, Object element) :
+    execution(boolean InnerClassFilesFilter.select(Viewer, Object, Object)) &&
+    args(viewer, parentElement, element);
+  
+  pointcut getChildren(BinaryType bt) :
+    execution(IJavaElement[] BinaryType.getChildren()) &&
+    target(bt);
+  
+  pointcut getAST(ITypeRoot element, SharedASTProvider.WAIT_FLAG waitFlag, IProgressMonitor progressMonitor) : 
+    execution(CompilationUnit SharedASTProvider.getAST(ITypeRoot, SharedASTProvider.WAIT_FLAG, IProgressMonitor)) &&
+    args(element, waitFlag, progressMonitor);
+  
+  pointcut resolve(HierarchyResolver hr, IGenericType suppliedType) :
+    execution(void HierarchyResolver.resolve(IGenericType)) &&
+    target(hr) &&
+    args(suppliedType);
+  
+  pointcut acceptType(IType type, int acceptFlags, boolean isSourceType) :
+    execution(boolean NameLookup.acceptType(IType, int, boolean)) &&
+    args(type, acceptFlags, isSourceType);
+  
+  pointcut find(SearchableEnvironment se, String typeName, String packageName) :
+    execution(NameEnvironmentAnswer find(String, String)) &&
+    target(se) &&
+    args(typeName, packageName);
+  
+  pointcut convert(SourceTypeConverter stc, ISourceType[] sourceTypes, CompilationResult compilationResult) :
+    execution(CompilationUnitDeclaration SourceTypeConverter.convert(ISourceType[], CompilationResult)) &&
+    target(stc) &&
+    args(sourceTypes, compilationResult);
+  
+  pointcut getAncestor(JavaElement je, int ancestorType) :
+    execution(IJavaElement JavaElement.getAncestor(int)) &&
+    target(je) &&
+    args(ancestorType);
+  
+  pointcut isContainerDirty(TypeNameMatch match) :
+    execution(boolean OpenTypeHistory.isContainerDirty(TypeNameMatch)) &&
+    args(match);
+  
+  ClassFile around(PackageFragment parent, String name) : 
+    classFileCreations(parent, name) {
+
+    ClassFile javaClassFile = proceed(parent, name);
+    byte[] bytes;
+    
+    try {
+        for (IClassFileProvider provider : ClassFileProviderRegistry.getInstance().getProviders()) {
+          if (provider.isInteresting(javaClassFile)) {
+            bytes = javaClassFile.getBytes();
+            ClassFile cf = provider.create(bytes, parent, name);
+            if (cf != null)
+              return cf;
+          }
+        }
+    } catch(Throwable t) {
+      return javaClassFile; 
+    }
+    
+    return javaClassFile;
+  }
+  
+  IBuffer around(ClassFile cf, SourceMapper mapper, IBinaryType info, IClassFile owner) :
+    mapSource(cf, mapper, info, owner) {
+    return mapSourceSubst(cf, mapper, info);
+  }
+
+  IBuffer around(ClassFile cf, SourceMapper mapper, IBinaryType info) :
+    mapSource2(cf, mapper, info) {
+    return mapSourceSubst(cf, mapper, info);
+  }
+
+  IBuffer mapSourceSubst(ClassFile cf, SourceMapper mapper, IBinaryType info) {
+    char[] contents = mapper.findSource(cf.getType(), info);
+    IBuffer buffer;
+    if (contents != null) {
+      buffer = BufferManager.createBuffer(cf);
+      buffer.setContents(contents);
+    } else {
+      buffer = BufferManager.createNullBuffer(cf);
+    }
+    BufferManager bufManager = cf.getBufferManager();
+    bufManager.addBuffer(buffer);
+    buffer.addBufferChangedListener(cf);
+    return buffer;
+  }
+
+  String around(ClassFile cf) :
+    getTypeName(cf) {
+    if(cf instanceof IScalaClassFile) {
+      int lastDollar = cf.name.lastIndexOf('$');
+      return (lastDollar == -1 || lastDollar == cf.name.length()-1) ? cf.name : Util.localTypeName(cf.name, lastDollar, cf.name.length());
+    } else
+      return proceed(cf);
+  }
+  
+  boolean around(Viewer viewer, Object parentElement, Object element) :
+    select(viewer, parentElement, element) {
+    if (element instanceof IScalaClassFile) {
+      IClassFile classFile = (IClassFile) element;
+      String name = classFile.getElementName(); 
+      int dollarIndex = name.indexOf('$');
+      return dollarIndex == -1 || dollarIndex == name.length()-7; // Trailing '$' implies object rather than inner class 
+    }
+    return proceed(viewer, parentElement, element);
+  }
+  
+  IJavaElement[] around(BinaryType bt) throws JavaModelException :
+    getChildren(bt) && 
+    target(BinaryType) {
+    ClassFile cf = (ClassFile)bt.parent;
+    if (cf instanceof IScalaClassFile)
+      return cf.getChildren();
+    else
+      return proceed(bt);
+  }
+  
+  CompilationUnit around(ITypeRoot element, SharedASTProvider.WAIT_FLAG waitFlag, IProgressMonitor progressMonitor) :
+    getAST(element, waitFlag, progressMonitor) {
+      if (element instanceof IScalaElement)
+        return null;
+      else
+        return proceed(element, waitFlag, progressMonitor);
+  }
+  
+  void around(HierarchyResolver hr, IGenericType suppliedType) :
+    resolve(hr, suppliedType) {
+    if (!suppliedType.isBinaryType()) {
+      IType tpe = ((SourceTypeElementInfo)suppliedType).getHandle();
+      IClassFile cf = tpe.getClassFile();
+      if (cf instanceof IScalaClassFile) {
+        hr.resolve(new Openable[]{(Openable)cf}, new HashSet(), null);
+        return;
+      }
+    }
+      
+    proceed(hr, suppliedType);
+  }
+  
+  String around(BinaryType bt) :
+    getSourceFileName(bt) {
+    IJavaElement parent = bt.getTypeRoot(); 
+    if (parent instanceof IScalaClassFile) {
+      return ((IScalaClassFile)parent).getSourceFileName();
+    }
+    else
+      return proceed(bt);
+  }
+  
+  boolean around(IType type, int acceptFlags, boolean isSourceType) :
+    acceptType(type, acceptFlags, isSourceType) {
+    if (!isSourceType && (type instanceof SourceType)) {
+      IJavaElement parent = type.getParent(); 
+      if (parent instanceof IScalaClassFile)
+        return proceed(type, acceptFlags, true);
+    }
+    
+    return proceed(type, acceptFlags, isSourceType);
+  }
+  
+  CompilationUnitDeclaration around(SourceTypeConverter stc, ISourceType[] sourceTypes, CompilationResult compilationResult) throws JavaModelException :
+    convert(stc, sourceTypes, compilationResult) {
+    stc.unit = new CompilationUnitDeclaration(stc.problemReporter, compilationResult, 0);
+    // not filled at this point
+
+    if (sourceTypes.length == 0 || sourceTypes[0] == null) return stc.unit;
+    SourceTypeElementInfo topLevelTypeInfo = (SourceTypeElementInfo) sourceTypes[0];
+    org.eclipse.jdt.core.ICompilationUnit cuHandle = topLevelTypeInfo.getHandle().getCompilationUnit();
+    stc.cu = (ICompilationUnit) cuHandle;
+
+    CompilationUnitElementInfo cuei = null;
+    Object info = ((JavaElement)stc.cu).getElementInfo();
+    if (info instanceof CompilationUnitElementInfo)
+      cuei = (CompilationUnitElementInfo)info;
+    
+    
+    if (stc.has1_5Compliance && cuei != null && cuei.annotationNumber > 10) { // experimental value
+      // if more than 10 annotations, diet parse as this is faster
+      return new Parser(stc.problemReporter, true).dietParse(stc.cu, compilationResult);
+    }
+
+    /* only positions available */
+    int start = topLevelTypeInfo.getNameSourceStart();
+    int end = topLevelTypeInfo.getNameSourceEnd();
+
+    /* convert package and imports */
+    String[] packageName = ((PackageFragment) cuHandle.getParent()).names;
+    if (packageName.length > 0)
+      // if its null then it is defined in the default package
+      stc.unit.currentPackage =
+        stc.createImportReference(packageName, start, end, false, ClassFileConstants.AccDefault);
+    IImportDeclaration[] importDeclarations = topLevelTypeInfo.getHandle().getCompilationUnit().getImports();
+    int importCount = importDeclarations.length;
+    stc.unit.imports = new ImportReference[importCount];
+    for (int i = 0; i < importCount; i++) {
+      ImportDeclaration importDeclaration = (ImportDeclaration) importDeclarations[i];
+      ISourceImport sourceImport = (ISourceImport) importDeclaration.getElementInfo();
+      String nameWithoutStar = importDeclaration.getNameWithoutStar();
+      stc.unit.imports[i] = stc.createImportReference(
+        Util.splitOn('.', nameWithoutStar, 0, nameWithoutStar.length()),
+        sourceImport.getDeclarationSourceStart(),
+        sourceImport.getDeclarationSourceEnd(),
+        importDeclaration.isOnDemand(),
+        sourceImport.getModifiers());
+    }
+    /* convert type(s) */
+    try {
+      int typeCount = sourceTypes.length;
+      final TypeDeclaration[] types = new TypeDeclaration[typeCount];
+      /*
+       * We used a temporary types collection to prevent this.unit.types from being null during a call to
+       * convert(...) when the source is syntactically incorrect and the parser is flushing the unit's types.
+       * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=97466
+       */
+      for (int i = 0; i < typeCount; i++) {
+        SourceTypeElementInfo typeInfo = (SourceTypeElementInfo) sourceTypes[i];
+        types[i] = stc.convert((SourceType) typeInfo.getHandle(), compilationResult);
+      }
+      stc.unit.types = types;
+      return stc.unit;
+    } catch (SourceTypeConverter.AnonymousMemberFound e) {
+      return new Parser(stc.problemReporter, true).parse(stc.cu, compilationResult);
+    }
+  }
+  
+  IJavaElement around(JavaElement je, int ancestorType) :
+    getAncestor(je, ancestorType) {
+    IJavaElement element = je;
+    while (element != null) {
+      if (element.getElementType() == ancestorType)
+        return element;
+      else if (element instanceof IScalaClassFile && ancestorType == IJavaElement.COMPILATION_UNIT)
+        return ((JavaElement)element).getCompilationUnit();
+      element= element.getParent();
+    }
+    return null;
+  }
+
+  boolean around(TypeNameMatch match) :
+    isContainerDirty(match) {
+    org.eclipse.jdt.core.ICompilationUnit cu = match.getType().getCompilationUnit();
+    if (cu == null) {
+      return false;
+    }
+    IResource resource= cu.getResource();
+    if (resource == null)
+      return false;
+    
+    ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
+    ITextFileBuffer textFileBuffer= manager.getTextFileBuffer(resource.getFullPath(), LocationKind.IFILE);
+    if (textFileBuffer != null) {
+      return textFileBuffer.isDirty();
+    }
+    return false;
+  }
+}

--- a/org.scala-ide.sdt.core/src-mars/org/scalaide/core/internal/jdt/util/JDTUtils.scala
+++ b/org.scala-ide.sdt.core/src-mars/org/scalaide/core/internal/jdt/util/JDTUtils.scala
@@ -1,0 +1,114 @@
+package org.scalaide.core.internal.jdt.util
+
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IFolder
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.runtime.CoreException
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.core.runtime.Status
+import org.eclipse.jdt.core.IClasspathEntry
+import org.eclipse.jdt.core.IJavaElement
+import org.eclipse.jdt.core.IPackageFragment
+import org.eclipse.jdt.core.IType
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.core.JavaModelException
+import org.eclipse.jdt.internal.core.ImportContainerInfo
+import org.eclipse.jdt.internal.core.JavaModelManager
+import org.eclipse.jdt.internal.core.NameLookup
+import org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart
+import org.eclipse.ui.progress.UIJob
+import org.scalaide.util.internal.ReflectionUtils
+import org.scalaide.core.internal.project.ScalaProject
+
+object JDTUtils {
+  private var refreshPending = false
+  private val lock = new Object
+
+  def refreshPackageExplorer() = {
+    lock.synchronized{
+      if (!refreshPending) {
+        refreshPending = true
+        new UIJob("Refresh package explorer") {
+          def runInUIThread(monitor : IProgressMonitor) : IStatus  = {
+            lock.synchronized {
+              refreshPending = false
+            }
+            val pep = PackageExplorerPart.getFromActivePerspective
+            if (pep != null)
+              pep.getTreeViewer.refresh()
+            Status.OK_STATUS
+          }
+        }.schedule
+      }
+    }
+  }
+
+  def resolveType(nameLookup : NameLookup, packageName : String, typeName : String, acceptFlags : Int) : Option[IType] = {
+    val pkgs = nameLookup.findPackageFragments(packageName, false)
+    for(p <- pkgs) {
+      val tpe = nameLookup.findType(typeName, p, false, acceptFlags, true, true)
+      if (tpe != null)
+        return Some(tpe)
+    }
+
+    return None
+  }
+
+  def getParentPackage(scalaFile : IFile) : IPackageFragment = {
+    val jp = JavaCore.create(scalaFile.getProject)
+    val pkg = JavaModelManager.determineIfOnClasspath(scalaFile, jp)
+    if (pkg != null && pkg.isInstanceOf[IPackageFragment])
+      pkg.asInstanceOf[IPackageFragment]
+    else {
+      // Not on classpath so use the default package
+      val root = jp.getPackageFragmentRoot(scalaFile.getParent)
+      root.getPackageFragment(IPackageFragment.DEFAULT_PACKAGE_NAME)
+    }
+  }
+
+  def flattenProject(project : IProject) : Iterator[IFile] = {
+    try {
+      if (!ScalaProject.isScalaProject(project))
+        return Iterator.empty
+
+      val jp = JavaCore.create(project)
+      jp.getRawClasspath.filter(_.getEntryKind == IClasspathEntry.CPE_SOURCE).
+        iterator.flatMap(entry => flatten(ResourcesPlugin.getWorkspace.getRoot.findMember(entry.getPath)))
+    } catch {
+      case _ : JavaModelException => Iterator.empty
+    }
+  }
+
+  def flatten(r : IResource) : Iterator[IFile] = {
+    try {
+      r match {
+        case r if r == null || !r.exists => Iterator.empty
+        case folder : IFolder if folder.getType == IResource.FOLDER => folder.members.iterator.flatMap{flatten _}
+        case file : IFile if file.getType == IResource.FILE && file.getFileExtension == "scala" => Iterator.single(file)
+        case _ => Iterator.empty
+      }
+    } catch {
+      case _ : CoreException => Iterator.empty
+    }
+  }
+}
+
+object SourceRefElementInfoUtils extends ReflectionUtils {
+  private val sreiClazz = Class.forName("org.eclipse.jdt.internal.core.SourceRefElementInfo")
+  private val setSourceRangeStartMethod = getDeclaredMethod(sreiClazz, "setSourceRangeStart", classOf[Int])
+  private val setSourceRangeEndMethod = getDeclaredMethod(sreiClazz, "setSourceRangeEnd", classOf[Int])
+
+  def setSourceRangeStart(srei : AnyRef, pos : Int) = setSourceRangeStartMethod.invoke(srei, new Integer(pos))
+  def setSourceRangeEnd(srei : AnyRef, pos : Int) = setSourceRangeEndMethod.invoke(srei, new Integer(pos))
+}
+
+object ImportContainerInfoUtils extends ReflectionUtils {
+  private val iciClazz = classOf[ImportContainerInfo]
+  private val childrenField = getDeclaredField(iciClazz, "children")
+
+  def setChildren(ic : ImportContainerInfo, children : Array[IJavaElement]): Unit = { childrenField.set(ic, children) }
+  def getChildren(ic : ImportContainerInfo) = childrenField.get(ic).asInstanceOf[Array[IJavaElement]]
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/CompilationUnitAdapter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/CompilationUnitAdapter.scala
@@ -39,7 +39,7 @@ import org.eclipse.text.edits.UndoEdit
 import org.scalaide.util.internal.Suppress
 
 class CompilationUnitAdapter(classFile : ScalaClassFile) extends Openable(classFile.getParent.asInstanceOf[JavaElement]) with ICompilationUnit with env.ICompilationUnit {
-  override def getAdapter(adapter : Class[_]) : AnyRef = (classFile : IAdaptable).getAdapter(adapter)
+  override def getAdapter[T](adapter : Class[T]): T = (classFile : IAdaptable).getAdapter(adapter)
 
   override def equals(o : Any) = classFile.equals(o)
   override def hashCode() = classFile.hashCode()
@@ -223,6 +223,6 @@ object CompilationUnitAdapter {
     override def getAttachedJavadoc(monitor: IProgressMonitor): String = throw new UnsupportedOperationException
     override def getAncestor(ancestorType: Int): IJavaElement = throw new UnsupportedOperationException
 
-    override def getAdapter(adapter: Class[_]): AnyRef = throw new UnsupportedOperationException
+    override def getAdapter[T](adapter: Class[T]): T = throw new UnsupportedOperationException
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaRetargettableActionAdapterFactory.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaRetargettableActionAdapterFactory.scala
@@ -6,13 +6,13 @@ import org.eclipse.debug.ui.actions.IToggleBreakpointsTarget
 import org.eclipse.jdt.internal.debug.ui.actions.RunToLineAdapter
 
 class ScalaRetargettableActionAdapterFactory extends IAdapterFactory {
-  override def getAdapter(adaptableObject : AnyRef, adapterType : Class[_]) =
-    if (adapterType == classOf[IRunToLineTarget])
+  override def getAdapter[T](adaptableObject: Any, adapterType : Class[T]): T =
+    (if (adapterType == classOf[IRunToLineTarget])
       new RunToLineAdapter
     else if (adapterType == classOf[IToggleBreakpointsTarget])
       new ScalaToggleBreakpointAdapter
     else
-      null
+      null).asInstanceOf[T]
 
   override def getAdapterList : Array[Class[_]] =
     Array(classOf[IRunToLineTarget], classOf[IToggleBreakpointsTarget])

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
@@ -36,6 +36,8 @@ import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.texteditor.IAbstractTextEditorHelpContextIds
 import org.eclipse.ui.texteditor.ITextEditorActionConstants
 import org.eclipse.ui.texteditor.TextOperationAction
+import org.eclipse.ui.part.WorkbenchPart
+
 import org.scalaide.core.internal.ScalaPlugin
 import org.scalaide.core.internal.extensions.SemanticHighlightingParticipants
 import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
@@ -402,7 +404,7 @@ class ScalaSourceFileEditor
     }
 
     override def smartBackspaceManager: SmartBackspaceManager =
-      self.getAdapter(classOf[SmartBackspaceManager]).asInstanceOf[SmartBackspaceManager]
+      (self: WorkbenchPart).getAdapter(classOf[SmartBackspaceManager]).asInstanceOf[SmartBackspaceManager]
 
     /** Calls auto edits and if they produce no changes the super implementation. */
     override def handleVerifyEvent(e: VerifyEvent): Unit = {

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/SocketListenConnectorScala.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/launching/SocketListenConnectorScala.scala
@@ -128,7 +128,7 @@ class ListenForConnectionProcess private (launch: ILaunch, port: Int) extends IP
 
   // -- from org.eclipse.core.runtime.IAdaptable
 
-  def getAdapter(adapter: Class[_]): Object = null
+  override def getAdapter[T](adapter: Class[T]): T = null.asInstanceOf[T]
 
   // ----------
 

--- a/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugElement.scala
+++ b/org.scala-ide.sdt.debug/src/org/scalaide/debug/internal/model/ScalaDebugElement.scala
@@ -25,11 +25,10 @@ import scala.util.control.Exception.Catch
 abstract class ScalaDebugElement(debugTarget: ScalaDebugTarget) extends DebugElement(debugTarget) with ITerminate with HasLogger {
 
   // Members declared in org.eclipse.core.runtime.IAdaptable
-
-  override def getAdapter(adapter: Class[_]): Object = {
+  override def getAdapter[T](adapter: Class[T]): T = {
     adapter match {
       case ScalaDebugger.classIDebugModelProvider =>
-        modelProvider
+        modelProvider.asInstanceOf[T]
       case _ =>
         super.getAdapter(adapter)
     }

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,12 @@
     <repo.eclipse.juno>http://download.eclipse.org/releases/juno</repo.eclipse.juno>
     <repo.eclipse.kepler>http://download.eclipse.org/releases/kepler</repo.eclipse.kepler>
     <repo.eclipse.luna>http://download.eclipse.org/releases/luna</repo.eclipse.luna>
+    <repo.eclipse.mars>http://download.eclipse.org/releases/mars</repo.eclipse.mars>
     <repo.ajdt.indigo>http://download.eclipse.org/tools/ajdt/37/update</repo.ajdt.indigo>
     <repo.ajdt.juno>http://download.eclipse.org/tools/ajdt/42/update</repo.ajdt.juno>
     <repo.ajdt.kepler>http://download.eclipse.org/tools/ajdt/43/update</repo.ajdt.kepler>
     <repo.ajdt.luna>http://download.eclipse.org/tools/ajdt/44/dev/update</repo.ajdt.luna>
+    <repo.ajdt.mars>http://download.eclipse.org/tools/ajdt/45/dev/update</repo.ajdt.mars>
     <repo.equinox.launcher>http://downloads.typesafe.com/scalaide/plugins/equinox-weaving-launcher/releases/site</repo.equinox.launcher>
     <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
     <repo.nebula>http://download.eclipse.org/technology/nebula/snapshot</repo.nebula>
@@ -42,8 +44,8 @@
     <!-- plugin versions -->
     <tycho.plugin.version>0.21.0</tycho.plugin.version>
     <scala.plugin.version>3.2.0</scala.plugin.version>
-    <aspectj.plugin.version>1.7</aspectj.plugin.version>
-    <aspectj.version>1.8.2</aspectj.version>
+    <aspectj.plugin.version>1.8</aspectj.plugin.version>
+    <aspectj.version>1.8.7</aspectj.version>
     <maven-bundle.plugin.version>2.3.7</maven-bundle.plugin.version>
     <properties-maven.plugin.version>1.1.10</properties-maven.plugin.version>
     <buildnumber-maven.plugin.version>1.1</buildnumber-maven.plugin.version>
@@ -176,6 +178,18 @@
         <repo.ajdt>${repo.ajdt.luna}</repo.ajdt>
         <jdt.core.version.range>[3.10.0,4.0.0)</jdt.core.version.range>
         <weaving.hook.plugin.version>1.1.100.weaving-hook-20140821</weaving.hook.plugin.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- Eclipse Mars -->
+      <id>eclipse-mars</id>
+      <properties>
+        <eclipse.codename>mars</eclipse.codename>
+        <repo.eclipse>${repo.eclipse.mars}</repo.eclipse>
+        <repo.ajdt>${repo.ajdt.mars}</repo.ajdt>
+        <jdt.core.version.range>[3.10.0,4.0.0)</jdt.core.version.range>
+        <weaving.hook.plugin.version>1.1.100.v20140821-1915</weaving.hook.plugin.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
This makes the IDE compile under Eclipse 4.5 (Mars).

- added `eclipse-mars` profile in pom.xml, with proper dependency on the weaving.hook
- source changes for making it compile with Mars
- duplicated sources from `src-luna` to `src-mars` in the `sdt.core` and `sdt.aspects` projects

- [ ] check if we need to keep different source folders, or we can drop Luna altogether (maybe the build is binary compatible?)