### PR TITLE
Increase timeout for Futures in test suite

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/util/TestFutureUtil.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/util/TestFutureUtil.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.DurationInt
 object TestFutureUtil {
   import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.duration._
-  val DefaultTimeout = 200 millis
+  val DefaultTimeout = 1000 millis
 
   def whenReady[T](future: => Future[T], timeout: Duration = DefaultTimeout)(withal: T => Unit): Unit =
     withal(Await.result(future, timeout))


### PR DESCRIPTION
The Scala testing machine seems to be slower than our own machine (or
they have more load than we have). It happened now multiple times that
tests failed because of a timeout. Increasing the timeout should fix the
problem.

See for example

  https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-ide/2195/console