### PR TITLE
Do not use maven.build.timestamp for OSGi version of sbt project

### DIFF
--- a/org.scala-ide.build-toolchain/pom.xml
+++ b/org.scala-ide.build-toolchain/pom.xml
@@ -13,10 +13,17 @@
   <packaging>pom</packaging>
   <version>4.5.0-SNAPSHOT</version>
 
+  <!-- scm configuration is required to extract the github hash-->
+  <scm>
+    <connection>scm:git://github.com/scala-ide/scala-ide.git</connection>
+    <url>https://github.com/scala-ide/scala-ide</url>
+  </scm>
+
   <properties>
     <sbt.ide.version>${sbt.version}-on-${scala.version}-for-IDE-SNAPSHOT</sbt.ide.version>
-    <sbt.osgi.version>${sbt.version}.${version.tag}-${version.suffix}-${maven.build.timestamp}</sbt.osgi.version>
-    <sbt.osgi.light.version>${sbt.version}.${version.tag}-${maven.build.timestamp}</sbt.osgi.light.version>
+    <sbt.osgi.version>${sbt.version}.${version.tag}-${version.suffix}-${maven.build.timestamp}-${buildNumber}</sbt.osgi.version>
+    <sbt.osgi.light.version>${sbt.version}.${version.tag}-${maven.build.timestamp}-${buildNumber}</sbt.osgi.light.version>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
   </properties>
 
   <!-- repository containing the sbt packages -->
@@ -28,6 +35,28 @@
     </repository>
   </repositories>
 
+  <build>
+    <plugins>
+      <plugin>
+        <!-- plugin used to extract the git hash and store it in ${buildNumber} -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <doCheck>false</doCheck>
+          <doUpdate>false</doUpdate>
+          <shortRevisionLength>7</shortRevisionLength>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/org.scala-ide.sdt.build/pom.xml
+++ b/org.scala-ide.sdt.build/pom.xml
@@ -11,7 +11,7 @@
   <packaging>pom</packaging>
   <version>4.5.0-SNAPSHOT</version>
 
-  <!-- scm configuration is require to extract the github hash-->
+  <!-- scm configuration is required to extract the github hash-->
   <scm>
     <connection>scm:git://github.com/scala-ide/scala-ide.git</connection>
     <url>https://github.com/scala-ide/scala-ide</url>


### PR DESCRIPTION
Normally the usage of `maven.build.timestamp` seems to result in a
correct OSGi version but as the ticket shows, it also can result in an
invalid version. The problem is fixed by hardcoding the format of the
generated timestamp to `yyyyMMddHHmm`. Furthermore we also append the
short git hash to the version. The git hash is not required but may make
it easier to find out against which sources the plugin is built.

Fix #1002667

Review by @dragos