### PR TITLE
Use typesafe URL to resolve scalariform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 
     <!-- the repos containing the Scala dependencies -->
     <repo.scala-refactoring>https://oss.sonatype.org/content/repositories/snapshots</repo.scala-refactoring>
-    <repo.scalariform>${repo.scala-ide.root}/scalariform-${scala.short.version}x</repo.scalariform>
+    <repo.scalariform>http://downloads.typesafe.com/scalaide/scalariform-${scala.short.version}x</repo.scalariform>
     <repo.typesafe>https://proxy-ch.typesafe.com:8082/artifactory/ide-${scala.minor.version}</repo.typesafe>
 
   </properties>


### PR DESCRIPTION
The redirect from scala-ide.org to typesafe.com is not correctly
configured.