### PR TITLE
Consider enclosing classes when adding types to the index

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/CompilerSupportTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/CompilerSupportTests.scala
@@ -10,6 +10,9 @@ import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
 import org.scalaide.core.testsetup.SDTTestUtils
 import org.scalaide.core.IScalaProject
 import java.util.UUID
+import scala.tools.refactoring.util.UniqueNames
+import org.scalaide.core.testsetup.BlockingProgressMonitor
+import org.eclipse.core.resources.IResource
 
 /**
  * Common functionality to be used in tests that need to interop with the
@@ -25,12 +28,13 @@ trait CompilerSupportTests {
   /** Can be overwritten in a subclass if desired. */
   val projectName: String = getClass().getSimpleName()
 
-  private val project: IScalaProject = SDTTestUtils.createProjectInWorkspace(projectName)
+  protected final val project: IScalaProject = SDTTestUtils.createProjectInWorkspace(projectName)
 
-  final def withCompiler(f: IScalaPresentationCompiler => Unit): Unit =
+  final def withCompiler[T](f: IScalaPresentationCompiler => T): Option[T] = {
     project.presentationCompiler { compiler =>
       f(compiler)
     }
+  }
 
   /**
    * Creates a Scala compilation unit whose underlying source file physically
@@ -53,10 +57,10 @@ trait CompilerSupportTests {
     val PkgFinder = """(?s).*?package ([\w\.]+).*?""".r
     val pkgName = source match {
       case PkgFinder(name) ⇒ name
-      case _ ⇒ uniquePkgName()
+      case _ ⇒ UniqueNames.scalaPackage()
     }
     val p = SDTTestUtils.createSourcePackage(pkgName)(project)
-    SDTTestUtils.createCompilationUnit(p, "testfile.scala", source, force).asInstanceOf[ScalaCompilationUnit]
+    SDTTestUtils.createCompilationUnit(p, UniqueNames.scalaFile(), source, force).asInstanceOf[ScalaCompilationUnit]
   }
 
   /**
@@ -110,21 +114,9 @@ trait CompilerSupportTests {
     SDTTestUtils.deleteProjects(project)
 
   /**
-   * Generates a package name that is guaranteed to be unique.
-   */
-  final def uniquePkgName(): String = {
-    def longToName(l: Long) = {
-      java.lang.Long.toString(l, Character.MAX_RADIX).replace("-", "_")
-    }
-
-    val uid = UUID.randomUUID()
-    "uniquepkg" + longToName(uid.getLeastSignificantBits) + longToName(uid.getMostSignificantBits)
-  }
-
-  /**
    * Adds a unique package declaration at the beginning of the given source.
    */
   final def addUniquePkgDecl(src: String): String = {
-    s"package ${uniquePkgName()}\n\n$src"
+    s"package ${UniqueNames.scalaPackage()}\n\n$src"
   }
 }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/CompilerSupportTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/CompilerSupportTests.scala
@@ -9,10 +9,7 @@ import org.scalaide.core.compiler.IScalaPresentationCompiler
 import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
 import org.scalaide.core.testsetup.SDTTestUtils
 import org.scalaide.core.IScalaProject
-import java.util.UUID
 import scala.tools.refactoring.util.UniqueNames
-import org.scalaide.core.testsetup.BlockingProgressMonitor
-import org.eclipse.core.resources.IResource
 
 /**
  * Common functionality to be used in tests that need to interop with the

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/TextEditTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/TextEditTests.scala
@@ -85,7 +85,9 @@ abstract class TextEditTests {
 
   final implicit class StringAsTest(input: String) {
     def becomes(expectedOutput: String) = input -> expectedOutput
+    def isNotModified = input -> input
   }
+
   final implicit class TestExecutor(testData: (String, String)) {
     def after(operation: Operation, marker: Char = '$') = test(testData._1, testData._2, operation, marker)
   }

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTestSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTestSuite.scala
@@ -9,6 +9,7 @@ import org.junit.runners.Suite
     classOf[AccessibilityTests],
     classOf[StandardCompletionTests],
     classOf[ParameterCompletionTests],
+    classOf[TypeCompletionTests],
     classOf[CompletionOrderTests]
 ))
 class CompletionTestSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTests.scala
@@ -6,14 +6,9 @@ import org.scalaide.core.ui.CompilerSupport
 import org.scalaide.core.ui.TextEditTests
 import org.scalaide.util.ScalaWordFinder
 import org.scalaide.core.completion.CompletionProposal
-import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
 import org.scalaide.core.internal.jdt.search.ScalaIndexBuilder
-import org.scalaide.core.testsetup.BlockingProgressMonitor
-import org.eclipse.core.resources.IResource
 import org.scalaide.core.testsetup.SDTTestUtils
 import org.eclipse.core.runtime.NullProgressMonitor
-import scala.reflect.internal.util.SourceFile
-import org.eclipse.core.resources.IncrementalProjectBuilder
 
 /**
  * This provides a test suite for the code completion functionality.

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/TypeCompletionTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/TypeCompletionTests.scala
@@ -1,0 +1,62 @@
+package org.scalaide.core.ui.completion
+
+import org.junit.Test
+
+object TypeCompletionTests extends CompletionTests
+
+class TypeCompletionTests {
+  import TypeCompletionTests._
+
+  @Test
+  def trivialCompletion() = """
+    class Foo(i: In^
+    """ expectCompletions(Seq("Int"))
+
+  @Test
+  def nestedClassCompletion() = """
+    package test
+
+    object SomeTypes {
+      class InnerClass
+      object InnerObject
+      type InnerType = String
+    }""" andInSeparateFile """
+    package com.github.mlangc.experiments
+
+    class Bug {
+      val ic: InnerC^
+    }
+    """ expectCompletions(Seq("InnerClass - test.SomeTypes"))
+
+  @Test
+  def nestedObjectCompletion() = """
+    package test
+
+    object SomeTypes {
+      class InnerClass
+      object InnerObject
+      type InnerType = String
+    }""" andInSeparateFile """
+    package com.github.mlangc.experiments
+
+    class Bug {
+      val io: InnerO^
+    }
+    """ expectCompletions(Seq("InnerObject - test.SomeTypes"))
+
+  @Test
+  def nestedTypeCompletion() = """
+    package test
+
+    object SomeTypes {
+      class InnerClass
+      object InnerObject
+      type InnerType = String
+    }""" andInSeparateFile """
+    package com.github.mlangc.experiments
+
+    class Bug {
+      val io: InnerT^
+    }
+    """ expectCompletions(Seq("InnerType - test.SomeTypes"))
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/saveactions/AddMissingOverrideTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/extensions/saveactions/AddMissingOverrideTest.scala
@@ -5,6 +5,7 @@ import scala.reflect.internal.util.SourceFile
 import org.junit.Ignore
 import org.junit.Test
 import org.scalaide.core.compiler.IScalaPresentationCompiler
+import scala.tools.refactoring.util.UniqueNames
 
 object AddMissingOverrideTest extends CompilerSaveActionTests {
   override def saveAction(spc: IScalaPresentationCompiler, tree: IScalaPresentationCompiler#Tree, sf: SourceFile, selectionStart: Int, selectionEnd: Int) =
@@ -274,8 +275,8 @@ class AddMissingOverrideTest {
 
   @Test
   def add_override_to_def_that_overrides_java_method() = {
-    val jPkg = uniquePkgName()
-    val sPkg = uniquePkgName()
+    val jPkg = UniqueNames.scalaPackage()
+    val sPkg = UniqueNames.scalaPackage()
     mkJavaCompilationUnit(s"""
       package $jPkg;
       public class T {
@@ -300,8 +301,8 @@ class AddMissingOverrideTest {
 
   @Test
   def add_no_override_to_val_that_overrides_java_field() = {
-    val jPkg = uniquePkgName()
-    val sPkg = uniquePkgName()
+    val jPkg = UniqueNames.scalaPackage()
+    val sPkg = UniqueNames.scalaPackage()
     mkJavaCompilationUnit(s"""
       package $jPkg;
       public class T {
@@ -326,8 +327,8 @@ class AddMissingOverrideTest {
 
   @Test
   def add_no_override_to_def_that_overrides_java_field() = {
-    val jPkg = uniquePkgName()
-    val sPkg = uniquePkgName()
+    val jPkg = UniqueNames.scalaPackage()
+    val sPkg = UniqueNames.scalaPackage()
     mkJavaCompilationUnit(s"""
       package $jPkg;
       public class T {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/search/ScalaIndexBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/search/ScalaIndexBuilder.scala
@@ -154,7 +154,7 @@ trait ScalaIndexBuilder extends HasLogger { self: ScalaPresentationCompiler =>
         mapModifiers(td.mods),
         packageName.toString.toCharArray,
         td.name.toChars,
-        Array.empty,
+        enclClassNames.reverse.toArray,
         Array.empty,
         Array.empty,
         Array.empty,

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/search/ScalaIndexBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/search/ScalaIndexBuilder.scala
@@ -22,6 +22,17 @@ import org.scalaide.logging.HasLogger
  */
 trait ScalaIndexBuilder extends HasLogger { self: ScalaPresentationCompiler =>
 
+  private var _lastIndexBuilderTraversals = List[String]()
+  private val _lastIndexBuilderTraversalsMonitor = new Object()
+
+  def lastIndexBuilderTraversals: Seq[String] = _lastIndexBuilderTraversalsMonitor.synchronized {
+    _lastIndexBuilderTraversals
+  }
+
+  private def rememberTraversalOf(path: String): Unit = _lastIndexBuilderTraversalsMonitor.synchronized {
+    _lastIndexBuilderTraversals = (path +: _lastIndexBuilderTraversals).take(25)
+  }
+
   class IndexBuilderTraverser(indexer : ScalaSourceIndexer) extends Traverser {
     var packageName = new StringBuilder
 
@@ -164,67 +175,82 @@ trait ScalaIndexBuilder extends HasLogger { self: ScalaPresentationCompiler =>
 
     var enclClassNames = List[Array[Char]]()
 
+    private var traversalLevel = 0
+
     override def traverse(tree: Tree): Unit = {
-      def inClass(c : Array[Char])(block : => Unit): Unit = {
-        val old = enclClassNames
-        enclClassNames = c::enclClassNames
-        block
-        enclClassNames = old
-      }
+      traversalLevel = traversalLevel + 1
 
-      /** Add several method reference in the indexer for the passed [[RefTree]].
-       *
-       * Adding method references in the indexer is tricky for methods that have default arguments.
-       * The problem is that method entries are encoded as selector '/' Arity, i.e., foo/0 for `foo()`.
-       *
-       * Hence, `addApproximateMethodReferences` adds {{{22 - minArgsNumber}} method reference entries in
-       * the indexer, for the passed [[RefTree]].
-       */
-      def addApproximateMethodReferences(tree: RefTree, minArgsNumber: Int = 0): Unit = {
-        val maxArgs = 22  // just arbitrary choice.
-        for (i <- minArgsNumber to maxArgs)
-          indexer.addMethodReference(tree.name.toChars, i)
-      }
+      try {
 
-      tree match {
-        case pd : PackageDef => addPackage(pd)
-        case cd : ClassDef => addClass(cd)
-        case md : ModuleDef => addModule(md)
-        case vd : ValDef => addVal(vd)
-        case td : TypeDef => addType(td)
-        case dd : DefDef if dd.name != nme.MIXIN_CONSTRUCTOR => addDef(dd)
+        def inClass(c : Array[Char])(block : => Unit): Unit = {
+          val old = enclClassNames
+          enclClassNames = c::enclClassNames
+          block
+          enclClassNames = old
+        }
 
-        case _ =>
-      }
+        /** Add several method reference in the indexer for the passed [[RefTree]].
+         *
+         * Adding method references in the indexer is tricky for methods that have default arguments.
+         * The problem is that method entries are encoded as selector '/' Arity, i.e., foo/0 for `foo()`.
+         *
+         * Hence, `addApproximateMethodReferences` adds {{{22 - minArgsNumber}} method reference entries in
+         * the indexer, for the passed [[RefTree]].
+         */
+        def addApproximateMethodReferences(tree: RefTree, minArgsNumber: Int = 0): Unit = {
+          val maxArgs = 22  // just arbitrary choice.
+          for (i <- minArgsNumber to maxArgs)
+            indexer.addMethodReference(tree.name.toChars, i)
+        }
 
-      tree match {
-        case cd : ClassDef => inClass(cd.name.toChars) { super.traverse(tree) }
-        case md : ModuleDef => inClass(md.name.append("$").toChars) { super.traverse(tree) }
+        tree match {
+          case pd : PackageDef => addPackage(pd)
+          case cd : ClassDef => addClass(cd)
+          case md : ModuleDef => addModule(md)
+          case vd : ValDef => addVal(vd)
+          case td : TypeDef => addType(td)
+          case dd : DefDef if dd.name != nme.MIXIN_CONSTRUCTOR => addDef(dd)
 
-        case Apply(rt : RefTree, args) =>
-          addApproximateMethodReferences(rt, args.size)
-          super.traverse(tree)
+          case _ =>
+        }
 
-        // Partial apply.
-        case Typed(ttree, Function(_, _)) =>
-          ttree match {
-            case rt : RefTree =>
-              addApproximateMethodReferences(rt)
-            case Apply(rt : RefTree, args) =>
-              addApproximateMethodReferences(rt, args.size)
-            case _ =>
-          }
-          super.traverse(tree)
+        tree match {
+          case cd : ClassDef => inClass(cd.name.toChars) { super.traverse(tree) }
+          case md : ModuleDef => inClass(md.name.append("$").toChars) { super.traverse(tree) }
 
-        case rt : RefTree =>
-          val name = rt.name.toChars
-          indexer.addTypeReference(name)
-          indexer.addMethodReference(name, 0)
-          if(nme.isSetterName(rt.name)) indexer.addFieldReference(rt.getterName.toChars)
-          else indexer.addFieldReference(name)
-          super.traverse(tree)
+          case Apply(rt : RefTree, args) =>
+            addApproximateMethodReferences(rt, args.size)
+            super.traverse(tree)
 
-        case _ => super.traverse(tree)
+          // Partial apply.
+          case Typed(ttree, Function(_, _)) =>
+            ttree match {
+              case rt : RefTree =>
+                addApproximateMethodReferences(rt)
+              case Apply(rt : RefTree, args) =>
+                addApproximateMethodReferences(rt, args.size)
+              case _ =>
+            }
+            super.traverse(tree)
+
+          case rt : RefTree =>
+            val name = rt.name.toChars
+            indexer.addTypeReference(name)
+            indexer.addMethodReference(name, 0)
+            if(nme.isSetterName(rt.name)) indexer.addFieldReference(rt.getterName.toChars)
+            else indexer.addFieldReference(name)
+            super.traverse(tree)
+
+          case _ => super.traverse(tree)
+        }
+      } finally {
+        traversalLevel = traversalLevel - 1
+
+        if (traversalLevel == 0) {
+          val traversedPath = tree.pos.source.file.canonicalPath
+          logger.info(s"Traversal of $traversedPath finished")
+          rememberTraversalOf(traversedPath)
+        }
       }
     }
   }


### PR DESCRIPTION
Fix [#1001103](https://www.assembla.com/spaces/scala-ide/tickets/1001103-inner-classes-are-added-to-imports-incorrectly/details#).