### PR TITLE
Save only a position instead of a compiler symbol in implicit annotat…

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/hyperlink/ImplicitHyperlinkDetector.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/hyperlink/ImplicitHyperlinkDetector.scala
@@ -1,9 +1,12 @@
 package org.scalaide.core.internal.hyperlink
 
+import scala.collection.mutable.ListBuffer
+
 import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.hyperlink.IHyperlink
 import org.eclipse.ui.texteditor.ITextEditor
 import org.scalaide.core.compiler.InteractiveCompilationUnit
+import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
 
 private class ImplicitHyperlinkDetector extends BaseHyperlinkDetector {
 
@@ -23,15 +26,18 @@ private class ImplicitHyperlinkDetector extends BaseHyperlinkDetector {
     import org.scalaide.ui.internal.editor.decorators.implicits.ImplicitConversionAnnotation
     import org.scalaide.util.eclipse.EditorUtils
 
-    var hyperlinks = List[IHyperlink]()
-
-    for ((ann, pos) <- EditorUtils.getAnnotationsAtOffset(editor, offset)) ann match {
-      case a: ImplicitConversionAnnotation if a.sourceLink.isDefined =>
-        hyperlinks = a.sourceLink.get :: hyperlinks
-      case _ => ()
+    val hyperlinks = ListBuffer[IHyperlink]()
+    editor match {
+      case icuEditor: InteractiveCompilationUnitEditor =>
+        for ((ann, pos) <- EditorUtils.getAnnotationsAtOffset(editor, offset)) ann match {
+          case a: ImplicitConversionAnnotation =>
+            hyperlinks ++= a.sourceLink(icuEditor)
+          case _ => ()
+        }
+      case _ =>
     }
 
-    hyperlinks
+    hyperlinks.toList
   }
 }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/implicits/ImplicitConversionsOrArgsAnnotation.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/implicits/ImplicitConversionsOrArgsAnnotation.scala
@@ -3,8 +3,15 @@
  */
 package org.scalaide.ui.internal.editor.decorators.implicits
 
+import scala.reflect.internal.util.Position
+
+import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.hyperlink.IHyperlink
 import org.eclipse.jface.text.source.Annotation
+import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits.RichResponse
+import org.scalaide.core.compiler.InteractiveCompilationUnit
+import org.scalaide.logging.HasLogger
+import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
 import org.scalaide.ui.editor.ScalaEditorAnnotation
 
 object ImplicitAnnotation {
@@ -14,8 +21,42 @@ object ImplicitAnnotation {
 abstract class ImplicitAnnotation(text: String) extends Annotation(ImplicitAnnotation.ID, /*isPersistent*/ false, text) with ScalaEditorAnnotation
 
 /** The source of this implicit conversion is computed lazily, only when needed. */
-class ImplicitConversionAnnotation(_sourceLink: () => Option[IHyperlink], text: String) extends ImplicitAnnotation(text) {
-  lazy val sourceLink = _sourceLink()
+class ImplicitConversionAnnotation(pos: Position, region: IRegion, text: String) extends ImplicitAnnotation(text) with HasLogger {
+
+  def sourceLink(editor: InteractiveCompilationUnitEditor): List[IHyperlink] = {
+    val icu: InteractiveCompilationUnit = editor.getInteractiveCompilationUnit
+
+    icu.withSourceFile { (sourcefile, compiler) =>
+      import compiler.ApplyImplicitView
+
+      /* Return a range position for the given line without leading whitespace. */
+      def trimLinePos(line: Int) = {
+        var offset = sourcefile.lineToOffset(line)
+        while (sourcefile.content(offset).isWhitespace)
+          offset += 1
+        val start = offset
+        while (sourcefile.content(offset) != '\n')
+          offset += 1
+        compiler.rangePos(sourcefile, start, start, offset)
+      }
+
+      // We ask for a type tree of the whole line, since `ApplyImplicitView` has the exact same
+      // range position as the argument to which it is applied and `askTypeAt` returns the innermost
+      // tree, leaving out the implicit application. We filter inside `collect` on the precise position
+      val syms = compiler.askTypeAt(trimLinePos(pos.line)).getOption().toList flatMap { tree =>
+        tree.collect {
+          case tree: ApplyImplicitView if pos.includes(tree.pos) => tree.fun.symbol
+        }
+      }
+
+      syms flatMap { sym =>
+        compiler.mkHyperlink(sym,
+          name = s"Open Implicit (${sym.name})",
+          region,
+          icu.scalaProject.javaProject)
+      }
+    }.toList.flatten
+  }
 }
 
 class ImplicitArgAnnotation(text: String) extends ImplicitAnnotation(text)

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/implicits/ImplicitConversionsOrArgsAnnotation.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/implicits/ImplicitConversionsOrArgsAnnotation.scala
@@ -35,7 +35,7 @@ class ImplicitConversionAnnotation(pos: Position, region: IRegion, text: String)
         while (sourcefile.content(offset).isWhitespace)
           offset += 1
         val start = offset
-        while (sourcefile.content(offset) != '\n')
+        while (!sourcefile.isEndOfLine(offset))
           offset += 1
         compiler.rangePos(sourcefile, start, start, offset)
       }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/implicits/ImplicitHighlightingPresenter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/decorators/implicits/ImplicitHighlightingPresenter.scala
@@ -55,13 +55,12 @@ object ImplicitHighlightingPresenter {
       val txt = new String(sourceFile.content, t.pos.start, math.max(0, t.pos.end - t.pos.start)).trim()
       val pos = mkPosition(t.pos, txt)
       val region = new Region(pos.offset, pos.getLength)
-      val msg = compiler.asyncExec{
+      val msg = compiler.asyncExec {
         val sname = t.fun.symbol.nameString
         s"Implicit conversion found: `$txt`$DisplayStringSeparator`$sname($txt): ${t.tpe}`"
       }.getOption()
 
-      val annotation = new ImplicitConversionAnnotation(
-          () => compiler.mkHyperlink(t.symbol, name = "Open Implicit", region, scu.scalaProject.javaProject), msg.getOrElse(""))
+      val annotation = new ImplicitConversionAnnotation(t.pos, region, msg.getOrElse(""))
       (annotation, pos)
     }
 


### PR DESCRIPTION
…ions.

Compiler symbols should not be kept inside UI elements or other long-lived objects. Symbols may retain in memory a full Scala compiler instance, including all the other symbols and types, leading to memory leaks. In this commit I removed the reference to the implicit symbol, instead keeping only the position. In case the user wants to hyperlink, we re-compute the symbol under the given position, and produce a hyperlink.

Fix #1002679