### PR TITLE
Fix src-luna source folders in classpath files

### DIFF
--- a/org.scala-ide.sdt.aspects/.classpath
+++ b/org.scala-ide.sdt.aspects/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="src" path="src-luna"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.scala-ide.sdt.debug/.classpath
+++ b/org.scala-ide.sdt.debug/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src"/>
+	<classpathentry kind="src" path="src-luna"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="target/lib/concurrentlinkedhashmap-lru-1.4.2.jar"/>


### PR DESCRIPTION
The correct source folders weren't added in the PR that introduced the
Mars build and therefore we neither do have a out of the box working
Luna or Mars setup for Eclipse.