### PR TITLE
Depend on final Scala version in nightly builds

### DIFF
--- a/org.scala-ide.refactoring/pom.xml
+++ b/org.scala-ide.refactoring/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.scala-refactoring</groupId>
-      <artifactId>org.scala-refactoring.library_${scala.minor.version}</artifactId>
+      <artifactId>org.scala-refactoring.library_${scala.version}</artifactId>
       <version>${scala-refactoring.version}</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- Scala 2.10.x -->
     <scala210.version>2.10.5</scala210.version>
     <!-- Scala 2.11.x -->
-    <scala211.version>2.11.8-SNAPSHOT</scala211.version>
+    <scala211.version>2.11.8</scala211.version>
     <scala211.binary.version>2.11</scala211.binary.version>
     <scala211.scala-xml.version>1.0.3</scala211.scala-xml.version>
     <scala211.scala-parser-combinators.version>1.0.3</scala211.scala-parser-combinators.version>


### PR DESCRIPTION
The Scala people don't publish nightlies of Scala anymore, therefore we
have to depend to the latest Scala release which is the most actual
published Scala version.