### PR TITLE
Improve class file check for mixed Scala/Java projects

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaClassFileProvider.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaClassFileProvider.scala
@@ -11,10 +11,19 @@ import org.eclipse.jdt.internal.core.ClassFile
 import org.eclipse.jdt.internal.core.PackageFragment
 import org.scalaide.core.internal.project.ScalaProject
 
+/**
+ * Provides a `ScalaClassFile` implementation for classfiles that belong to
+ * Scala sources.
+ *
+ * This class caches the result of the association between package fragments
+ * (usually a jar) and classfiles. The cache is based on a heuristic because
+ * scanning the entire classpath may be expensive.
+ */
 class ScalaClassFileProvider extends IClassFileProvider with HasLogger {
 
-  /** @return a ScalaClassFile implementation if bytes represent a Scala classfile, or `null`
-   *          if the default JDT implementation should be used.
+  /**
+   * Returns a `ScalaClassFile` implementation if `contents` represent a Scala
+   * classfile or `null` if the default JDT implementation should be used.
    */
   override def create(contents: Array[Byte], parent: PackageFragment, name: String): ClassFile = {
     def updateCache(isScalaClassfile: Boolean): Unit = {
@@ -22,8 +31,16 @@ class ScalaClassFileProvider extends IClassFileProvider with HasLogger {
       if (pfr ne null)
         scalaPackageFragments.synchronized {
           if (!scalaPackageFragments.isDefinedAt(pfr)) {
-            logger.debug(s"Setting ${pfr.getElementName} (because of class $name) to be ${if (isScalaClassfile) "Scala" else "Java"}")
-            scalaPackageFragments += pfr -> isScalaClassfile
+            val jarName = pfr.getElementName
+            val isProbablyScalaArtifact = jarName matches """.*_2\.\d+.*"""
+            val ignoreClassfile = !isScalaClassfile && isProbablyScalaArtifact
+
+            if (ignoreClassfile)
+              logger.debug(s"Do not set $jarName (because of class $name) to be Java because it seems to be a Scala library.")
+            else {
+              logger.debug(s"Setting $jarName (because of class $name) to be ${if (isScalaClassfile) "Scala" else "Java"}.")
+              scalaPackageFragments += pfr -> isScalaClassfile
+            }
           }
         }
     }
@@ -36,11 +53,8 @@ class ScalaClassFileProvider extends IClassFileProvider with HasLogger {
     scalaCF
   }
 
-  /** Return `true` if the classfile could be a Scala classfile.
-   *
-   *  @note This method caches the result of the first classfile read from a package fragment (usually a jar).
-   *        This heuristic might fail if a single jar mixes Java and Scala classfiles, and if the first classfile
-   *        is comes from Java, a plain Java classfile editor and icon would be used for all classfiles in that jar.
+  /**
+   * Returns `true` if the classfile could be a Scala classfile.
    */
   override def isInteresting(classFile: IClassFile): Boolean = {
     if (ScalaProject.isScalaProject(classFile.getJavaProject)) {


### PR DESCRIPTION
In case we have a JAR file that belongs to a project that contains both
Scala and Java source code we need a more intelligent check to find out
if the entire JAR should be checked for class files that belong to Scala
source code.

So far, the first found classfile was responsible for specifying if the
JAR file should be scanned further. If the classfile belongs to a Java
source file, the scanning is aborted, which meant that in a mixed
Scala/Java project, no Scala classfiles can be detected.

In such a case we simply do another check, which finds out if the name
of the JAR file contains a Scala version. This way we can be sure that
it was created from Scala source code because it is unlikely that Java
artifacts contain the Scala version in its artifact name. Once we found
that out, we simply ignore the first classfile if it belongs to Java
source code. Instead we continue with the next classfile until we found
one that belongs to Scala source code.

This is inefficient in case a JAR file contains a Scala version name but
does not contain any Scala sources but this is a very unlikely use case.
For now it allows us to handle mixed Scala/Java projects.

Fixes #1002687