### PR TITLE
Sort type completions differently

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -9,8 +9,8 @@ ROOT_DIR=${PWD}
 
 if [ -z "$*" ]
 then
-  MVN_ARGS="-Pscala-2.11.x -Peclipse-luna clean install"
-  MVN_P2_ARGS="-Dtycho.localArtifacts=ignore -Pscala-2.11.x -Peclipse-luna clean verify"
+  MVN_ARGS="-Pscala-2.11.x -Peclipse-mars $ADDITIONAL_MVN_OPTS clean install"
+  MVN_P2_ARGS="-Dtycho.localArtifacts=ignore -Pscala-2.11.x -Peclipse-mars $ADDITIONAL_MVN_OPTS clean verify"
 else
   MVN_ARGS="$*"
   MVN_P2_ARGS="-Dtycho.localArtifacts=ignore $*"

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTestSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/CompletionTestSuite.scala
@@ -10,6 +10,7 @@ import org.junit.runners.Suite
     classOf[StandardCompletionTests],
     classOf[ParameterCompletionTests],
     classOf[TypeCompletionTests],
-    classOf[CompletionOrderTests]
+    classOf[CompletionOrderTests],
+    classOf[ProposalRelevanceCalculatorTest]
 ))
 class CompletionTestSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/ProposalRelevanceCalculatorTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/ProposalRelevanceCalculatorTest.scala
@@ -1,0 +1,45 @@
+package org.scalaide.core.ui.completion
+
+import org.junit.Test
+import org.junit.Assert._
+import org.scalaide.core.completion.ProposalRelevanceCalculator
+
+class ProposalRelevanceCalculatorTest {
+  private val calc = new ProposalRelevanceCalculator
+
+  private def makeSureThatJdtProposalsAreOrderedLike(proposals: (String, String)*): Unit = {
+    val sortedProposals = proposals.reverse.sortBy { case (prefix, name) =>
+      -calc.forJdtType(prefix, name)
+    }
+
+    assertEquals(proposals, sortedProposals)
+  }
+
+  @Test
+  def testIllustrativeJdtCompletions(): Unit = {
+    makeSureThatJdtProposalsAreOrderedLike(
+        "" -> "X",
+        "z" -> "X",
+        "a.a" -> "X")
+  }
+
+  @Test
+  def testTypicalJdtUriCompletions(): Unit = {
+    makeSureThatJdtProposalsAreOrderedLike(
+        "java.net" -> "URI",
+        "akka.http.scaladsl.model" -> "Uri",
+        "gate.creole.ontology" -> "URI",
+        "akka.http.javadsl.model" -> "Uri",
+        "com.sun.jndi.toolkit.url" -> "Uri",
+        "com.microsoft.schemas.office.x2006.encryption.CTKeyEncryptor" -> "Uri")
+  }
+
+  @Test
+  def testTypicalJdtDocumentCompletions(): Unit = {
+    makeSureThatJdtProposalsAreOrderedLike(
+        "org.bson" -> "Document",
+        "org.mongodb.scala.bson.collection.immutable" -> "Document",
+        "gate.creole.annic.apache.lucene.document" -> "Document")
+  }
+
+}

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/ProposalRelevanceCalculatorTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/ui/completion/ProposalRelevanceCalculatorTest.scala
@@ -3,11 +3,13 @@ package org.scalaide.core.ui.completion
 import org.junit.Test
 import org.junit.Assert._
 import org.scalaide.core.completion.ProposalRelevanceCalculator
+import org.scalaide.core.completion.ProposalRelevanceCfg
+import org.scalaide.core.completion.DefaultProposalRelevanceCfg
 
 class ProposalRelevanceCalculatorTest {
-  private val calc = new ProposalRelevanceCalculator
+  private def makeSureThatJdtProposalsAreOrderedLike(cfg: ProposalRelevanceCfg = DefaultProposalRelevanceCfg)(proposals: (String, String)*): Unit = {
+    val calc = new ProposalRelevanceCalculator(cfg)
 
-  private def makeSureThatJdtProposalsAreOrderedLike(proposals: (String, String)*): Unit = {
     val sortedProposals = proposals.reverse.sortBy { case (prefix, name) =>
       -calc.forJdtType(prefix, name)
     }
@@ -17,7 +19,7 @@ class ProposalRelevanceCalculatorTest {
 
   @Test
   def testIllustrativeJdtCompletions(): Unit = {
-    makeSureThatJdtProposalsAreOrderedLike(
+    makeSureThatJdtProposalsAreOrderedLike()(
         "" -> "X",
         "z" -> "X",
         "a.a" -> "X")
@@ -25,21 +27,56 @@ class ProposalRelevanceCalculatorTest {
 
   @Test
   def testTypicalJdtUriCompletions(): Unit = {
-    makeSureThatJdtProposalsAreOrderedLike(
+    makeSureThatJdtProposalsAreOrderedLike()(
         "java.net" -> "URI",
         "akka.http.scaladsl.model" -> "Uri",
         "gate.creole.ontology" -> "URI",
-        "akka.http.javadsl.model" -> "Uri",
         "com.sun.jndi.toolkit.url" -> "Uri",
+        "akka.http.javadsl.model" -> "Uri",
         "com.microsoft.schemas.office.x2006.encryption.CTKeyEncryptor" -> "Uri")
   }
 
   @Test
   def testTypicalJdtDocumentCompletions(): Unit = {
-    makeSureThatJdtProposalsAreOrderedLike(
+    makeSureThatJdtProposalsAreOrderedLike()(
         "org.bson" -> "Document",
         "org.mongodb.scala.bson.collection.immutable" -> "Document",
         "gate.creole.annic.apache.lucene.document" -> "Document")
   }
 
+  @Test
+  def testWithTypicalJsonCompletion(): Unit = {
+    makeSureThatJdtProposalsAreOrderedLike()(
+        "play.api.libs" -> "Json",
+        "com.mongodb.util" -> "Json",
+        "org.apache.avro.data" -> "Json",
+        "play.libs" -> "Json")
+  }
+
+  @Test
+  def testWithArtificialExampleAndCfg(): Unit = {
+    val cfg = new ProposalRelevanceCfg {
+      def favoritePackages =
+        """.*favorite.*""".r :: Nil
+
+      def preferedPackages =
+        """.*prefered.*""".r :: Nil
+
+      def unpopularPackages =
+        """.*unpopular.*""".r :: Nil
+
+      def shunnedPackages =
+        """.*shunned.*""".r :: Nil
+    }
+
+    makeSureThatJdtProposalsAreOrderedLike(cfg)(
+        "z.favorite" -> "A",
+        "y.prefered" -> "A",
+        "x.unpopular" -> "A",
+        "w.shunned" -> "A",
+        "z.favorite" -> "Aaaa",
+        "y.prefered" -> "Aaaa",
+        "x.unpopular" -> "Aaaa",
+        "w.shunned" -> "Aaaa")
+  }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCalculator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCalculator.scala
@@ -49,7 +49,7 @@ class ProposalRelevanceCalculator(cfg: ProposalRelevanceCfg = DefaultProposalRel
   }
 
   def forJdtType(prefix: String, name: String): Int = {
-    val maxRelevance = MaxExternalRelevance / 4 * 3
+    val baseRelevance = MaxExternalRelevance / 4 * 3
 
     def deltaForPrefix(deltaIfMatch: Int, regexes: Seq[Regex]): Int = {
       regexes.foldLeft(0) { (acc, rx) =>
@@ -80,6 +80,6 @@ class ProposalRelevanceCalculator(cfg: ProposalRelevanceCfg = DefaultProposalRel
       name.length*3 +
       nestingLevel
 
-    internalToExternalRelevance(maxRelevance + bonus - penalty)
+    internalToExternalRelevance(baseRelevance + bonus - penalty)
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCalculator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCalculator.scala
@@ -1,0 +1,38 @@
+package org.scalaide.core.completion
+
+import scala.tools.nsc.interactive.Global
+
+class ProposalRelevanceCalculator {
+  def forScala[CompilerT <: Global](pc: CompilerT)(prefix: String, name: String, sym: pc.Symbol, viaView: pc.Symbol, inherited: Option[Boolean]): Int = {
+    // rudimentary relevance, place own members before inherited ones, and before view-provided ones
+    var relevance = 100
+    if (!sym.isLocalToBlock) relevance -= 10 // non-local symbols are less relevant than local ones
+    if (!sym.hasGetter) relevance -= 5 // fields are more relevant than non-fields
+    if (inherited.exists(_ == true)) relevance -= 10
+    if (viaView != pc.NoSymbol) relevance -= 20
+    if (sym.hasPackageFlag) relevance -= 30
+    // theoretically we'd need an 'ask' around this code, but given that
+    // Any and AnyRef are definitely loaded, we call directly to definitions.
+    if (sym.owner == pc.definitions.AnyClass
+      || sym.owner == pc.definitions.AnyRefClass
+      || sym.owner == pc.definitions.ObjectClass) {
+      relevance -= 40
+    }
+
+    // global symbols are less relevant than local symbols
+    sym.owner.enclosingPackage.fullName match {
+      case "java" => relevance -= 15
+      case "scala"  => relevance -= 10
+      case _ =>
+    }
+
+    val casePenalty = if (name.substring(0, prefix.length) != prefix) 50 else 0
+    relevance -= casePenalty
+
+    relevance
+  }
+
+  def forJdtType(prefix: String, name: String): Int = {
+    50
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCalculator.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCalculator.scala
@@ -6,7 +6,7 @@ import org.scalaide.logging.HasLogger
 class ProposalRelevanceCalculator extends HasLogger {
   def forScala[CompilerT <: Global](pc: CompilerT)(prefix: String, name: String, sym: pc.Symbol, viaView: pc.Symbol, inherited: Option[Boolean]): Int = {
     // rudimentary relevance, place own members before inherited ones, and before view-provided ones
-    var relevance = 100
+    var relevance = 1000
     if (!sym.isLocalToBlock) relevance -= 10 // non-local symbols are less relevant than local ones
     if (!sym.hasGetter) relevance -= 5 // fields are more relevant than non-fields
     if (inherited.exists(_ == true)) relevance -= 10
@@ -34,7 +34,7 @@ class ProposalRelevanceCalculator extends HasLogger {
   }
 
   def forJdtType(prefix: String, name: String): Int = {
-    val maxRelevance = 100
+    val maxRelevance = 500
 
     val boni = {
         if (prefix.contains(".scala")) 1

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCfg.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ProposalRelevanceCfg.scala
@@ -1,0 +1,31 @@
+package org.scalaide.core.completion
+
+import scala.util.matching.Regex
+
+trait ProposalRelevanceCfg {
+  def favoritePackages: Seq[Regex]
+  def preferedPackages: Seq[Regex]
+
+  def unpopularPackages: Seq[Regex]
+  def shunnedPackages: Seq[Regex]
+}
+
+object DefaultProposalRelevanceCfg extends ProposalRelevanceCfg {
+  val favoritePackages =
+    """scala\..*""".r ::
+    Nil
+
+  val preferedPackages =
+    """java\..*""".r ::
+    """.*\.scala.*""".r ::
+    """akka\..*""".r ::
+    """play.api\..*""".r ::
+    Nil
+
+  val unpopularPackages = Nil
+
+  val shunnedPackages =
+    """.*\.javadsl.*""".r ::
+    """play\.(?!api\.).*""".r ::
+    Nil
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ScalaCompletions.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/completion/ScalaCompletions.scala
@@ -137,6 +137,9 @@ class ScalaCompletions extends HasLogger {
             logger.info(s"Found type: $fullyQualifiedName")
 
             if (simpleName.indexOf("$") < 0 && !isAlreadyListed(fullyQualifiedName, simpleName)) {
+              val relevanceCalc = new ProposalRelevanceCalculator
+              val relevance = relevanceCalc.forJdtType(packageWithEnclosing, simpleName)
+
               logger.info(s"Adding type: $fullyQualifiedName")
               listedTypes.addBinding(fullyQualifiedName, CompletionProposal(
                 MemberKind.Object,
@@ -145,7 +148,7 @@ class ScalaCompletions extends HasLogger {
                 simpleName,
                 simpleName,
                 packageWithEnclosing,
-                50,
+                relevance,
                 true,
                 () => List(),
                 List(),


### PR DESCRIPTION
This PR addresses the problems explained in detail in [#1002686](https://www.assembla.com/spaces/scala-ide/tickets/1002686-scala-type-completions-should-be-sorted-differently/details#). Note we might want to expose `ProposalRelevanceCfg` in the GUI so that users can tweak it individually in future versions. At the moment a hardcoded default configuration is used.