### PR TITLE
Do not cache the `MarkOccurrenceIndex`

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/markoccurrences/ScalaOccurrencesFinder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/markoccurrences/ScalaOccurrencesFinder.scala
@@ -8,8 +8,6 @@ import scala.tools.refactoring.implementations.MarkOccurrences
 import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.Region
 import org.scalaide.util.Utils
-import scala.ref.WeakReference
-import org.scalaide.core.compiler.IScalaPresentationCompiler
 import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
 
 case class Occurrences(name: String, locations: List[IRegion])
@@ -24,28 +22,6 @@ case class Occurrences(name: String, locations: List[IRegion])
 class ScalaOccurrencesFinder(unit: InteractiveCompilationUnit) extends HasLogger {
   import ScalaOccurrencesFinder._
 
-  /* IMPORTANT:
-   * In the current implementation, all access to `indexCache` are confined to the Presentation
-   * Compiler thread (and this is why `indexCache` requires no synchronization policy).
-   */
-  private var indexCache: Option[TimestampedIndex] = None
-
-  private def getCachedIndex(lastModified: Long, currentCompiler: IScalaPresentationCompiler): Option[MarkOccurrencesIndex] = indexCache match {
-    case Some(TimestampedIndex(`lastModified`, WeakReference(index))) if index.global eq currentCompiler => Some(index)
-    case _ =>
-      logger.info("No valid MarkOccurrences index.")
-      None
-  }
-
-  /** We store the index in a weak reference. This way we trade-off memory consumption with
-   *  speed of execution: if the editor stays open for a long time (for instance, the user is
-   *  hyperlinking around), the VM might need more memory and it's a bad idea to hold on to
-   *  an index that can be easily recomputed.
-   */
-  private def cacheIndex(lastModified: Long, index: MarkOccurrencesIndex): Unit = {
-    indexCache = Some(TimestampedIndex(lastModified, new WeakReference(index)))
-  }
-
   def findOccurrences(region: IRegion, lastModified: Long): Option[Occurrences] = {
     unit.withSourceFile { (sourceFile, compiler) =>
 
@@ -56,7 +32,7 @@ class ScalaOccurrencesFinder(unit: InteractiveCompilationUnit) extends HasLogger
         logger.info("Source %s is not loded in the presentation compiler. Aborting occurrences update." format (sourceFile.file.name))
         None
       } else {
-        val occurrencesIndex = getCachedIndex(lastModified, compiler) getOrElse {
+        val occurrencesIndex =  {
           val occurrencesIndex = new MarkOccurrencesIndex {
             val global = compiler
             import global.askLoadedTyped
@@ -67,9 +43,9 @@ class ScalaOccurrencesFinder(unit: InteractiveCompilationUnit) extends HasLogger
               }
             }
           }
-          cacheIndex(lastModified, occurrencesIndex)
           occurrencesIndex
         }
+
         compiler.asyncExec {
           val (from, to) = (region.getOffset, region.getOffset + region.getLength)
           val (selectedTree, occurrences) = occurrencesIndex.occurrencesOf(sourceFile.file, from, to)
@@ -88,5 +64,4 @@ class ScalaOccurrencesFinder(unit: InteractiveCompilationUnit) extends HasLogger
 
 object ScalaOccurrencesFinder {
   private abstract class MarkOccurrencesIndex extends MarkOccurrences with GlobalIndexes
-  private case class TimestampedIndex(timestamp: Long, index: WeakReference[MarkOccurrencesIndex])
 }


### PR DESCRIPTION
Caching the `MarkOccurrenceIndex` is problematic, since this quickly leads
to an index, that is referencing an AST that is not identical to the most
recent one from the presentation compiler. Since equality for symbols is
implemented as reference equality, this is a problem even if the trees are
semantically equivalent, resulting in erratic behaviour as described in
ticket [#1002701](https://app.assembla.com/spaces/scala-ide/tickets/1002701-mark-occurrences-behaves-erratically).

I've experimented with a solution in the refactoring library, that performs
semantic equality comparisons on symbols, to work around this problem. This
worked as far as the trees where indeed semantically equivalent. In some cases
however, there where semantic differences in the trees, even though the source
code did not change, like positions being available in one one tree,
but absent in the other. Maybe this could be sorted out by digging deeper, but
in order to keep it simple, I'd rather not go this route unless not caching
actually results in noticeable performance problems.

Fix #1002701