### PR TITLE
Enable `MarkOccurrences` for operators

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/markoccurrences/ScalaOccurrencesFinder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/decorators/markoccurrences/ScalaOccurrencesFinder.scala
@@ -50,7 +50,7 @@ class ScalaOccurrencesFinder(unit: InteractiveCompilationUnit) extends HasLogger
           val (from, to) = (region.getOffset, region.getOffset + region.getLength)
           val (selectedTree, occurrences) = occurrencesIndex.occurrencesOf(sourceFile.file, from, to)
 
-          Option(selectedTree.symbol) filter (!_.name.isOperatorName) map { sym =>
+          Option(selectedTree.symbol).map { sym =>
             val locations = occurrences map { pos =>
               new Region(pos.start, pos.end - pos.start)
             }


### PR DESCRIPTION
There is no reason to disable `MarkOccurrences` for operators.

Fix [#1002703](https://app.assembla.com/spaces/scala-ide/tickets/1002703-markoccurrences-doesn--39-t-work-with-operators/details#) (but see [#1002705](https://app.assembla.com/spaces/scala-ide/tickets/1002705-mark-occurrences-does-not-work-with-operators-in-patterns/details#))