### PR TITLE
Do not log missing cases in outline to error log

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/outline/ModelBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/outline/ModelBuilder.scala
@@ -89,7 +89,7 @@ object ModelBuilder extends HasLogger {
 
               case _ => sb.append(showName(name, t))
             }
-          case _ => logger.error("renderATT. Unknown Tree type " + t.getClass)
+          case _ =>
         }
       }
 
@@ -116,7 +116,7 @@ object ModelBuilder extends HasLogger {
 
           case This(qual: TypeName) =>
 
-          case _ => logger.error("renderType. Unknown Tree type " + tt.getClass)
+          case _ =>
         }
       }
 
@@ -167,7 +167,7 @@ object ModelBuilder extends HasLogger {
             renderQualifier(sb, qualifier)
             sb.append(".")
             sb.append(name)
-          case _ => logger.error("Unknown Qualifier tree " + t.getClass)
+          case _ =>
         }
       }
 


### PR DESCRIPTION
We could log it to info instead but it just pollutes the log. Since we
can't fix these cases anyway because we don't log the original source
code (we could log the sources but that would pollute the logs even more
and it is not likely that users will report back this stuff) it is
better to just not log anything. If we find a case that is not working,
we can still write a test for it and fix it.

Fix #1002710