### PR TITLE
Automatically restart PC in order to avoid false positive errors

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -1,24 +1,26 @@
 package org.scalaide.core.internal.builder
 
-import scala.collection.mutable.HashSet
 import java.{ util => ju }
+
+import scala.collection.mutable.HashSet
+
 import org.eclipse.core.resources.IFile
-import org.eclipse.core.resources.IncrementalProjectBuilder
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResourceDelta
 import org.eclipse.core.resources.IResourceDeltaVisitor
+import org.eclipse.core.resources.IncrementalProjectBuilder
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.SubMonitor
+import org.eclipse.core.runtime.jobs.ISchedulingRule
 import org.eclipse.jdt.internal.core.builder.JavaBuilder
 import org.eclipse.jdt.internal.core.builder.State
+import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.SdtConstants
+import org.scalaide.core.internal.jdt.util.JDTUtils
+import org.scalaide.logging.HasLogger
+import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.ReflectionUtils
-import org.scalaide.logging.HasLogger
-import org.eclipse.core.runtime.jobs.ISchedulingRule
-import org.scalaide.core.internal.jdt.util.JDTUtils
-import org.scalaide.core.SdtConstants
-import org.scalaide.core.IScalaPlugin
-import org.scalaide.util.eclipse.EditorUtils
 
 class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with HasLogger {
 
@@ -39,7 +41,7 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
   }
 
   override def build(kind: Int, ignored: ju.Map[String, String], monitor: IProgressMonitor): Array[IProject] = {
-    import IncrementalProjectBuilder._
+    import org.eclipse.core.resources.IncrementalProjectBuilder._
 
     val project = IScalaPlugin().getScalaProject(this.project)
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -18,6 +18,7 @@ import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.SdtConstants
 import org.scalaide.core.internal.jdt.util.JDTUtils
 import org.scalaide.logging.HasLogger
+import org.scalaide.ui.internal.preferences.ResourcesPreferences
 import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.ReflectionUtils
@@ -134,10 +135,13 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
         (Set.empty ++ depends ++ javaDepends).toArray
       }
 
-    EditorUtils.withCurrentScalaSourceFile { ssf ⇒
-      if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
-        logger.debug(s"Restarting presentation compiler of ${project.underlying.getName} due to finished build.")
-        project.presentationCompiler.askRestart()
+    val isPcAutoRestartEnabled = IScalaPlugin().getPreferenceStore.getBoolean(ResourcesPreferences.PRES_COMP_AUTO_RESTART)
+    if (isPcAutoRestartEnabled) {
+      EditorUtils.withCurrentScalaSourceFile { ssf ⇒
+        if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
+          logger.debug(s"Restarting presentation compiler of ${project.underlying.getName} due to finished build.")
+          project.presentationCompiler.askRestart()
+        }
       }
     }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.jobs.ISchedulingRule
 import org.scalaide.core.internal.jdt.util.JDTUtils
 import org.scalaide.core.SdtConstants
 import org.scalaide.core.IScalaPlugin
+import org.scalaide.util.eclipse.EditorUtils
 
 class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with HasLogger {
 
@@ -131,8 +132,13 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
         (Set.empty ++ depends ++ javaDepends).toArray
       }
 
-    logger.debug(s"Restarting presentation compiler of ${project.underlying.getName} due to finished build.")
-    project.presentationCompiler.askRestart()
+    EditorUtils.withCurrentScalaSourceFile { ssf ⇒
+      if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
+        logger.debug(s"Restarting presentation compiler of ${project.underlying.getName} due to finished build.")
+        project.presentationCompiler.askRestart()
+      }
+    }
+
     ret
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -121,14 +121,19 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
     }
 
     // SBT build manager already calls java builder internally
-    if (allSourceFiles.exists(FileUtils.hasBuildErrors(_)) || !shouldRunJavaBuilder)
-      depends.toArray
-    else {
-      ensureProject()
-      val javaDepends = scalaJavaBuilder.build(kind, ignored, subMonitor)
-      refresh()
-      (Set.empty ++ depends ++ javaDepends).toArray
-    }
+    val ret =
+      if (allSourceFiles.exists(FileUtils.hasBuildErrors(_)) || !shouldRunJavaBuilder)
+        depends.toArray
+      else {
+        ensureProject()
+        val javaDepends = scalaJavaBuilder.build(kind, ignored, subMonitor)
+        refresh()
+        (Set.empty ++ depends ++ javaDepends).toArray
+      }
+
+    logger.debug(s"Restarting presentation compiler of ${project.underlying.getName} due to finished build.")
+    project.presentationCompiler.askRestart()
+    ret
   }
 }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -18,8 +18,6 @@ import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.SdtConstants
 import org.scalaide.core.internal.jdt.util.JDTUtils
 import org.scalaide.logging.HasLogger
-import org.scalaide.ui.internal.preferences.ResourcesPreferences
-import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.ReflectionUtils
 
@@ -125,27 +123,14 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
     }
 
     // SBT build manager already calls java builder internally
-    val ret =
-      if (allSourceFiles.exists(FileUtils.hasBuildErrors(_)) || !shouldRunJavaBuilder)
-        depends.toArray
-      else {
-        ensureProject()
-        val javaDepends = scalaJavaBuilder.build(kind, ignored, subMonitor)
-        refresh()
-        (Set.empty ++ depends ++ javaDepends).toArray
-      }
-
-    val isPcAutoRestartEnabled = IScalaPlugin().getPreferenceStore.getBoolean(ResourcesPreferences.PRES_COMP_AUTO_RESTART)
-    if (isPcAutoRestartEnabled) {
-      EditorUtils.withCurrentScalaSourceFile { ssf ⇒
-        if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
-          logger.debug(s"Restarting presentation compiler of ${project.underlying.getName} due to finished build.")
-          project.presentationCompiler.askRestart()
-        }
-      }
+    if (allSourceFiles.exists(FileUtils.hasBuildErrors(_)) || !shouldRunJavaBuilder)
+      depends.toArray
+    else {
+      ensureProject()
+      val javaDepends = scalaJavaBuilder.build(kind, ignored, subMonitor)
+      refresh()
+      (Set.empty ++ depends ++ javaDepends).toArray
     }
-
-    ret
   }
 }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/ScalaBuilder.scala
@@ -62,7 +62,7 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
           val removed0 = new HashSet[IFile]
 
           getDelta(project.underlying).accept(new IResourceDeltaVisitor {
-            def visit(delta: IResourceDelta) = {
+            override def visit(delta: IResourceDelta) = {
               delta.getResource match {
                 case file: IFile if FileUtils.isBuildable(file) && project.sourceFolders.exists(_.isPrefixOf(file.getLocation)) =>
                   delta.getKind match {
@@ -86,7 +86,7 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
 
             if (project.directDependencies.exists(hasChanges)) {
               // reset presentation compilers if a dependency has been rebuilt
-              logger.debug("Resetting presentation compiler for %s due to dependent project change".format(project.underlying.getName()))
+              logger.debug(s"Restart presentation compiler for ${project.underlying.getName} due to dependent project change.")
               project.presentationCompiler.askRestart()
 
               // in theory need to be able to identify the exact dependencies
@@ -111,10 +111,10 @@ class ScalaBuilder extends IncrementalProjectBuilder with JDTBuilderFacade with 
 
     val depends = project.transitiveDependencies
 
-    /** The Java builder has to be run for copying resources (non-source files) to the output directory.
+    /* The Java builder has to be run for copying resources (non-source files) to the output directory.
      *
-     *  We need to run it when no Java sources have been modified
-     *  (since the SBT builder automatically calls the JDT builder internally if there are modified Java sources).
+     * We need to run it when no Java sources have been modified
+     * (since the SBT builder automatically calls the JDT builder internally if there are modified Java sources).
      */
     def shouldRunJavaBuilder: Boolean = {
       (needToCopyResources && !addedOrUpdated.exists(_.getName().endsWith(SdtConstants.JavaFileExtn)))

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/PresentationCompilerProxy.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/PresentationCompilerProxy.scala
@@ -150,7 +150,7 @@ final class PresentationCompilerProxy(name: String, initializeSettings: () => Se
     pcLock.synchronized {
       try {
         val pc = new ScalaPresentationCompiler(name, initializeSettings())
-        logger.debug("Presentation compiler classpath: " + pc.classPath)
+        logger.debug(pc.settings.userSetSettings.toSeq.sortBy(_.name.toLowerCase).mkString(s"Presentation compiler settings for $name:\n  ", "\n  ", ""))
         publish(Start)
         pc
       } catch {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/PresentationCompilerProxy.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/PresentationCompilerProxy.scala
@@ -47,9 +47,11 @@ final class PresentationCompilerProxy(name: String, initializeSettings: () => Se
   @volatile private var restartNextTime = false
 
   /** Ask to restart the presentation compiler before processing the next request. */
-  def askRestart(): Unit = {
-    restartNextTime = true
-    publish(Restart)
+  override def askRestart(): Unit = {
+    if (!restartNextTime) {
+      restartNextTime = true
+      publish(Restart)
+    }
   }
 
   override def apply[U](op: IScalaPresentationCompiler => U): Option[U] =

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/PresentationCompilerProxy.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/PresentationCompilerProxy.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable.Publisher
 final class PresentationCompilerProxy(name: String, initializeSettings: () => Settings) extends IPresentationCompilerProxy
     with Publisher[PresentationCompilerActivity] with HasLogger {
 
-  type Pub = PresentationCompilerProxy
+  override type Pub = PresentationCompilerProxy
 
   /** Current 'live' instance of the presentation compiler.
     *
@@ -133,7 +133,7 @@ final class PresentationCompilerProxy(name: String, initializeSettings: () => Se
     *
     * @note If you need the presentation compiler to be re-initialized (because, for instance, you have changed the project's classpath), use `askRestart`.
     */
-  def shutdown(): Unit = {
+  override def shutdown(): Unit = {
     publish(Shutdown)
     val oldPc = pcLock.synchronized {
       val temp = pc
@@ -187,4 +187,3 @@ case object Start    extends PresentationCompilerActivity
  *  once the PC has really started.
  */
 case object Restart  extends PresentationCompilerActivity
-

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -203,8 +203,7 @@ class ScalaPresentationCompiler(private[compiler] val name: String, _settings: S
         askLoadedTyped(unit.source, false).get
         unit.problems.toList flatMap presentationReporter.eclipseProblem
       case None =>
-        logger.info("Missing unit for file %s when retrieving errors. Errors will not be shown in this file".format(file))
-        logger.info(unitOfFile.toString)
+        logger.info(s"Missing unit for file $file when retrieving errors. Errors will not be shown in this file. Loaded units are: $unitOfFile")
         Nil
     }
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -355,8 +355,8 @@ class ScalaPresentationCompiler(private[compiler] val name: String, _settings: S
   def mkCompletionProposal(prefix: String, start: Int, sym: Symbol, tpe: Type,
     inherited: Boolean, viaView: Symbol, context: CompletionContext.ContextType, project: IScalaProject): CompletionProposal = {
 
-    /** Some strings need to be enclosed in back-ticks to be usable as identifiers in scala
-     *  source. This function adds the back-ticks to a given identifier, if necessary.
+    /* Some strings need to be enclosed in back-ticks to be usable as identifiers in scala
+     * source. This function adds the back-ticks to a given identifier, if necessary.
      */
     def addBackTicksIfNecessary(identifier: String): String = {
       def needsBackTicks(identifier: String) = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaSourceFile.scala
@@ -1,30 +1,33 @@
 package org.scalaide.core.internal.jdt.model
 
-import java.util.{ HashMap => JHashMap }
+import java.util.{ HashMap ⇒ JHashMap }
+
+import scala.tools.eclipse.contribution.weaving.jdt.IScalaSourceFile
+import scala.tools.nsc.interactive.Response
+import scala.tools.nsc.io.AbstractFile
+import scala.tools.nsc.io.VirtualFile
+import scala.util.control.Exception
+
 import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.CoreException
+import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.jdt.core.ICompilationUnit
 import org.eclipse.jdt.core.IJavaElement
 import org.eclipse.jdt.core.IType
+import org.eclipse.jdt.core.JavaModelException
 import org.eclipse.jdt.core.WorkingCopyOwner
+import org.eclipse.jdt.core.compiler.CharOperation
 import org.eclipse.jdt.core.compiler.IProblem
-import org.eclipse.jdt.internal.core.util.HandleFactory
-import org.eclipse.jdt.internal.core.{ CompilationUnit => JDTCompilationUnit }
+import org.eclipse.jdt.core.dom.CompilationUnit
+import org.eclipse.jdt.internal.core.{ CompilationUnit ⇒ JDTCompilationUnit }
 import org.eclipse.jdt.internal.core.OpenableElementInfo
 import org.eclipse.jdt.internal.core.PackageFragment
-import scala.tools.nsc.io.AbstractFile
-import scala.tools.nsc.io.VirtualFile
-import scala.tools.eclipse.contribution.weaving.jdt.IScalaSourceFile
-import org.scalaide.core.resources.EclipseFile
-import org.eclipse.jdt.core.compiler.CharOperation
-import scala.tools.nsc.interactive.Response
-import org.scalaide.core.extensions.SourceFileProvider
-import org.eclipse.jdt.core.JavaModelException
+import org.eclipse.jdt.internal.core.util.HandleFactory
 import org.scalaide.core.compiler.InteractiveCompilationUnit
-import org.eclipse.core.runtime.IPath
-import scala.util.control.Exception
-import org.eclipse.core.runtime.CoreException
 import org.scalaide.core.compiler.ScalaCompilationProblem
+import org.scalaide.core.extensions.SourceFileProvider
+import org.scalaide.core.resources.EclipseFile
 
 class ScalaSourceFileProvider extends SourceFileProvider {
   override def createFrom(path: IPath): Option[InteractiveCompilationUnit] =
@@ -33,22 +36,24 @@ class ScalaSourceFileProvider extends SourceFileProvider {
 
 object ScalaSourceFile {
 
-  /** Considering [[org.eclipse.jdt.internal.core.util.HandleFactory]] isn't thread-safe, and because
-   *  `ScalaSourceFile#createFromPath` can be called concurrently from different threads, using a
-   *  `ThreadLocal` ensures that a `HandleFactory` instance is never shared across threads.
+  /**
+   * Considering [[org.eclipse.jdt.internal.core.util.HandleFactory]] isn't thread-safe, and because
+   * `ScalaSourceFile#createFromPath` can be called concurrently from different threads, using a
+   * `ThreadLocal` ensures that a `HandleFactory` instance is never shared across threads.
    */
   private val handleFactory: ThreadLocal[HandleFactory] = new ThreadLocal[HandleFactory] {
     override protected def initialValue(): HandleFactory = new HandleFactory
   }
 
-  /** Creates a Scala source file handle if the given resource path points to a scala source.
-   *  The resource path is a path to a Scala source file in the workbench (e.g. /Proj/a/b/c/Foo.scala).
+  /**
+   * Creates a Scala source file handle if the given resource path points to a scala source.
+   * The resource path is a path to a Scala source file in the workbench (e.g. /Proj/a/b/c/Foo.scala).
    *
-   *  @note This assumes that the resource path is the toString() of an `IPath`.
+   * @note This assumes that the resource path is the toString() of an `IPath`.
    *
-   *  @param path Is a path to a Scala source file in the workbench.
+   * @param path Is a path to a Scala source file in the workbench.
    */
-  def createFromPath(path: String) : Option[ScalaSourceFile] = {
+  def createFromPath(path: String): Option[ScalaSourceFile] = {
     if (!path.endsWith(".scala"))
       None
     else {
@@ -56,35 +61,35 @@ object ScalaSourceFile {
       val unusedScope = null
       val source = handleFactory.get().createOpenable(path, unusedScope)
       source match {
-        case ssf : ScalaSourceFile => Some(ssf)
-        case _ => None
+        case ssf: ScalaSourceFile ⇒ Some(ssf)
+        case _                    ⇒ None
       }
     }
   }
 }
 
-class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCopyOwner : WorkingCopyOwner)
-  extends JDTCompilationUnit(fragment, elementName, workingCopyOwner) with ScalaCompilationUnit with IScalaSourceFile {
+class ScalaSourceFile(fragment: PackageFragment, elementName: String, workingCopyOwner: WorkingCopyOwner)
+    extends JDTCompilationUnit(fragment, elementName, workingCopyOwner) with ScalaCompilationUnit with IScalaSourceFile {
 
-  override def getMainTypeName : Array[Char] =
+  override def getMainTypeName: Array[Char] =
     getElementName.substring(0, getElementName.length - ".scala".length).toCharArray()
 
-  /** Schedule this source file for reconciliation. Add the file to
-   *  the loaded files managed by the presentation compiler.
+  /**
+   * Schedule this source file for reconciliation. Add the file to
+   * the loaded files managed by the presentation compiler.
    */
   override def initialReconcile(): Response[Unit] = {
     val reloaded = super.initialReconcile()
 
     this.reconcile(
-        ICompilationUnit.NO_AST,
-        false /* don't force problem detection */,
-        null /* use primary owner */,
-        null /* no progress monitor */);
+      ICompilationUnit.NO_AST,
+      false /* don't force problem detection */,
+      null /* use primary owner */,
+      null /* no progress monitor */)
 
     reloaded
   }
 
-  /* getProblems should be reserved for a Java context, @see getProblems */
   def reconcile(newContents: String): List[ScalaCompilationProblem] = {
     super.forceReconcile()
   }
@@ -97,19 +102,19 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
    * @see #1002412
    */
   override def reconcile(
-      astLevel : Int,
-      reconcileFlags : Int,
-      workingCopyOwner : WorkingCopyOwner,
-      monitor : IProgressMonitor) : org.eclipse.jdt.core.dom.CompilationUnit = {
+    astLevel: Int,
+    reconcileFlags: Int,
+    workingCopyOwner: WorkingCopyOwner,
+    monitor: IProgressMonitor): CompilationUnit = {
     null
   }
 
   override def makeConsistent(
-    astLevel : Int,
-    resolveBindings : Boolean,
-    reconcileFlags : Int,
-    problems : JHashMap[_,_],
-    monitor : IProgressMonitor) : org.eclipse.jdt.core.dom.CompilationUnit = {
+    astLevel: Int,
+    resolveBindings: Boolean,
+    reconcileFlags: Int,
+    problems: JHashMap[_, _],
+    monitor: IProgressMonitor): CompilationUnit = {
 
     // don't rerun this expensive operation unless necessary
     if (!isConsistent()) {
@@ -122,14 +127,14 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
     null
   }
 
-  override def codeSelect(offset : Int, length : Int, workingCopyOwner : WorkingCopyOwner) : Array[IJavaElement] =
+  override def codeSelect(offset: Int, length: Int, workingCopyOwner: WorkingCopyOwner): Array[IJavaElement] =
     codeSelect(this, offset, length, workingCopyOwner)
 
-  override lazy val file : AbstractFile = {
-    val res = try { getCorrespondingResource } catch { case _: JavaModelException => null }
+  override lazy val file: AbstractFile = {
+    val res = try { getCorrespondingResource } catch { case _: JavaModelException ⇒ null }
     res match {
-      case f : IFile => new EclipseFile(f)
-      case _ => new VirtualFile(getElementName, getPath.toString)
+      case f: IFile ⇒ new EclipseFile(f)
+      case _        ⇒ new VirtualFile(getElementName, getPath.toString)
     }
   }
 
@@ -139,9 +144,10 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
     if (probs.isEmpty) null else probs.toArray
   }
 
-  override def getType(name : String) : IType = new LazyToplevelClass(this, name)
+  override def getType(name: String): IType =
+    new LazyToplevelClass(this, name)
 
-  override def getContents() : Array[Char] = {
+  override def getContents(): Array[Char] = {
     // in the following case, super#getContents() logs an exception for no good reason
     if (getBufferManager().getBuffer(this) == null && getResource().getLocation() == null && getResource().getLocationURI() == null) {
       return CharOperation.NO_CHAR
@@ -150,7 +156,7 @@ class ScalaSourceFile(fragment : PackageFragment, elementName: String, workingCo
   }
 
   /** Makes sure {{{this}}} source is not in the ignore buffer of the compiler and ask the compiler to reload it. */
-  final def forceReload(): Unit = scalaProject.presentationCompiler { compiler =>
+  final def forceReload(): Unit = scalaProject.presentationCompiler { compiler ⇒
     compiler.askToDoFirst(this)
     reload()
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -68,6 +68,13 @@ object ScalaProject {
 
   /** Listen for [[IWorkbenchPart]] event and takes care of loading/discarding scala compilation units.*/
   private class ProjectPartListener(project: ScalaProject) extends PartAdapter with HasLogger {
+    override def partActivated(part: IWorkbenchPart): Unit = {
+      doWithCompilerAndFile(part) { (_, _) =>
+        logger.debug(s"Restarting presentation compiler for ${project.underlying.getName} because ${part.getTitle} gained focus.")
+        project.presentationCompiler.askRestart()
+      }
+    }
+
     override def partOpened(part: IWorkbenchPart): Unit = {
       doWithCompilerAndFile(part) { (compiler, ssf) =>
         logger.debug("open " + part.getTitle)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -71,9 +71,11 @@ object ScalaProject {
   /** Listen for [[IWorkbenchPart]] event and takes care of loading/discarding scala compilation units.*/
   private class ProjectPartListener(project: ScalaProject) extends PartAdapter with HasLogger {
     override def partActivated(part: IWorkbenchPart): Unit = {
-      doWithCompilerAndFile(part) { (_, _) =>
-        logger.debug(s"Restarting presentation compiler for ${project.underlying.getName} because ${part.getTitle} gained focus.")
-        project.presentationCompiler.askRestart()
+      doWithCompilerAndFile(part) { (_, ssf) =>
+        if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
+          logger.debug(s"Restarting presentation compiler for ${project.underlying.getName} because ${part.getTitle} gained focus.")
+          project.presentationCompiler.askRestart()
+        }
       }
     }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -55,6 +55,7 @@ import org.scalaide.ui.internal.editor.ScalaEditor
 import org.scalaide.ui.internal.preferences.CompilerSettings
 import org.scalaide.ui.internal.preferences.IDESettings
 import org.scalaide.ui.internal.preferences.PropertyStore
+import org.scalaide.ui.internal.preferences.ResourcesPreferences
 import org.scalaide.ui.internal.preferences.ScalaPluginSettings
 import org.scalaide.util.eclipse.EclipseUtils
 import org.scalaide.util.eclipse.FileUtils
@@ -71,10 +72,13 @@ object ScalaProject {
   /** Listen for [[IWorkbenchPart]] event and takes care of loading/discarding scala compilation units.*/
   private class ProjectPartListener(project: ScalaProject) extends PartAdapter with HasLogger {
     override def partActivated(part: IWorkbenchPart): Unit = {
-      doWithCompilerAndFile(part) { (_, ssf) =>
-        if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
-          logger.debug(s"Restarting presentation compiler for ${project.underlying.getName} because ${part.getTitle} gained focus.")
-          project.presentationCompiler.askRestart()
+      val isPcAutoRestartEnabled = IScalaPlugin().getPreferenceStore.getBoolean(ResourcesPreferences.PRES_COMP_AUTO_RESTART)
+      if (isPcAutoRestartEnabled) {
+        doWithCompilerAndFile(part) { (_, ssf) =>
+          if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
+            logger.debug(s"Restarting presentation compiler for ${project.underlying.getName} because ${part.getTitle} gained focus.")
+            project.presentationCompiler.askRestart()
+          }
         }
       }
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
@@ -1,7 +1,9 @@
 package org.scalaide.ui.internal.editor
 
 import java.util.ResourceBundle
+
 import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.jdt.core.dom.AST
 import org.eclipse.jdt.core.dom.CompilationUnit
 import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitEditor
 import org.eclipse.jdt.internal.ui.javaeditor.JavaSourceViewer
@@ -33,13 +35,14 @@ import org.eclipse.swt.events.VerifyEvent
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.ui.IWorkbenchCommandConstants
 import org.eclipse.ui.PlatformUI
+import org.eclipse.ui.part.WorkbenchPart
 import org.eclipse.ui.texteditor.IAbstractTextEditorHelpContextIds
 import org.eclipse.ui.texteditor.ITextEditorActionConstants
 import org.eclipse.ui.texteditor.TextOperationAction
-import org.eclipse.ui.part.WorkbenchPart
 import org.scalaide.core.internal.ScalaPlugin
 import org.scalaide.core.internal.extensions.SemanticHighlightingParticipants
 import org.scalaide.core.internal.jdt.model.ScalaCompilationUnit
+import org.scalaide.core.internal.jdt.model.ScalaSourceFile
 import org.scalaide.logging.HasLogger
 import org.scalaide.refactoring.internal.OrganizeImports
 import org.scalaide.refactoring.internal.RefactoringHandler
@@ -51,13 +54,11 @@ import org.scalaide.ui.internal.actions
 import org.scalaide.ui.internal.editor.decorators.semantichighlighting.TextPresentationEditorHighlighter
 import org.scalaide.ui.internal.editor.decorators.semantichighlighting.TextPresentationHighlighter
 import org.scalaide.ui.internal.editor.hover.FocusedControlCreator
+import org.scalaide.ui.internal.editor.outline.OutlinePageEditorExtension
 import org.scalaide.ui.internal.preferences.EditorPreferencePage
+import org.scalaide.util.Utils
 import org.scalaide.util.eclipse.EclipseUtils
 import org.scalaide.util.ui.DisplayThread
-import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.eclipse.jdt.core.dom.AST
-import org.scalaide.util.Utils
-import org.scalaide.ui.internal.editor.outline.OutlinePageEditorExtension
 
 class ScalaSourceFileEditor
     extends CompilationUnitEditor

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceViewerConfiguration.scala
@@ -97,7 +97,6 @@ class ScalaSourceViewerConfiguration(
     }
 
   override def getOutlinePresenter(sourceViewer: ISourceViewer, doCodeResolve: Boolean): IInformationPresenter = {
-
     val presenter = new InformationPresenter(getOutlinePresenterControlCreator(sourceViewer, IJavaEditorActionDefinitionIds.SHOW_OUTLINE))
     presenter.setDocumentPartitioning(getConfiguredDocumentPartitioning(sourceViewer))
     presenter.setAnchor(AbstractInformationControlManager.ANCHOR_GLOBAL)
@@ -106,6 +105,7 @@ class ScalaSourceViewerConfiguration(
     presenter.setSizeConstraints(50, 20, true, false)
     presenter
   }
+
   override def getTabWidth(sourceViewer: ISourceViewer): Int =
     combinedPrefStore.getInt(IndentSpaces.eclipseKey)
 
@@ -222,7 +222,8 @@ class ScalaSourceViewerConfiguration(
   override def getAnnotationHover(sourceViewer: ISourceViewer) = annotationHover
 
   /**
-   * Creates a reconciler with a delay of 500ms.
+   * Creates a reconciler with a configurable delay. The delay can be set in the
+   * user preferences.
    */
   override def getReconciler(sourceViewer: ISourceViewer): IReconciler =
     reconciler

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ResourcesPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ResourcesPreferencePage.scala
@@ -30,6 +30,7 @@ class ResourcesPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefe
   // these ones are disposed by parent class
   private var closingEnabledEditor: BooleanFieldEditor = null
   private var maxIdlenessLengthEditor: IntegerFieldEditor = null
+  private var autoRestart: BooleanFieldEditor = null
 
   override def init(wb: IWorkbench): Unit = {}
 
@@ -59,6 +60,9 @@ class ResourcesPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefe
     }
     maxIdlenessLengthEditor.setValidRange(10, Integer.MAX_VALUE)
     addField(maxIdlenessLengthEditor)
+
+    autoRestart = new BooleanFieldEditor(PRES_COMP_AUTO_RESTART, "Automatically restart PC on builds and editor focus changes if editor contains errors or warnings.\n This helps to prevent false positive errors shown in the editor.", presCompGroup)
+    addField(autoRestart)
   }
 
   override def initialize(): Unit = {
@@ -76,6 +80,7 @@ class ResourcesPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefe
   override def dispose(): Unit = {
     if (presCompGroup != null) presCompGroup.dispose()
     if (presCompInnerGroup != null) presCompInnerGroup.dispose()
+    if (autoRestart != null) autoRestart.dispose()
     super.dispose()
   }
 
@@ -110,6 +115,7 @@ object ResourcesPreferences {
 
   val PRES_COMP_CLOSE_UNUSED = "org.scala-ide.sdt.core.resources.presentationCompiler.closeUnused"
   val PRES_COMP_MAX_IDLENESS_LENGTH = "org.scala-ide.sdt.core.resources.presentationCompiler.maxIdlenessLength"
+  val PRES_COMP_AUTO_RESTART = "org.scala-ide.sdt.core.resources.presentationCompiler.autoRestart"
 
   /**
    * Changes in preferences related to closing presentation compilers should be always taken into account together.
@@ -128,5 +134,6 @@ class ResourcesPreferencePageInitializer extends AbstractPreferenceInitializer {
     store.setDefault(PRES_COMP_CLOSE_UNUSED, true)
     store.setDefault(PRES_COMP_MAX_IDLENESS_LENGTH, 120)
     store.setDefault(PRES_COMP_PREFERENCES_CHANGE_MARKER, true)
+    store.setDefault(PRES_COMP_AUTO_RESTART, true)
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ResourcesPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ResourcesPreferencePage.scala
@@ -61,7 +61,7 @@ class ResourcesPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefe
     maxIdlenessLengthEditor.setValidRange(10, Integer.MAX_VALUE)
     addField(maxIdlenessLengthEditor)
 
-    autoRestart = new BooleanFieldEditor(PRES_COMP_AUTO_RESTART, "Automatically restart PC on builds and editor focus changes if editor contains errors or warnings.\n This helps to prevent false positive errors shown in the editor.", presCompGroup)
+    autoRestart = new BooleanFieldEditor(PRES_COMP_AUTO_RESTART, "Automatically restart PC on editor focus changes if editor contains errors or warnings.\n This helps to prevent false positive errors shown in the editor.", presCompGroup)
     addField(autoRestart)
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
@@ -45,13 +45,11 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
         forceReconciling()
       }
     }
-
-    override def partDeactivated(part: IWorkbenchPart): Unit = {}
   }
 
   /** Listen for presentation-compiler restart events. */
   object compilerListener extends Subscriber[PresentationCompilerActivity, PresentationCompilerProxy] {
-    def notify(pub: PresentationCompilerProxy, event: PresentationCompilerActivity): Unit = event match {
+    override def notify(pub: PresentationCompilerProxy, event: PresentationCompilerActivity): Unit = event match {
       case Restart =>
         if (pub == compilerProxy) {
           logger.debug(s"Reconciling ${editor.getTitle} due to restart")
@@ -77,8 +75,6 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
         forceReconciling()
       }
     }
-
-    override def shellDeactivated(event: ShellEvent): Unit = {}
   }
 
   override def install(textViewer: ITextViewer): Unit = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
@@ -11,6 +11,7 @@ import org.eclipse.swt.widgets.Control
 import org.eclipse.ui.IPartService
 import org.eclipse.ui.IWorkbenchPart
 import org.eclipse.ui.texteditor.ITextEditor
+import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.compiler.IPresentationCompilerProxy
 import org.scalaide.core.internal.compiler.PresentationCompilerActivity
 import org.scalaide.core.internal.compiler.PresentationCompilerProxy
@@ -18,6 +19,7 @@ import org.scalaide.core.internal.compiler.Restart
 import org.scalaide.logging.HasLogger
 import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
 import org.scalaide.ui.internal.actions.PartAdapter
+import org.scalaide.ui.internal.preferences.ResourcesPreferences
 import org.scalaide.util.Utils._
 import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.eclipse.SWTUtils
@@ -73,7 +75,10 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
 
     override def shellActivated(event: ShellEvent): Unit = {
       if (!control.isDisposed() && control.isVisible()) {
-        restartPc()
+        val isPcAutoRestartEnabled = IScalaPlugin().getPreferenceStore.getBoolean(ResourcesPreferences.PRES_COMP_AUTO_RESTART)
+        if (isPcAutoRestartEnabled) {
+          restartPc()
+        }
         forceReconciling()
       }
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
@@ -1,25 +1,26 @@
 package org.scalaide.ui.internal.reconciliation
 
-import org.eclipse.jface.text.reconciler.MonoReconciler
-import org.scalaide.ui.internal.actions.PartAdapter
-import org.eclipse.ui.IWorkbenchPart
-import org.eclipse.jface.text.reconciler.IReconcilingStrategy
-import org.eclipse.jface.text.ITextViewer
-import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
-import org.eclipse.ui.IPartService
-import org.eclipse.ui.texteditor.ITextEditor
 import scala.collection.mutable.Subscriber
+
+import org.eclipse.jface.text.ITextViewer
+import org.eclipse.jface.text.reconciler.IReconcilingStrategy
+import org.eclipse.jface.text.reconciler.MonoReconciler
+import org.eclipse.swt.events.ShellAdapter
+import org.eclipse.swt.events.ShellEvent
+import org.eclipse.swt.widgets.Control
+import org.eclipse.ui.IPartService
+import org.eclipse.ui.IWorkbenchPart
+import org.eclipse.ui.texteditor.ITextEditor
+import org.scalaide.core.compiler.IPresentationCompilerProxy
 import org.scalaide.core.internal.compiler.PresentationCompilerActivity
 import org.scalaide.core.internal.compiler.PresentationCompilerProxy
-import org.scalaide.logging.HasLogger
-import org.scalaide.core.compiler.IPresentationCompilerProxy
-import org.scalaide.util.Utils._
-import org.eclipse.swt.events.ShellAdapter
-import org.eclipse.swt.widgets.Control
-import org.eclipse.swt.events.ShellEvent
-import org.scalaide.util.eclipse.SWTUtils
 import org.scalaide.core.internal.compiler.Restart
+import org.scalaide.logging.HasLogger
+import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
+import org.scalaide.ui.internal.actions.PartAdapter
+import org.scalaide.util.Utils._
 import org.scalaide.util.eclipse.EditorUtils
+import org.scalaide.util.eclipse.SWTUtils
 
 /** A Scala reconciler that forces reconciliation on various events:
  *   - the editor is shown through tab navigation

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
@@ -19,6 +19,8 @@ import org.eclipse.swt.widgets.Control
 import org.eclipse.swt.events.ShellEvent
 import org.scalaide.util.eclipse.SWTUtils
 import org.scalaide.core.internal.compiler.Restart
+import org.scalaide.util.eclipse.EditorUtils
+import org.scalaide.core.IScalaPlugin
 
 /** A Scala reconciler that forces reconciliation on various events:
  *   - the editor is shown through tab navigation
@@ -61,8 +63,17 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
 
   /** Listen for events regarding Eclipse getting focus. */
   class ActivationListener(control: Control) extends ShellAdapter {
+    def restartPc() = {
+      EditorUtils.resourceOfActiveEditor.foreach { r ⇒
+        logger.debug(s"Restarting presentation compiler for ${r.getProject.getName} because Eclipse gained focus.")
+        val scalaProject = IScalaPlugin().asScalaProject(r.getProject)
+        scalaProject foreach (_.presentationCompiler.askRestart())
+      }
+    }
+
     override def shellActivated(event: ShellEvent): Unit = {
       if (!control.isDisposed() && control.isVisible()) {
+        restartPc()
         forceReconciling()
       }
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
@@ -52,7 +52,7 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
     def notify(pub: PresentationCompilerProxy, event: PresentationCompilerActivity): Unit = event match {
       case Restart =>
         if (pub == compilerProxy) {
-          logger.debug("Reconciling due to restart")
+          logger.debug(s"Reconciling ${editor.getTitle} due to restart")
           forceReconciling()
         }
       case _ =>


### PR DESCRIPTION
Because the PC ofter shows false positives the idea is to automatically
restart the PC, which would get rid of the false positives. After a
restart all of the invalid state in the PC is gone. A better fix would
be to not get invalid state in the PC but I don't understand the PC good
enough to provide such a fix.

The PC is automatically restart in the following situations:

- After Eclipse gained focus. This happens once Eclipse lost focus
  and gained it afterwards.
- After an editor gained focus. This happens when a different editor
  is selected.

Since restarting the PC is relatively fast and happens asynchronously in
the background, this shouldn't block users in any way.

Fix #1002725