### PR TITLE
Do not show errors for block imports

### DIFF
--- a/org.scala-ide.sdt.core/scala-ide-style-config.xml
+++ b/org.scala-ide.sdt.core/scala-ide-style-config.xml
@@ -114,5 +114,5 @@
  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="false"/>
  <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="false"/>
  <check level="warning" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="false" />
- <check level="error" class="org.scalastyle.scalariform.BlockImportChecker" enabled="true"/>
+ <check level="error" class="org.scalastyle.scalariform.BlockImportChecker" enabled="false"/>
 </scalastyle>


### PR DESCRIPTION
There is a bug for block imports. The following is detected as a block
import but it shouldn't:

    import a.b.{ x => y }

As long as this bug is not fixed, it is better to disable this style
check, otherwise it just breaks our build for rename imports.