### PR TITLE
Revert introduction of new feature that can automatically restart PC

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/ScalaProject.scala
@@ -55,7 +55,6 @@ import org.scalaide.ui.internal.editor.ScalaEditor
 import org.scalaide.ui.internal.preferences.CompilerSettings
 import org.scalaide.ui.internal.preferences.IDESettings
 import org.scalaide.ui.internal.preferences.PropertyStore
-import org.scalaide.ui.internal.preferences.ResourcesPreferences
 import org.scalaide.ui.internal.preferences.ScalaPluginSettings
 import org.scalaide.util.eclipse.EclipseUtils
 import org.scalaide.util.eclipse.FileUtils
@@ -71,18 +70,6 @@ object ScalaProject {
 
   /** Listen for [[IWorkbenchPart]] event and takes care of loading/discarding scala compilation units.*/
   private class ProjectPartListener(project: ScalaProject) extends PartAdapter with HasLogger {
-    override def partActivated(part: IWorkbenchPart): Unit = {
-      val isPcAutoRestartEnabled = IScalaPlugin().getPreferenceStore.getBoolean(ResourcesPreferences.PRES_COMP_AUTO_RESTART)
-      if (isPcAutoRestartEnabled) {
-        doWithCompilerAndFile(part) { (_, ssf) =>
-          if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
-            logger.debug(s"Restarting presentation compiler for ${project.underlying.getName} because ${part.getTitle} gained focus.")
-            project.presentationCompiler.askRestart()
-          }
-        }
-      }
-    }
-
     override def partOpened(part: IWorkbenchPart): Unit = {
       doWithCompilerAndFile(part) { (_, ssf) =>
         logger.debug("open " + part.getTitle)

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ResourcesPreferencePage.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/preferences/ResourcesPreferencePage.scala
@@ -30,7 +30,6 @@ class ResourcesPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefe
   // these ones are disposed by parent class
   private var closingEnabledEditor: BooleanFieldEditor = null
   private var maxIdlenessLengthEditor: IntegerFieldEditor = null
-  private var autoRestart: BooleanFieldEditor = null
 
   override def init(wb: IWorkbench): Unit = {}
 
@@ -60,9 +59,6 @@ class ResourcesPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefe
     }
     maxIdlenessLengthEditor.setValidRange(10, Integer.MAX_VALUE)
     addField(maxIdlenessLengthEditor)
-
-    autoRestart = new BooleanFieldEditor(PRES_COMP_AUTO_RESTART, "Automatically restart PC on editor focus changes if editor contains errors or warnings.\n This helps to prevent false positive errors shown in the editor.", presCompGroup)
-    addField(autoRestart)
   }
 
   override def initialize(): Unit = {
@@ -80,7 +76,6 @@ class ResourcesPreferencePage extends FieldEditorPreferencePage(FieldEditorPrefe
   override def dispose(): Unit = {
     if (presCompGroup != null) presCompGroup.dispose()
     if (presCompInnerGroup != null) presCompInnerGroup.dispose()
-    if (autoRestart != null) autoRestart.dispose()
     super.dispose()
   }
 
@@ -115,7 +110,6 @@ object ResourcesPreferences {
 
   val PRES_COMP_CLOSE_UNUSED = "org.scala-ide.sdt.core.resources.presentationCompiler.closeUnused"
   val PRES_COMP_MAX_IDLENESS_LENGTH = "org.scala-ide.sdt.core.resources.presentationCompiler.maxIdlenessLength"
-  val PRES_COMP_AUTO_RESTART = "org.scala-ide.sdt.core.resources.presentationCompiler.autoRestart"
 
   /**
    * Changes in preferences related to closing presentation compilers should be always taken into account together.
@@ -134,6 +128,5 @@ class ResourcesPreferencePageInitializer extends AbstractPreferenceInitializer {
     store.setDefault(PRES_COMP_CLOSE_UNUSED, true)
     store.setDefault(PRES_COMP_MAX_IDLENESS_LENGTH, 120)
     store.setDefault(PRES_COMP_PREFERENCES_CHANGE_MARKER, true)
-    store.setDefault(PRES_COMP_AUTO_RESTART, true)
   }
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/reconciliation/ScalaReconciler.scala
@@ -11,7 +11,6 @@ import org.eclipse.swt.widgets.Control
 import org.eclipse.ui.IPartService
 import org.eclipse.ui.IWorkbenchPart
 import org.eclipse.ui.texteditor.ITextEditor
-import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.compiler.IPresentationCompilerProxy
 import org.scalaide.core.internal.compiler.PresentationCompilerActivity
 import org.scalaide.core.internal.compiler.PresentationCompilerProxy
@@ -19,9 +18,7 @@ import org.scalaide.core.internal.compiler.Restart
 import org.scalaide.logging.HasLogger
 import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
 import org.scalaide.ui.internal.actions.PartAdapter
-import org.scalaide.ui.internal.preferences.ResourcesPreferences
 import org.scalaide.util.Utils._
-import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.util.eclipse.SWTUtils
 
 /** A Scala reconciler that forces reconciliation on various events:
@@ -63,22 +60,8 @@ class ScalaReconciler(editor: InteractiveCompilationUnitEditor,
 
   /** Listen for events regarding Eclipse getting focus. */
   class ActivationListener(control: Control) extends ShellAdapter {
-    def restartPc() = {
-      EditorUtils.withCurrentScalaSourceFile { ssf ⇒
-        if (Option(ssf.getProblems()).exists(_.nonEmpty)) {
-          val scalaProject = ssf.scalaProject
-          logger.debug(s"Restarting presentation compiler for ${scalaProject.underlying.getName} because Eclipse gained focus.")
-          scalaProject.presentationCompiler.askRestart()
-        }
-      }
-    }
-
     override def shellActivated(event: ShellEvent): Unit = {
       if (!control.isDisposed() && control.isVisible()) {
-        val isPcAutoRestartEnabled = IScalaPlugin().getPreferenceStore.getBoolean(ResourcesPreferences.PRES_COMP_AUTO_RESTART)
-        if (isPcAutoRestartEnabled) {
-          restartPc()
-        }
         forceReconciling()
       }
     }


### PR DESCRIPTION
The automatic restarts of the PC were introduced in order to get rid of
false positive errors that are shown in the editor. After testing this
feature for some time in usage it turned out that this feature is
basically worthless.

The main problem is that most of the time an editor shown real errors or
warnings and in all of these cases the PC is restarted, even though it
shouldn't. There is no way to test if an error is a false positive or
not, therefore the PC is restarted many times, which not only slows down
the editor but also has weird effects. Semantic highlighting often is
cleared after the PC is restarted and therefore users have to live only
with syntax highlighting for a second or two. The automatic restarts
of the PC basically are an unsafe feature and should only be used
manually by the user. Syncing all of the possible semantic features of
the IDE with the restart times of the PC may be possible but seem to
require heavy efforts, which should not be invested in a feature that
after all is a hack to work around bugs in the PC.

Because of this, this new feature is removed.

Fix #1002741
Re #1002725