### PR TITLE
Allows scalac ignores java errors.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -40,6 +40,7 @@ import org.scalaide.core.sbtbuilder.OutputFoldersTest
 import org.scalaide.core.sbtbuilder.ProjectDependenciesTest
 import org.scalaide.core.sbtbuilder.SbtBuilderTest
 import org.scalaide.core.sbtbuilder.ScalaCompilerClasspathTest
+import org.scalaide.core.sbtbuilder.ScalacNotUnderstandJavaTest
 import org.scalaide.core.sbtbuilder.ScalaJavaDepTest
 import org.scalaide.core.sbtbuilder.ScalaJavaDepTicket_1000607Test
 import org.scalaide.core.sbtbuilder.ScalaJavaDepWhenJavaIsWrongTest
@@ -130,6 +131,7 @@ import org.scalaide.ui.internal.preferences.StringListMapperTest
     classOf[ScopeCompileConfigurationTest],
     classOf[OutlineModelTest],
     classOf[StringListMapperTest],
-    classOf[NonScalaSourceErrorMarkersTest]
+    classOf[NonScalaSourceErrorMarkersTest],
+    classOf[ScalacNotUnderstandJavaTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalacNotUnderstandJavaTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalacNotUnderstandJavaTest.scala
@@ -1,0 +1,58 @@
+package org.scalaide.core
+package sbtbuilder
+
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.junit.Assert._
+import org.junit.BeforeClass
+import org.junit.Test
+import org.scalaide.core.testsetup.SDTTestUtils
+
+object ScalacNotUnderstandJavaTest extends testsetup.TestProjectSetup("scalacnotunderstandjava") {
+  @BeforeClass def setup(): Unit = {
+    SDTTestUtils.enableAutoBuild(false)
+  }
+}
+
+class ScalacNotUnderstandJavaTest {
+  import ScalacNotUnderstandJavaTest._
+  import testsetup.SDTTestUtils._
+
+  @Test def shouldContinueJavaCompilationEvenWhenScalacDoesNotUnderstandJavaFile(): Unit = {
+    val NoErrors = 0
+    val JavaCannotConvertFromStringToInt = 1
+    cleanProject()
+
+    val SScalaCU = compilationUnit("test/S.scala")
+    val JJavaCU = compilationUnit("test/J.java")
+    def findProblems() = getProblemMarkers(JJavaCU, SScalaCU)
+
+    rebuild()
+    val problems0 = findProblems()
+    assertTrue("One build error expected, got: " + markersMessages(problems0), problems0.length == NoErrors)
+
+    val originalSScala = slurpAndClose(project.underlying.getFile("src/test/S.scala").getContents)
+    changeContentOfFile(SScalaCU.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], changedSScala)
+    rebuild()
+    val problems1 = findProblems()
+    assertTrue("One build error expected, got: " + markersMessages(problems1), problems1.length == JavaCannotConvertFromStringToInt)
+
+    changeContentOfFile(SScalaCU.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], originalSScala)
+    rebuild()
+    val problems2 = findProblems()
+    assertTrue("Build errors found: " + markersMessages(problems2), problems2.isEmpty)
+  }
+
+  private def rebuild(): Unit = {
+    project.underlying.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor)
+  }
+
+  lazy private val changedSScala = """
+package test
+
+class S {
+  def foo = "51"
+}
+"""
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>scalacnotunderstandjava</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/src/test/J.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/src/test/J.java
@@ -1,0 +1,14 @@
+package test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value=RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+@interface ScalacDoesNotGetMe {}
+
+class J<@ScalacDoesNotGetMe X> {
+  public int f = (new S()).foo();
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/src/test/S.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scalacnotunderstandjava/src/test/S.scala
@@ -1,0 +1,5 @@
+package test
+
+class S {
+  def foo = 51
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtBuildReporter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtBuildReporter.scala
@@ -13,7 +13,7 @@ import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.SbtUtils
 
 private case class SbtProblem(severity: xsbti.Severity, message: String, position: xsbti.Position, category: String)
-  extends xsbti.Problem {
+    extends xsbti.Problem {
 
   import SbtUtils.m2o
 
@@ -54,25 +54,46 @@ private[zinc] class SbtBuildReporter(project: IScalaProject) extends xsbti.Repor
   override def problems: Array[xsbti.Problem] = probs.toArray
   override def comment(pos: xsbti.Position, msg: String): Unit = {}
 
+  private def riseErrorOrWarning(sev: xsbti.Severity): Unit = {
+    import xsbti.Severity._
+    sev match {
+      case Warn => seenWarnings = true
+      case Error => seenErrors = true
+      case _ =>
+    }
+  }
+
+  private def riseNonJavaErrorOrWarning(pos: xsbti.Position, sev: xsbti.Severity): Unit =
+    SbtUtils.m2o(pos.sourceFile).flatMap { file =>
+      FileUtils.resourceForPath(new Path(file.getAbsolutePath), project.underlying.getFullPath)
+    }.map { resource =>
+      if (resource.getFileExtension != "java")
+        riseErrorOrWarning(_)
+      else
+        (sev: xsbti.Severity) => ()
+    }.orElse {
+      Option(riseErrorOrWarning(_))
+    }.foreach(_(sev))
+
   override def log(pos: xsbti.Position, msg: String, sev: xsbti.Severity): Unit = {
     val problem = SbtProblem(sev, msg, pos, "compile")
     if (!probs.contains(problem)) {
       createMarker(pos, msg, sev)
       probs += problem
     }
-
-    import xsbti.Severity._
-    sev match {
-      case Warn  => seenWarnings = true
-      case Error => seenErrors = true
-      case _     =>
-    }
+    riseNonJavaErrorOrWarning(pos, sev)
   }
 
   def eclipseSeverity(severity: xsbti.Severity): Int = severity match {
-    case xsbti.Severity.Info  => IMarker.SEVERITY_INFO
+    case xsbti.Severity.Info => IMarker.SEVERITY_INFO
     case xsbti.Severity.Error => IMarker.SEVERITY_ERROR
-    case xsbti.Severity.Warn  => IMarker.SEVERITY_WARNING
+    case xsbti.Severity.Warn => IMarker.SEVERITY_WARNING
+  }
+
+  def riseJavaErrorOrWarning(severity: Int) = severity match {
+    case IMarker.SEVERITY_WARNING => riseErrorOrWarning(xsbti.Severity.Warn)
+    case IMarker.SEVERITY_ERROR => riseErrorOrWarning(xsbti.Severity.Error)
+    case _ =>
   }
 
   def createMarker(pos: xsbti.Position, msg: String, sev: xsbti.Severity) = {
@@ -88,7 +109,7 @@ private[zinc] class SbtBuildReporter(project: IScalaProject) extends xsbti.Repor
       val markerPos = MarkerFactory.RegionPosition(offset, identifierLength(pos.lineContent, pos.pointer), line)
       BuildProblemMarker.create(resource, severity, msg, markerPos)
     } else
-      logger.error(s"suppressed error in Java file ${resource.getFullPath}:$line: $msg")
+      logger.info(s"suppressed error in Java file ${resource.getFullPath}:$line: $msg")
 
     // if we couldn't determine what file/offset to put this marker on, create one on the project
     if (!marker.isDefined) {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -47,13 +47,15 @@ class SbtInputs(installation: IScalaInstallation,
 
   def analysisMap(f: File): Maybe[Analysis] =
     if (f.isFile)
-      Maybe.just(Analysis.Empty)
+      Maybe.nothing[Analysis]
     else {
       val analysis = allProjects.collectFirst {
         case project if project.buildManager.buildManagerOf(f).nonEmpty =>
           project.buildManager.buildManagerOf(f).get.latestAnalysis(incOptions)
       }
-      Maybe.just(analysis.getOrElse(Analysis.Empty))
+      analysis.map { analysis =>
+        Maybe.just(analysis)
+      }.getOrElse(Maybe.nothing[Analysis])
     }
 
   def progress = Maybe.just(scalaProgress)


### PR DESCRIPTION
Java errors are reported to `SbtBuildReporter` by java compiler
directly.
Commit removes a bug when java depends on scala code (see `SbtInputs`)

Fixes #1002738