### PR TITLE
Ensure that mark occurrences is not called if it is disabled

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/MarkOccurrencesEditorExtension.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/MarkOccurrencesEditorExtension.scala
@@ -41,7 +41,8 @@ trait MarkOccurrencesEditorExtension extends ScalaCompilationUnitEditor {
   }
 
   override def updateOccurrenceAnnotations(selection: ITextSelection, astRoot: CompilationUnit): Unit = {
-    requireOccurrencesUpdate(selection)
+    if (isMarkingOccurrences)
+      requireOccurrencesUpdate(selection)
   }
 
   override def installOccurrencesFinder(forceUpdate: Boolean): Unit = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaCompilationUnitEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaCompilationUnitEditor.scala
@@ -13,8 +13,9 @@ import org.scalaide.ui.internal.actions.ScalaCopyQualifiedNameAction
 import org.scalaide.ui.internal.editor.decorators.indentguide.IndentGuidePainter
 import org.scalaide.ui.internal.editor.decorators.semantichighlighting
 import org.scalaide.ui.internal.editor.decorators.semicolon.InferredSemicolonPainter
+import org.scalaide.ui.internal.preferences.EditorPreferencePage
 import org.scalaide.ui.syntax.ScalaSyntaxClasses
-import org.scalaide.util.eclipse.SWTUtils.fnToPropertyChangeListener
+import org.scalaide.util.eclipse.SWTUtils._
 import org.scalaide.util.ui.DisplayThread
 
 /** Trait containing common logic used by both the `ScalaSourceFileEditor` and `ScalaClassFileEditor`.*/
@@ -109,4 +110,7 @@ trait ScalaCompilationUnitEditor extends JavaEditor with ScalaEditor {
   override final def getInteractiveCompilationUnit(): InteractiveCompilationUnit = {
     IScalaPlugin().scalaCompilationUnit(getEditorInput()).orNull
   }
+
+  override def isMarkingOccurrences =
+    scalaPrefStore.getBoolean(EditorPreferencePage.P_ENABLE_MARK_OCCURRENCES)
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaSourceFileEditor.scala
@@ -344,9 +344,6 @@ class ScalaSourceFileEditor
     }
   }
 
-  override def isMarkingOccurrences =
-    scalaPrefStore.getBoolean(EditorPreferencePage.P_ENABLE_MARK_OCCURRENCES)
-
   override def createSemanticHighlighter: TextPresentationHighlighter =
     TextPresentationEditorHighlighter(this, semanticHighlightingPreferences, addReconcilingListener _, removeReconcilingListener _)
 


### PR DESCRIPTION
There is no documentation on the `isMarkingOccurrences` method about
when it should be called. It was not called by the Java editor,
therefore we do it manually to ensure that mark occurrences is not
called when it is disabled.

Furthermore, the `isMarkingOccurrences` method is moved to
`ScalaCompilationUnitEditor` otherwise it can't be called in
`MarkOccurrencesEditorExtension`.