### PR TITLE
After migration to zinc all project is rebuilt

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalacNotUnderstandJavaTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/sbtbuilder/ScalacNotUnderstandJavaTest.scala
@@ -20,7 +20,6 @@ class ScalacNotUnderstandJavaTest {
   import testsetup.SDTTestUtils._
 
   @Test def shouldContinueJavaCompilationEvenWhenScalacDoesNotUnderstandJavaFile(): Unit = {
-    val NoErrors = 0
     val JavaCannotConvertFromStringToInt = 1
     cleanProject()
 
@@ -30,7 +29,7 @@ class ScalacNotUnderstandJavaTest {
 
     rebuild()
     val problems0 = findProblems()
-    assertTrue("One build error expected, got: " + markersMessages(problems0), problems0.length == NoErrors)
+    assertTrue("No build error expected, got: " + markersMessages(problems0), problems0.isEmpty)
 
     val originalSScala = slurpAndClose(project.underlying.getFile("src/test/S.scala").getContents)
     changeContentOfFile(SScalaCU.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], changedSScala)
@@ -41,7 +40,7 @@ class ScalacNotUnderstandJavaTest {
     changeContentOfFile(SScalaCU.getResource().getAdapter(classOf[IFile]).asInstanceOf[IFile], originalSScala)
     rebuild()
     val problems2 = findProblems()
-    assertTrue("Build errors found: " + markersMessages(problems2), problems2.isEmpty)
+    assertTrue("No build error expected, got: " + markersMessages(problems2), problems2.isEmpty)
   }
 
   private def rebuild(): Unit = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/AnalysisStore.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/AnalysisStore.scala
@@ -1,0 +1,24 @@
+package org.scalaide.core.internal.builder.zinc
+
+import sbt.internal.inc.Analysis
+
+import xsbti.compile.CompileAnalysis
+import xsbti.compile.MiniSetup
+
+object AnalysisStore {
+  import sbt.internal.inc.{ AnalysisStore => SbtAnalysisStore }
+  def materializeLazy(backing: SbtAnalysisStore): SbtAnalysisStore = new SbtAnalysisStore {
+    private def materializeApis(analysis: CompileAnalysis, setup: MiniSetup) = {
+      if (setup.storeApis()) {
+        val apis = analysis match { case a: Analysis => a.apis }
+        apis.internal.foreach { case (_, v) => v.api }
+        apis.external.foreach { case (_, v) => v.api }
+      }
+      (analysis, setup)
+    }
+    def set(analysis: CompileAnalysis, setup: MiniSetup): Unit = {
+      Function.tupled(backing.set _)(materializeApis(analysis, setup))
+    }
+    def get(): Option[(CompileAnalysis, MiniSetup)] = backing.get()
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
@@ -4,16 +4,16 @@ import java.io.File
 
 import org.scalaide.util.internal.SbtUtils
 
-import sbt.internal.inc.MixedAnalyzingCompiler
 import sbt.internal.inc.Analysis
+import sbt.internal.inc.IncrementalCompilerImpl
+import sbt.internal.inc.MixedAnalyzingCompiler
 import xsbti.Logger
 import xsbti.Reporter
-import xsbti.compile.ScalaCompiler
-import xsbti.compile.JavaCompiler
-import sbt.internal.inc.IncrementalCompilerImpl
-import xsbti.compile.PerClasspathEntryLookup
-import xsbti.compile.DefinesClass
 import xsbti.compile.CompileResult
+import xsbti.compile.DefinesClass
+import xsbti.compile.JavaCompiler
+import xsbti.compile.PerClasspathEntryLookup
+import xsbti.compile.ScalaCompiler
 
 /**
  * Contains a Scala and a Java compiler. Should be used instead of
@@ -56,7 +56,7 @@ class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logg
 
   private def cacheAndReturnLastAnalysis(compilationResult: CompileResult): Analysis = {
     if (compilationResult.hasModified)
-      MixedAnalyzingCompiler.staticCachedStore(cacheFile).set(compilationResult.analysis, compilationResult.setup)
+      AnalysisStore.materializeLazy(MixedAnalyzingCompiler.staticCachedStore(cacheFile)).set(compilationResult.analysis, compilationResult.setup)
     compilationResult.analysis match {
       case a: Analysis => a
       case a => throw new IllegalStateException(s"object of type `Analysis` was expected but got `${a.getClass}`.")

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -27,9 +27,9 @@ import org.scalaide.logging.HasLogger
 import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.SbtUtils
 
-import xsbti.CompileFailed
 import sbt.internal.inc.Analysis
 import sbt.internal.inc.SourceInfo
+import xsbti.CompileFailed
 import xsbti.F0
 import xsbti.Logger
 import xsbti.compile.CompileProgress
@@ -80,6 +80,7 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
     monitor = pm
     hasInternalErrors = false
     try {
+      ProductExposer.hideJavaCompilationProductsIfCompilationFailed(project.underlying)
       update(toBuild, removed)
     } catch {
       case oce: OperationCanceledException =>
@@ -89,6 +90,8 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
         BuildProblemMarker.create(project, e)
         eclipseLog.error("Error in Scala compiler", e)
         sbtReporter.log(SbtUtils.NoPosition, "SBT builder crashed while compiling. The error message is '" + e.getMessage() + "'. Check Error Log for details.", xsbti.Severity.Error)
+    } finally {
+      ProductExposer.showJavaCompilationProducts(project.underlying)
     }
     hasInternalErrors = sbtReporter.hasErrors || hasInternalErrors
     analysisStore.refreshLocal(IResource.DEPTH_ZERO, null)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
@@ -9,10 +9,6 @@ import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.resources.IncrementalProjectBuilder.INCREMENTAL_BUILD
 import org.eclipse.core.resources.ResourcesPlugin
-import org.eclipse.core.resources.IResource
-import xsbti.compile.JavaCompiler
-import xsbti.Logger
-import org.scalaide.core.internal.builder.JDTBuilderFacade
 import org.eclipse.core.runtime.SubMonitor
 import org.eclipse.jdt.core.IJavaModelMarker
 import org.scalaide.core.IScalaPlugin
@@ -34,14 +30,12 @@ class JavaEclipseCompiler(p: IProject, monitor: SubMonitor) extends JavaCompiler
 
   override def run(sources: Array[File], unusedOptions: Array[String], reporter: Reporter, unusedLog: Logger): Boolean = {
     val scalaProject = IScalaPlugin().getScalaProject(project)
-
     val allSourceFiles = scalaProject.allSourceFiles()
     val depends = scalaProject.directDependencies
     if (allSourceFiles.exists(FileUtils.hasBuildErrors(_)))
       depends.toArray
     else {
       ensureProject
-
       // refresh output directories, since SBT removes classfiles that the Eclipse
       // Java compiler expects to find
       for (folder <- scalaProject.outputFolders) {
@@ -54,22 +48,23 @@ class JavaEclipseCompiler(p: IProject, monitor: SubMonitor) extends JavaCompiler
       }
 
       BuildManagerStore.INSTANCE.setJavaSourceFilesToCompile(sources, project)
-      try
+      try {
         scalaJavaBuilder.build(INCREMENTAL_BUILD, new java.util.HashMap(), monitor)
-      finally
+      } finally {
         BuildManagerStore.INSTANCE.setJavaSourceFilesToCompile(null, project)
+        ProductExposer.hideJavaCompilationProductsIfCompilationFailed(project)
+      }
 
       refresh()
     }
-
+    val javaProblems: Seq[IMarker] = project.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE)
     Option(reporter).collect {
       case reporter: SbtBuildReporter =>
-        val javaProblems: Seq[IMarker] = project.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE)
         javaProblems.foreach { marker =>
           reporter.riseJavaErrorOrWarning(marker.getAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO))
         }
     }
-
-    true
+    javaProblems.isEmpty
   }
+
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/JavaEclipseCompiler.scala
@@ -49,6 +49,7 @@ class JavaEclipseCompiler(p: IProject, monitor: SubMonitor) extends JavaCompiler
 
       BuildManagerStore.INSTANCE.setJavaSourceFilesToCompile(sources, project)
       try {
+        ProductExposer.showJavaCompilationProducts(project)
         scalaJavaBuilder.build(INCREMENTAL_BUILD, new java.util.HashMap(), monitor)
       } finally {
         BuildManagerStore.INSTANCE.setJavaSourceFilesToCompile(null, project)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ProductExposer.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ProductExposer.scala
@@ -1,0 +1,102 @@
+package org.scalaide.core.internal.builder.zinc
+
+import java.io.File
+import java.io.FilenameFilter
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardCopyOption
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.runtime.IPath
+import org.eclipse.jdt.core.IJavaModelMarker
+import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.SdtConstants
+
+private[zinc] object ProductExposer {
+  private val ProductExtension = ".failed"
+  private val RootProject = 1
+
+  private def packageAndClassPrefix(project: IProject, file: IPath) = {
+    val ClassFile = 1
+    val scalaProject = IScalaPlugin().getScalaProject(project)
+    scalaProject.sourceFolders.map { srcFolder =>
+      val relativeSrcPath = project.getFullPath.append(srcFolder.makeRelativeTo(project.getLocation))
+      if (file.matchingFirstSegments(relativeSrcPath) == relativeSrcPath.segmentCount()) {
+        val packageClassFile = file.removeFirstSegments(relativeSrcPath.segmentCount())
+        Option((packageClassFile.removeLastSegments(ClassFile), packageClassFile.segments.last.takeWhile { _ != '.' }))
+      } else None
+    }.collectFirst {
+      case Some(src) => src
+    }
+  }
+
+  def hideJavaCompilationProductsIfCompilationFailed(project: IProject) = {
+    val Dot = 1
+    val shouldHide = project.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE).nonEmpty
+    if (shouldHide) {
+      val scalaProject = IScalaPlugin().getScalaProject(project)
+      scalaProject.allSourceFiles.filter {
+        _.getFileExtension == SdtConstants.JavaFileExtn.drop(Dot)
+      }.map { f =>
+        packageAndClassPrefix(project, f.getFullPath)
+      }.collect {
+        case Some(p) => p
+      }.foreach {
+        case (packagePath, productPrefix) =>
+          scalaProject.outputFolders.map { output =>
+            val absOutput = project.getLocation.append(output.segments.drop(RootProject).mkString(File.separator)).makeAbsolute
+            absOutput.append(packagePath).makeAbsolute.toFile
+          }.collect {
+            case packagePath if packagePath.exists =>
+              packagePath.listFiles(product(productPrefix))
+          }.flatten.foreach { p =>
+            val path = p.toPath
+            Files.move(path, path.resolveSibling(p.getName + ProductExtension), StandardCopyOption.REPLACE_EXISTING)
+          }
+      }
+    }
+  }
+
+  private def product(mainTypeName: String) = new FilenameFilter {
+    def accept(file: File, name: String): Boolean =
+      name.startsWith(mainTypeName + ".") || name.startsWith(mainTypeName + "$")
+  }
+
+  def showJavaCompilationProducts(project: IProject) = {
+    val scalaProject = IScalaPlugin().getScalaProject(project)
+    scalaProject.outputFolderLocations.flatMap { output =>
+      val finder = new Finder
+      Files.walkFileTree(output.makeAbsolute.toFile.toPath, finder)
+      finder.collected
+    }.foreach { path =>
+      val fname = path.toFile.getName
+      Files.move(path, path.resolveSibling(fname.substring(0, fname.lastIndexOf(ProductExtension))), StandardCopyOption.REPLACE_EXISTING)
+    }
+  }
+
+  class Finder extends SimpleFileVisitor[Path] {
+    import java.nio.file._
+    import java.nio.file.FileVisitResult._
+    import java.nio.file.attribute._
+    import scala.collection.mutable.ListBuffer
+    def collected = coll.toSeq
+    private val coll: scala.collection.mutable.ListBuffer[Path] = ListBuffer.empty
+    private val matcher = FileSystems.getDefault().getPathMatcher("glob:" + s"*$ProductExtension")
+
+    private def find(file: Path) = {
+      val name = file.getFileName()
+      if (name != null && matcher.matches(name))
+        coll += file
+    }
+
+    override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      find(file)
+      CONTINUE
+    }
+
+    override def visitFileFailed(file: Path, exc: IOException) = CONTINUE
+  }
+}


### PR DESCRIPTION
although the single file has been updated. The problem is touching
3 areas:
- class name finding in class jars on classpath, names of class files
  don't match with full class names, so class file names are transformed
  to class names
- zinc needs all classpath, so jdk libs are now added for analysis
- zinc tries to modify companions api entry in cache zip structure, so the
  lazy structures in analysis need to be materialized