### PR TITLE
Special handling type definitions in `ScalaStructureBuilder`

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/findreferences/FindReferencesTests.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/findreferences/FindReferencesTests.scala
@@ -112,14 +112,15 @@ class FindReferencesTests extends FindReferencesTester with HasLogger {
 
   private def jdtElement2testElement(e: JavaElement): Element = {
     val testElement: String => Element = e match {
-      case e: ScalaDefElement      => Method.apply _
-      case e: ScalaAccessorElement => Method.apply _
-      case e: ScalaVarElement      => FieldVar.apply _
-      case e: ScalaValElement      => FieldVal.apply _
-      case e: ScalaClassElement    => Clazz.apply _
-      case e: ScalaTypeElement     => TypeAlias.apply _
-      case e: ScalaModuleElement   => Module.apply _
-      case e: SourceType           => Clazz.apply _
+      case e: ScalaDefElement       => Method.apply _
+      case e: ScalaAccessorElement  => Method.apply _
+      case e: ScalaVarElement       => FieldVar.apply _
+      case e: ScalaValElement       => FieldVal.apply _
+      case e: ScalaClassElement     => Clazz.apply _
+      case e: ScalaTypeElement      => TypeAlias.apply _
+      case e: ScalaTypeFieldElement => TypeAlias.apply _
+      case e: ScalaModuleElement    => Module.apply _
+      case e: SourceType            => Clazz.apply _
       case _ =>
         val msg = "Don't know how to convert element `%s` of type `%s`".format(e.getElementName, e.getClass)
         throw new IllegalArgumentException(msg)

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/structurebuilder/TraitsTestOracle.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/structurebuilder/TraitsTestOracle.scala
@@ -44,7 +44,9 @@ C1.scala [in traits [in src [in simple-structure-builder]]]
       int x
       int x()
       InnerC(traits.C<T>, int)
+    class T
     java.lang.Object T
+    class U
     java.lang.Object U
     scala.runtime.Null. map(scala.Function1<scala.collection.immutable.List<java.lang.Object>,U>)
     scala.runtime.Null. takeArray(scala.collection.immutable.List<java.lang.String>[])
@@ -69,8 +71,11 @@ T1.scala [in traits [in src [in simple-structure-builder]]]
     scala.collection.immutable.List<java.lang.Object> xs()
     scala.Nothing m(int, int)
     scala.Nothing n(int, int, int)
+    class T
     java.lang.Object T
+    class U
     java.lang.Object U
+    class Z
     java.lang.Object Z
     class Inner
       Inner()

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaElements.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaElements.scala
@@ -147,6 +147,12 @@ class ScalaVarElement(parent : JavaElement, name: String, display : String)
 }
 
 class ScalaTypeElement(parent : JavaElement, name : String, display : String)
+  extends ScalaSourceTypeElement(parent, name) {
+  override def getLabelText(flags : Long) = display
+  override def getImageDescriptor = ScalaImages.SCALA_TYPE
+}
+
+class ScalaTypeFieldElement(parent : JavaElement, name : String, display : String)
   extends SourceField(parent, name) with ScalaFieldElement {
   override def getLabelText(flags : Long) = display
   override def getImageDescriptor = ScalaImages.SCALA_TYPE


### PR DESCRIPTION
This tweak fixes [#1002773](https://app.assembla.com/spaces/scala-ide/tickets/1002773-open-type-fails-for-type-aliases/details#). I'm not sure that I like it though, so your comments are highly welcome!