### PR TITLE
Make use of ehanced package rename functionality introduced in refactoring-library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ org.scala-ide.sdt.update-site/site.xml
 .idea
 .metadata
 *~
-org.scala-ide.sbt.build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ org.scala-ide.sdt.update-site/site.xml
 .idea
 .metadata
 *~
+org.scala-ide.sbt.build

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -237,7 +237,7 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
 
       // dirty-hack for ticket #1001595 until Sbt provides a better API for tracking sources recompiled by the incremental compiler
       if (phaseName == "parser") {
-        val file = FileUtils.resourceForPath(unitIPath, project.underlying.getFullPath)
+        val file = FileUtils.fileResourceForPath(unitIPath, project.underlying.getFullPath)
         file.foreach { f =>
           TaskManager.clearTasks(f)
           compiledFiles += f

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtBuildReporter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtBuildReporter.scala
@@ -65,7 +65,7 @@ private[zinc] class SbtBuildReporter(project: IScalaProject) extends xsbti.Repor
 
   private def riseNonJavaErrorOrWarning(pos: xsbti.Position, sev: xsbti.Severity): Unit =
     SbtUtils.m2o(pos.sourceFile).flatMap { file =>
-      FileUtils.resourceForPath(new Path(file.getAbsolutePath), project.underlying.getFullPath)
+      FileUtils.fileResourceForPath(new Path(file.getAbsolutePath), project.underlying.getFullPath)
     }.map { resource =>
       if (resource.getFileExtension != "java")
         riseErrorOrWarning(_)
@@ -102,7 +102,7 @@ private[zinc] class SbtBuildReporter(project: IScalaProject) extends xsbti.Repor
 
     val marker: Option[Unit] = for {
       file <- m2o(pos.sourceFile)
-      resource <- FileUtils.resourceForPath(new Path(file.getAbsolutePath), project.underlying.getFullPath)
+      resource <- FileUtils.fileResourceForPath(new Path(file.getAbsolutePath), project.underlying.getFullPath)
       offset <- m2o(pos.offset)
       line <- m2o(pos.line)
     } yield if (resource.getFileExtension != "java") {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/resources/EclipseFile.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/resources/EclipseFile.scala
@@ -46,14 +46,14 @@ object EclipseResource extends HasLogger {
    */
   def fromString(path: String, prefix: IPath = Path.EMPTY): Option[EclipseResource[IResource]] = {
     val path0 = new Path(path)
-    FileUtils.resourceForPath(path0, prefix) match {
+    FileUtils.fileResourceForPath(path0, prefix) match {
       case Some(res) => Some(EclipseResource(res))
       case None =>
         // Attempt to refresh the parent folder and try again
-        FileUtils.resourceForPath(path0.removeLastSegments(1)) match {
+        FileUtils.fileResourceForPath(path0.removeLastSegments(1)) match {
           case Some(res) =>
             res.refreshLocal(IResource.DEPTH_ONE, null)
-            FileUtils.resourceForPath(path0).map(EclipseResource(_))
+            FileUtils.fileResourceForPath(path0).map(EclipseResource(_))
           case None => None
         }
     }

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/FileUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/eclipse/FileUtils.scala
@@ -12,7 +12,6 @@ import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IFolder
 import org.eclipse.core.resources.IMarker
 import org.eclipse.core.resources.IResource
-import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.Path
@@ -24,8 +23,10 @@ import java.io.File
 import org.scalaide.core.SdtConstants
 import scala.util.control.NonFatal
 import org.scalaide.core.internal.logging.EclipseLogger
+import java.net.URI
 
 object FileUtils {
+  import EclipseUtils.workspaceRoot
 
   /**
    * Tries to obtain the most accurate [[IFile]] embedded in an [[AbstractFile]],
@@ -117,8 +118,7 @@ object FileUtils {
    * path is used disambiguate.
    */
   def fileResourceForPath(location: IPath, prefix: IPath = Path.EMPTY): Option[IFile] = {
-    val resources = Try(workspaceRoot.findFilesForLocationURI(URIUtil.toURI(location))).getOrElse(Array())
-    resources.find(prefix isPrefixOf _.getFullPath)
+    lookupPathWithPrefix(location, prefix)(workspaceRoot.findFilesForLocationURI)
   }
 
   private def containerResourceForPath(location: String, prefix: IPath = Path.EMPTY): Option[IContainer] = {
@@ -126,11 +126,19 @@ object FileUtils {
   }
 
   private def containerResourceForPath(location: IPath, prefix: IPath): Option[IContainer] = {
-    val resources = Try(workspaceRoot.findContainersForLocationURI(URIUtil.toURI(location))).getOrElse(Array())
-    resources.find(r => prefix.isPrefixOf(r.getFullPath))
+    lookupPathWithPrefix(location, prefix)(workspaceRoot.findContainersForLocationURI)
   }
 
-  private def workspaceRoot = ResourcesPlugin.getWorkspace.getRoot
+  private def lookupPathWithPrefix[ResourceT <: IResource](location: IPath, prefix: IPath)(findForURI: URI => Array[ResourceT]): Option[ResourceT] = {
+    try {
+      val resources = findForURI(URIUtil.toURI(location))
+      resources.find(r => prefix.isPrefixOf(r.getFullPath))
+    } catch {
+      case NonFatal(e) =>
+        EclipseLogger.error(s"Error looking up $location for $prefix", e)
+        None
+    }
+  }
 
   /** Is the file buildable by the Scala plugin? In other words, is it a
    *  Java or Scala source file?

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <sbt-util.version>0.1.0-M14</sbt-util.version>
     <sbt-io.version>1.0.0-M7</sbt-io.version>
     <sbinary.version>0.4.3</sbinary.version>
-    <scala-refactoring.version>0.12.0-SNAPSHOT</scala-refactoring.version>
+    <scala-refactoring.version>0.13.0-SNAPSHOT</scala-refactoring.version>
 
     <!-- plugin versions -->
     <tycho.plugin.version>0.21.0</tycho.plugin.version>


### PR DESCRIPTION
This PR enhances the IDE to make use of enhanced package rename functionality introduced in https://github.com/scala-ide/scala-refactoring/pull/181. Further details can be found in the linked PR.

See [#1002769](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1002769-package-renaming-error-in-the-package-object/details#).