### PR TITLE
Computes class name for breakpoint setting

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -68,6 +68,7 @@ import org.scalaide.core.sbtbuilder.CompilerBridgeStoreTest
 import org.scalaide.ui.internal.preferences.StringListMapperTest
 import org.scalaide.core.sbtbuilder.Scala210Compilation
 import org.scalaide.core.sbtbuilder.SourcePathFinderTest
+import org.scalaide.core.scalaelements.ScalaElementsNameTest
 
 @RunWith(classOf[Suite])
 @Suite.SuiteClasses(
@@ -137,6 +138,7 @@ import org.scalaide.core.sbtbuilder.SourcePathFinderTest
     classOf[ScalacNotUnderstandJavaTest],
     classOf[ScalaJavaDepTwoScopesTest],
     classOf[Scala210Compilation],
-    classOf[SourcePathFinderTest]
+    classOf[SourcePathFinderTest],
+    classOf[ScalaElementsNameTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/scalaelements/ScalaElementsNameTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/scalaelements/ScalaElementsNameTest.scala
@@ -1,0 +1,46 @@
+package org.scalaide.core.scalaelements
+
+import org.scalaide.core.internal.jdt.model.ScalaSourceTypeElement
+import org.scalaide.core.testsetup.SDTTestUtils
+import org.scalaide.core.testsetup.TestProjectSetup
+import org.scalaide.logging.HasLogger
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+
+object ScalaElementsNameTest extends TestProjectSetup("scala-elements") {
+  @BeforeClass
+  def setup(): Unit = {
+    SDTTestUtils.enableAutoBuild(false)
+  }
+
+  @AfterClass
+  def tearDown(): Unit = {
+    SDTTestUtils.deleteProjects(project)
+  }
+
+  val mainObject = "test.a.Main$"
+  val extendedTrait = "test.b.c.C"
+  val clazz = "test.b.B"
+  val nestedClass = "test.b.B$BB"
+  val nestedObject = "test.b.B$OB$"
+}
+
+class ScalaElementsNameTest extends HasLogger {
+  import ScalaElementsNameTest._
+
+  @Test
+  def shouldCollectAllJavaTypesWithPkgNotRespodingToFoldersStructure(): Unit = {
+    cleanProject()
+    val cu = scalaCompilationUnit("test/ScalaElementExamples.scala")
+    waitUntilTypechecked(cu)
+
+    val allTypes = cu.getAllTypes
+    val actualTypes = allTypes.collect {
+      case e: ScalaSourceTypeElement => e
+    }.map { _.getFullyQualifiedName }.toSet
+
+    val expectedTypes = Set(mainObject, extendedTrait, clazz, nestedClass, nestedObject)
+    assert((expectedTypes & actualTypes) == expectedTypes, s"Expected all in expected types, got difference: ${(expectedTypes & actualTypes).mkString(",")}")
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/scala-elements/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scala-elements/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/scala-elements/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scala-elements/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>scala-elements</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/scala-elements/src/test/ScalaElementExamples.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/scala-elements/src/test/ScalaElementExamples.scala
@@ -1,0 +1,32 @@
+package test {
+  package b {
+    class B {
+      object OB {
+        def obFoo(i: Int)(f: Int => Int) =
+          f(i)
+      }
+      class BB {
+        def bbFoo =
+          OB.obFoo(5) { x =>
+            x + 42
+          }
+      }
+      def foo =
+        (new BB).bbFoo
+    }
+    package c {
+      trait C {
+        def bar = 7
+      }
+    }
+  }
+  package a {
+    import test.b.c.C
+    object Main extends App with C {
+      import test.b.B
+      val b = new B
+      println(b.foo)
+      println(bar)
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaElements.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/jdt/model/ScalaElements.scala
@@ -80,21 +80,15 @@ class ScalaSourceTypeElement(parent: JavaElement, name: String, declaringType: O
     getCorrespondingElement(method).getOrElse(method).asInstanceOf[IMethod]
   }
 
-  private val turnTypeSuffixToModuleName: String => String = typ =>
-    if (typ.endsWith(".type"))
-      typ.replace(".type", "$")
-    else
-      typ
-
-  private val trimTypeParamsToPureClassName: String => String = typ =>
-    Option(typ.indexOf("[")).map {
-      case -1 => typ
-      case typeParamStartsIndex => typ.substring(0, typeParamStartsIndex)
-    }.get
-
   override def getFullyQualifiedName: String =
     declaringType.map { declaringType =>
-      (trimTypeParamsToPureClassName andThen turnTypeSuffixToModuleName)(declaringType.safeToString)
+      val pkgSym = declaringType.typeSymbol.enclosingPackage
+      if (pkgSym.isEmptyPackage)
+        super.getFullyQualifiedName
+      else {
+        val pkg = pkgSym.javaClassName
+        pkg + "." + getTypeQualifiedName('$', /*showParameters =*/ false)
+      }
     }.getOrElse(super.getFullyQualifiedName)
 }
 

--- a/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/SourcePathInStackFrameTest.scala
+++ b/org.scala-ide.sdt.debug.tests/src/org/scalaide/debug/internal/SourcePathInStackFrameTest.scala
@@ -48,7 +48,7 @@ class SourcePathInStackFrameTest {
     }
   }
 
-  private val mainBreakpoint = 16
+  private val mainBreakpoint = 27
   private val expectedSourcePath = File.separator + "test" + File.separator + "SourcePath.scala"
   @Test
   def simpleCheckForSourcePathInTopMostStackFrameForClassesWithPkgsWhichDontReflectSourceFoldersStruct(): Unit = {
@@ -56,10 +56,18 @@ class SourcePathInStackFrameTest {
     session.runToLine(BP_TYPENAME, mainBreakpoint)
     Assert.assertTrue(session.currentStackFrame.getSourcePath == expectedSourcePath)
 
-    val bp4 = session.addLineBreakpoint("test.b.B", 4)
-    val bp8 = session.addLineBreakpoint("test.b.c.C", 8)
+    val inTopMostClass = session.addLineBreakpoint("test.b.B", 15)
+    val inInheritedTrait = session.addLineBreakpoint("test.b.c.C", 19)
+    val inInnerClassAnonFunc = session.addLineBreakpoint("test.b.B$BB", 11)
+    val inInnerObject = session.addLineBreakpoint("test.b.B$OB", 6)
     try {
-      session.waitForBreakpointsToBeEnabled(bp4, bp8)
+      session.waitForBreakpointsToBeEnabled(inTopMostClass, inInheritedTrait, inInnerClassAnonFunc, inInnerObject)
+
+      session.resumeToSuspension()
+      Assert.assertTrue(session.currentStackFrame.getSourcePath == expectedSourcePath)
+
+      session.resumeToSuspension()
+      Assert.assertTrue(session.currentStackFrame.getSourcePath == expectedSourcePath)
 
       session.resumeToSuspension()
       Assert.assertTrue(session.currentStackFrame.getSourcePath == expectedSourcePath)
@@ -69,8 +77,10 @@ class SourcePathInStackFrameTest {
 
       session.resumeToCompletion()
     } finally {
-      bp4.delete()
-      bp8.delete()
+      inTopMostClass.delete()
+      inInheritedTrait.delete()
+      inInnerClassAnonFunc.delete()
+      inInnerObject.delete()
     }
   }
 }

--- a/org.scala-ide.sdt.debug.tests/test-workspace/source-path/src/test/SourcePath.scala
+++ b/org.scala-ide.sdt.debug.tests/test-workspace/source-path/src/test/SourcePath.scala
@@ -1,7 +1,18 @@
 package test {
   package b {
     class B {
-      def foo = 5
+      object OB {
+        def obFoo(i: Int)(f: Int => Int) =
+          f(i)
+      }
+      class BB {
+        def bbFoo =
+          OB.obFoo(5) { x =>
+            x + 42
+          }
+      }
+      def foo =
+        (new BB).bbFoo
     }
     package c {
       trait C {


### PR DESCRIPTION
Old implementation relied on java model `getFullyQualifiedName`, the
next implementation tried to get type from Scala's Type. Current
implementation gets correct java type name and only package prefix is
taken from Scala model.