### PR TITLE
Removes options from OrganizeImports

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/refactoring/internal/OrganizeImports.scala
@@ -243,22 +243,6 @@ class OrganizeImports extends RefactoringExecutorWithoutWizard {
       val project = file.getJavaProject.getProject
       val organizationStrategy = getOrganizeImportStrategy(project)
 
-      val options = {
-        import refactoring.oiWorker.participants._
-        val expandOrCollapse = organizationStrategy match {
-          case CollapseImports => List(SortImportSelectors)
-          case PreserveExistingGroups => Nil // this is not passed as an option
-        }
-
-        val scalaPackageStrategy = if (shouldOmitScalaPackage(project)){
-          DropScalaPackage
-        } else {
-          PrependScalaPackage
-        }
-
-        expandOrCollapse ::: List(scalaPackageStrategy)
-      }
-
       val deps = {
         if(compilationUnitHasProblems) {
           // this is safer when there are problems in the compilation unit
@@ -277,7 +261,7 @@ class OrganizeImports extends RefactoringExecutorWithoutWizard {
           groups = getGroupsForProject(project).toList,
           scalaPackageStrategy = shouldOmitScalaPackage(project)))
 
-      new refactoring.RefactoringParameters(options = options, deps = deps,
+      new refactoring.RefactoringParameters(deps = deps,
           config = organizeImportsConfig)
     }
   }


### PR DESCRIPTION
It is done to remove dependency to scala-refactoring specific classes
used as configuration in scala-ide code. This sort of data should rather
be passes as simple scala types.

depends on: https://github.com/scala-ide/scala-refactoring/pull/187