### PR TITLE
Update to zinc-1.0.0 x9

### DIFF
--- a/org.scala-ide.sdt.core/.classpath
+++ b/org.scala-ide.sdt.core/.classpath
@@ -6,18 +6,18 @@
 	<classpathentry kind="src" output="target/classes" path="src"/>
 	<classpathentry kind="lib" path="target/lib/miglayout-3.7.4.jar"/>
 	<classpathentry kind="lib" path="target/lib/log4j-1.2.17.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc_2.11-1.0.0-X6.jar" sourcepath="target/lib/zinc_2.11-1.0.0-X6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-core_2.11-1.0.0-X6.jar" sourcepath="target/lib/zinc-core_2.11-1.0.0-X6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-interface-0.1.0-M14.jar" sourcepath="target/lib/util-interface-0.1.0-M14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-classpath_2.11-1.0.0-X6.jar" sourcepath="target/lib/zinc-classpath_2.11-1.0.0-X6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/compiler-interface-1.0.0-X6.jar" sourcepath="target/lib/compiler-interface-1.0.0-X6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-compile-core_2.11-1.0.0-X6.jar" sourcepath="target/lib/zinc-compile-core_2.11-1.0.0-X6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-persist_2.11-1.0.0-X6.jar" sourcepath="target/lib/zinc-persist_2.11-1.0.0-X6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-logging_2.11-0.1.0-M14.jar" sourcepath="target/lib/util-logging_2.11-0.1.0-M14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-control_2.11-0.1.0-M14.jar" sourcepath="target/lib/util-control_2.11-0.1.0-M14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/io_2.11-1.0.0-M6.jar" sourcepath="target/lib/io_2.11-1.0.0-M6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/sbinary_2.11-0.4.3.jar" sourcepath="target/lib/sbinary_2.11-0.4.3-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-apiinfo_2.11-1.0.0-X6.jar" sourcepath="target/lib/zinc-apiinfo_2.11-1.0.0-X6-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-relation_2.11-0.1.0-M14.jar" sourcepath="target/lib/util-relation_2.11-0.1.0-M14-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc_2.11-1.0.0-X9.jar" sourcepath="target/lib/zinc_2.11-1.0.0-X9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-core_2.11-1.0.0-X9.jar" sourcepath="target/lib/zinc-core_2.11-1.0.0-X9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-interface-1.0.0-M19.jar" sourcepath="target/lib/util-interface-1.0.0-M19-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-classpath_2.11-1.0.0-X9.jar" sourcepath="target/lib/zinc-classpath_2.11-1.0.0-X9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/compiler-interface-1.0.0-X9.jar" sourcepath="target/lib/compiler-interface-1.0.0-X9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-compile-core_2.11-1.0.0-X9.jar" sourcepath="target/lib/zinc-compile-core_2.11-1.0.0-X9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-persist_2.11-1.0.0-X9.jar" sourcepath="target/lib/zinc-persist_2.11-1.0.0-X9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-logging_2.11-1.0.0-M19.jar" sourcepath="target/lib/util-logging_2.11-1.0.0-M19-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-control_2.11-1.0.0-M19.jar" sourcepath="target/lib/util-control_2.11-1.0.0-M19-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/io_2.11-1.0.0-M9.jar" sourcepath="target/lib/io_2.11-1.0.0-M6-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/sbinary_2.11-0.4.4.jar" sourcepath="target/lib/sbinary_2.11-0.4.3-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-apiinfo_2.11-1.0.0-X9.jar" sourcepath="target/lib/zinc-apiinfo_2.11-1.0.0-X9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-relation_2.11-1.0.0-M19.jar" sourcepath="target/lib/util-relation_2.11-1.0.0-M19-sources.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.scala-ide.sdt.core/pom.xml
+++ b/org.scala-ide.sdt.core/pom.xml
@@ -119,12 +119,12 @@
     <dependency>
       <groupId>org.scala-sbt</groupId>
       <artifactId>io_${scala.minor.version}</artifactId>
-      <version>1.0.0-M6</version>
+      <version>${sbt-io.version}</version>
     </dependency>
     <dependency>
       <groupId>org.scala-sbt</groupId>
       <artifactId>sbinary_${scala.minor.version}</artifactId>
-      <version>0.4.3</version>
+      <version>${sbinary.version}</version>
     </dependency>
   </dependencies>
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
@@ -50,7 +50,7 @@ class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logg
         case (a, s) => (Option(a), Option(s))
       }.getOrElse((Option(SbtUtils.readAnalysis(cacheFile)), None))
     cacheAndReturnLastAnalysis(new IncrementalCompilerImpl().incrementalCompile(comps.scalac, comps.javac, in.sources, in.classpath, in.output, in.cache,
-      SbtUtils.m2o(in.progress), in.scalacOptions, in.javacOptions, previousAnalysis, previousSetup, lookup,
+      SbtUtils.toOption(in.progress), in.scalacOptions, in.javacOptions, previousAnalysis, previousSetup, lookup,
       sbtReporter, in.order, skip = false, in.incOptions, extra = Nil)(log))
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -49,6 +49,7 @@ import org.scalaide.util.eclipse.RegionUtils.RichRegion
 import scalariform.lexer.ScalaLexer
 import scalariform.lexer.ScalaLexerException
 import org.scalaide.core.completion.ProposalRelevanceCalculator
+import java.util.concurrent.atomic.AtomicLong
 
 class ScalaPresentationCompiler(private[compiler] val name: String, _settings: Settings)
   extends Global(_settings, new ScalaPresentationCompiler.PresentationReporter(name), name)
@@ -449,9 +450,26 @@ class ScalaPresentationCompiler(private[compiler] val name: String, _settings: S
   }
 
   private [core] def defaultHyperlinkLabel(sym: Symbol): String = s"${sym.kindString} ${sym.fullName}"
+
+  import ScalaPresentationCompiler.RefTimeStamp
+  import ScalaPresentationCompiler.Ids
+
+  /*
+   * Meant to ease debugging. These fields allow to easily distinguish different presentation compilers,
+   * for example when examining heap dumps.
+   */
+  val timeStamp = (System.currentTimeMillis() - RefTimeStamp)
+  val id = Ids.getAndIncrement
+
+  override def toString = {
+    s"ScalaPresentationCompiler[$id@$timeStamp]"
+  }
 }
 
 object ScalaPresentationCompiler {
+  private val RefTimeStamp = System.currentTimeMillis()
+  private val Ids = new AtomicLong()
+
   case class InvalidThread(msg: String) extends RuntimeException(msg)
 
   def defaultScalaSettings(errorFn: String => Unit = Console.println): Settings = new Settings(errorFn)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -50,17 +50,8 @@ import scalariform.lexer.ScalaLexer
 import scalariform.lexer.ScalaLexerException
 import org.scalaide.core.completion.ProposalRelevanceCalculator
 
-class ScalaPresentationCompiler(private[compiler] val name: String, _settings: Settings) extends {
-  /*
-   * Lock object for protecting compiler names. Names are cached in a global `Array[Char]`
-   * and concurrent access may lead to overwritten names.
-   *
-   * @note This field is EARLY because `newTermName` is hit during construction of the superclass `Global`,
-   *       and the lock object has to be constructed already.
-   */
-  private val nameLock = new Object
-
-} with Global(_settings, new ScalaPresentationCompiler.PresentationReporter(name), name)
+class ScalaPresentationCompiler(private[compiler] val name: String, _settings: Settings)
+  extends Global(_settings, new ScalaPresentationCompiler.PresentationReporter(name), name)
   with ScaladocGlobalCompatibilityTrait
   with ScalaStructureBuilder
   with ScalaIndexBuilder

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/SbtUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/SbtUtils.scala
@@ -6,9 +6,17 @@ import sbt.internal.inc.Analysis
 import sbt.internal.inc.FileBasedStore
 import xsbti._
 import xsbti.compile.MiniSetup
+import java.util.Optional
 
 object SbtUtils {
-  def m2o[S](opt: Maybe[S]): Option[S] = if (opt.isEmpty) None else Some(opt.get)
+  def toOption[S](opt: Maybe[S]): Option[S] = {
+    if (opt.isEmpty) None else Some(opt.get)
+  }
+
+  def toOption[T](optional: Optional[T]): Option[T] = {
+    if (optional.isPresent()) Some(optional.get)
+    else None
+  }
 
   def readCache(cacheFile: File): Option[(Analysis, MiniSetup)] =
     FileBasedStore(cacheFile).get().map(_ match {
@@ -21,13 +29,12 @@ object SbtUtils {
     readCache(cacheFile).map(_._1).getOrElse(Analysis.empty(nameHashing = true))
 
   object NoPosition extends xsbti.Position {
-    def line(): Maybe[Integer] = Maybe.nothing()
+    def line(): Optional[Integer] = Optional.empty()
     def lineContent(): String = ""
-    def offset(): Maybe[Integer] = Maybe.nothing[Integer]
-    def pointer(): Maybe[Integer] = Maybe.nothing[Integer]
-    def pointerSpace(): Maybe[String] = Maybe.nothing[String]
-    def sourceFile(): Maybe[File] = Maybe.nothing[File]
-    def sourcePath(): Maybe[String] = Maybe.nothing[String]
-
+    def offset(): Optional[Integer] = Optional.empty()
+    def pointer(): Optional[Integer] = Optional.empty()
+    def pointerSpace(): Optional[String] = Optional.empty()
+    def sourceFile(): Optional[File] = Optional.empty()
+    def sourcePath(): Optional[String] = Optional.empty()
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,10 @@
     <log4j.version>1.2.17</log4j.version>
     <json-io.version>4.1.6</json-io.version>
     <mockito.version>1.9.5</mockito.version>
-    <zinc.version>1.0.0-X6</zinc.version>
-    <sbt-util.version>0.1.0-M14</sbt-util.version>
-    <sbt-io.version>1.0.0-M7</sbt-io.version>
-    <sbinary.version>0.4.3</sbinary.version>
+    <zinc.version>1.0.0-X9</zinc.version>
+    <sbt-util.version>1.0.0-M19</sbt-util.version>
+    <sbt-io.version>1.0.0-M9</sbt-io.version>
+    <sbinary.version>0.4.4</sbinary.version>
     <scala-refactoring.version>0.13.0-SNAPSHOT</scala-refactoring.version>
 
     <!-- plugin versions -->


### PR DESCRIPTION
Update zinc to 1.0.0-X9 (switching to X10 would require more refactorings).

Important: Go to `${WORKSPACE}/.metadata/.plugins/org.scala-ide.sdt.core` and
remove both `compiler-bridges/` and `compiler-interfaces/`. Otherwise the old
JARs stored in these directories might take precedence, leading to
`ClassNotFoundExceptions` during compiles.

This PR also contains a minor tweak to `ScalaPresentationCompiler` that is meant to help with debugging.