### PR TITLE
Fix missing version bump

### DIFF
--- a/org.scala-ide.sdt.feature/resources/feature.xml
+++ b/org.scala-ide.sdt.feature/resources/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.scala-ide.sdt.feature"
       label="Scala IDE for Eclipse"
-      version="4.5.1.qualifier"
+      version="4.6.0.qualifier"
       provider-name="scala-ide.org"
       plugin="org.scala-ide.sdt.core">
 


### PR DESCRIPTION
For some reason `ag "4\.5\.1"` couldn't find it but I don't understand
why.