### PR TITLE
Set scalp version in MAFIFEST.MF through filtering

### DIFF
--- a/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
+++ b/org.scala-ide.sdt.core/resources/META-INF/MANIFEST-2_12.MF
@@ -194,5 +194,5 @@ Bundle-ClassPath: .,
  target/lib/util-relation_2.12-@SBT_UTIL_VERSION@.jar,
  target/lib/io_2.12-@SBT_IO_VERSION@.jar,
  target/lib/sbinary_2.12-@SBINARY_VERSION@.jar,
- target/lib/scalap-2.12.2.jar
+ target/lib/scalap-@SCALA_VERSION@.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,7 @@
                           <filter token="SBT_UTIL_VERSION" value="${sbt-util.version}"/>
                           <filter token="SBT_IO_VERSION" value="${sbt-io.version}"/>
                           <filter token="SBINARY_VERSION" value="${sbinary.version}"/>
+                          <filter token="SCALA_VERSION" value="${scala.version}"/>
                         </filterset>
                     </copy>
                     <copy file="${sdt.debug.dir}/resources/META-INF/MANIFEST-${version.suffix}.MF"


### PR DESCRIPTION
This is a followup to #1159: scalap version in `org.scala-ide.sdt.core` `MANIFEST.MF` will be generated from Maven `scala.version` property. This should make future upgrades smoother.