### PR TITLE
Move compiler bridge cache outside the workspace

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/ScalaPlugin.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/ScalaPlugin.scala
@@ -9,6 +9,7 @@ import org.eclipse.core.resources.IResourceChangeListener
 import org.eclipse.core.resources.IResourceDelta
 import org.eclipse.core.resources.IResourceDeltaVisitor
 import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.runtime.Path
 import org.eclipse.core.runtime.Platform
 import org.eclipse.core.runtime.content.IContentType
 import org.eclipse.jdt.core.ElementChangedEvent
@@ -24,6 +25,7 @@ import org.eclipse.ui.PlatformUI
 import org.osgi.framework.BundleContext
 import org.scalaide.core.IScalaInstallation
 import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.ScalaIdeDataStore
 import org.scalaide.core.SdtConstants
 import org.scalaide.core.internal.builder.zinc.CompilerBridgeStore
 import org.scalaide.core.internal.jdt.model.ScalaClassFile
@@ -121,8 +123,8 @@ class ScalaPlugin extends IScalaPlugin with PluginLogConfigurator with IResource
     ScalaPlugin.plugin = null
   }
 
-  /** The compiler-bridge store, located in this plugin configuration area (usually inside the metadata directory */
-  lazy val compilerBridgeStore: CompilerBridgeStore = new CompilerBridgeStore(Platform.getStateLocation(sdtCoreBundle), this)
+  /** The compiler-bridge store, located in user data area */
+  lazy val compilerBridgeStore: CompilerBridgeStore = new CompilerBridgeStore(new Path(ScalaIdeDataStore.dataStoreLocation), this)
 
   /** A LRU cache of class loaders for Scala builders */
   lazy val classLoaderStore: FixedSizeCache[IScalaInstallation,ClassLoader] = new FixedSizeCache(initSize = 2, maxSize = 3)

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CompilerBridgeStore.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CompilerBridgeStore.scala
@@ -25,7 +25,7 @@ import xsbti.Logger
 /** This class manages a store of compiler-bridge jars (as consumed by zinc). Each specific
  *  version of Scala needs a compiler-bridge jar compiled against that version.
  *
- *  `base` is used to store compiler-bridges on disk. The cache is based on the
+ *  `base` is used to store compiler-bridges on disk. The cache is based on the Zinc version included in IDE and
  *  Scala version for a given installation. The first time a client requests a compiler-bridge,
  *  the store will instantiate a raw compiler and compile it from the source. This may take some time,
  *  in the order of seconds.
@@ -93,7 +93,7 @@ class CompilerBridgeStore(base: IPath, plugin: ScalaPlugin) extends HasLogger {
   def getStats: (Int, Int) = (hits, misses)
 
   private def cacheDir(installation: IScalaInstallation): IPath =
-    compilerBridgesDir / installation.version.unparse
+    compilerBridgesDir / plugin.zincCompilerBridgeBundle.getVersion.toString / installation.version.unparse
 
   private def bridgeJar(installation: IScalaInstallation): IPath = {
     cacheDir(installation) / compilerBridgeName


### PR DESCRIPTION
This change allows re-using complier bridge binaries among all workspaces of
the OS user. This also speeds up unit tests which recreate workspaces
frequently and thus need to recompile the bridges repeatedly.

Including Zinc version in cache path will prevent a problem with incorrect
versions of bridge classes that are faced by users of nightly builds whenever
Zinc dependency is updated.