### PR TITLE
Adds explicit type to `analyzer`

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -66,7 +66,10 @@ class ScalaPresentationCompiler(private[compiler] val name: String, _settings: S
   with HasLogger
   with Scaladoc { self =>
 
-  override lazy val analyzer = new {
+  import scala.tools.nsc.interactive.InteractiveAnalyzer
+  type ThisGlobal = { val global: ScalaPresentationCompiler.this.type }
+  type AnalyzerType = InteractiveAnalyzer with ThisGlobal
+  override lazy val analyzer: AnalyzerType = new {
     val global: ScalaPresentationCompiler.this.type = ScalaPresentationCompiler.this
   } with InteractiveScaladocAnalyzer with CommentPreservingTypers {
     // Copy pasted from the overriden method to change the line marked with the 'Modified' comment.


### PR DESCRIPTION
some compiler plugins (like `paradise` of `scalameta`) want to override
`Global.analyzer` value. And it is done with reflection. So problem is
that `private analyzer` field gets the most specific type if type is not
given and setting with reflection fails. To solve it `val analyzer` needs
explicit type.