### PR TITLE
Enables using global Compiler Additional Parameters

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/util/WhenThenIn.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/util/WhenThenIn.scala
@@ -1,10 +1,10 @@
 package org.scalaide.core.util
 
-class when private (description: String) {
+class when private {
   def `then`(description: String) = this
   def in(body: => Unit): Unit = body
 }
 
 object when {
-  def apply(description: String) = new when(description)
+  def apply(description: String) = new when
 }


### PR DESCRIPTION
Scenario:
- create new project, compiler uses default global additional params
- next change project's scala installation
- it should lead to situation where global settings are preceived and Xsource
and Xmacro-expand are added
- but if project specific setting's of additional params is not empty then switching scala installation should retain these settings and change Xsource and Xmacro-expand only