### PR TITLE
Enable projection document

### DIFF
--- a/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.aspects/META-INF/MANIFEST.MF
@@ -35,7 +35,8 @@ Eclipse-SupplementBundle:
  org.eclipse.jdt.ui,
  org.eclipse.pde.ui,
  org.eclipse.jdt.groovy.core,
- org.eclipse.jdt.junit
+ org.eclipse.jdt.junit,
+ org.eclipse.text
 Bundle-ActivationPolicy: lazy
 Export-Package: scala.tools.eclipse.contribution.weaving.jdt,scala.too
  ls.eclipse.contribution.weaving.jdt.builderoptions,scala.tools.eclips
@@ -52,7 +53,8 @@ Export-Package: scala.tools.eclipse.contribution.weaving.jdt,scala.too
  ctions,scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor,sca
  la.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter,sca
  la.tools.eclipse.contribution.weaving.pde.ui,scala.tools.eclipse.cont
- ribution.weaving.jdt.jdi
+ ribution.weaving.jdt.jdi,scala.tools.eclipse.contribution.weaving.jdt
+ .ui.document
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: org.eclipse.equinox.frameworkadmin,
  org.eclipse.equinox.internal.simpleconfigurator.manipulator,

--- a/org.scala-ide.sdt.aspects/META-INF/aop.xml
+++ b/org.scala-ide.sdt.aspects/META-INF/aop.xml
@@ -32,5 +32,6 @@
 <aspect name="scala.tools.eclipse.contribution.weaving.pde.ui.PluginImportAspect"/>
 <aspect name="scala.tools.eclipse.contribution.weaving.jdt.launching.JUnitLaunchConfigurationTabAspect"/>
 <!-- aspect name="scala.tools.eclipse.contribution.weaving.jdt.jdi.JdiEntryGuardianAspect"/ -->
+<aspect name="scala.tools.eclipse.contribution.weaving.jdt.ui.document.CreateSlaveProjectionDocument"/>
 </aspects>
 </aspectj>

--- a/org.scala-ide.sdt.aspects/masterprojdocprovider.exsd
+++ b/org.scala-ide.sdt.aspects/masterprojdocprovider.exsd
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="scala.tools.eclipse.contribution.weaving.jdt" xmlns="http://www.w3.org/2001/XMLSchema">
+   <annotation>
+      <appinfo>
+         <meta.schema plugin="scala.tools.eclipse.contribution.weaving.jdt" id="masterprojdocprovider" name="Master Projection Document Provider"/>
+      </appinfo>
+      <documentation>
+         Provides an implementation of scala.tools.eclipse.contribution.weaving.jdt.ui.document.IMasterProjectionDocumentProvider to extract actual master document.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="provider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="provider">
+      <annotation>
+         <documentation>
+            Declares the class of provider.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":scala.tools.eclipse.contribution.weaving.jdt.ui.document.IMasterProjectionDocumentProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+</schema>

--- a/org.scala-ide.sdt.aspects/plugin.xml
+++ b/org.scala-ide.sdt.aspects/plugin.xml
@@ -8,4 +8,5 @@
    <extension-point id="cuprovider" name="Compilation Unit Provider" schema="cuprovider.exsd"/>
    <extension-point id="imagedescriptorselector" name="Image Descriptor Selector" schema="imagedescriptorselector.exsd"/>
    <extension-point id="openactionprovider" name="Open Action Provider" schema="openactionprovider.exsd"/>
+   <extension-point id="masterprojdocprovider" name="Master Projection Document Provider" schema="masterprojdocprovider.exsd"/>
 </plugin>

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/document/CreateSlaveProjectionDocument.aj
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/document/CreateSlaveProjectionDocument.aj
@@ -1,0 +1,18 @@
+package scala.tools.eclipse.contribution.weaving.jdt.ui.document;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.projection.ProjectionDocumentManager;
+
+public privileged aspect CreateSlaveProjectionDocument {
+	pointcut createSlaveDocument(IDocument master):
+		execution(IDocument ProjectionDocumentManager.createSlaveDocument(IDocument)) &&
+		args(master);
+
+	IDocument around(IDocument master): createSlaveDocument(master) {
+		IDocument extracted = master;
+		for (IMasterProjectionDocumentProvider provider : MasterProjectionDocumentProviderRegistry.getInstance().getProviders()) {
+			extracted = provider.extractActualMaster(extracted);
+	    }
+		return proceed(extracted);
+	}
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/document/IMasterProjectionDocumentProvider.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/document/IMasterProjectionDocumentProvider.java
@@ -1,0 +1,7 @@
+package scala.tools.eclipse.contribution.weaving.jdt.ui.document;
+
+import org.eclipse.jface.text.IDocument;
+
+public interface IMasterProjectionDocumentProvider {
+	IDocument extractActualMaster(IDocument master);
+}

--- a/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/document/MasterProjectionDocumentProviderRegistry.java
+++ b/org.scala-ide.sdt.aspects/src/scala/tools/eclipse/contribution/weaving/jdt/ui/document/MasterProjectionDocumentProviderRegistry.java
@@ -1,0 +1,19 @@
+package scala.tools.eclipse.contribution.weaving.jdt.ui.document;
+
+import scala.tools.eclipse.contribution.weaving.jdt.util.AbstractProviderRegistry;
+
+public class MasterProjectionDocumentProviderRegistry extends AbstractProviderRegistry<IMasterProjectionDocumentProvider> {
+
+	private static final MasterProjectionDocumentProviderRegistry INSTANCE = new MasterProjectionDocumentProviderRegistry();
+
+    public static String MASTER_PROJ_DOC_PROVIDERS_EXTENSION_POINT = "org.scala-ide.sdt.aspects.masterprojdocprovider"; //$NON-NLS-1$
+
+	public static MasterProjectionDocumentProviderRegistry getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	protected String getExtensionPointId() {
+	    return MASTER_PROJ_DOC_PROVIDERS_EXTENSION_POINT;
+	}
+}


### PR DESCRIPTION
Allows other bundles to set correct master document for its projection
in moment of its creation. This work is linked to problem with editting
of Play2 templates but can be used for any editor and structured
document.