### PR TITLE
Upgrade Zinc to 1.0.0-X18

### DIFF
--- a/org.scala-ide.sdt.core/.classpath
+++ b/org.scala-ide.sdt.core/.classpath
@@ -6,19 +6,20 @@
 	<classpathentry kind="src" output="target/classes" path="src"/>
 	<classpathentry kind="lib" path="target/lib/miglayout-3.7.4.jar"/>
 	<classpathentry kind="lib" path="target/lib/log4j-1.2.17.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc_2.12-1.0.0-X14.jar" sourcepath="target/lib/zinc_2.12-1.0.0-X14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-core_2.12-1.0.0-X14.jar" sourcepath="target/lib/zinc-core_2.12-1.0.0-X14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-interface-1.0.0-M23.jar" sourcepath="target/lib/util-interface-1.0.0-M23-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-classpath_2.12-1.0.0-X14.jar" sourcepath="target/lib/zinc-classpath_2.12-1.0.0-X14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/compiler-interface-1.0.0-X14.jar" sourcepath="target/lib/compiler-interface-1.0.0-X14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-compile-core_2.12-1.0.0-X14.jar" sourcepath="target/lib/zinc-compile-core_2.12-1.0.0-X14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-persist_2.12-1.0.0-X14.jar" sourcepath="target/lib/zinc-persist_2.12-1.0.0-X14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-logging_2.12-1.0.0-M23.jar" sourcepath="target/lib/util-logging_2.12-1.0.0-M23-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-control_2.12-1.0.0-M23.jar" sourcepath="target/lib/util-control_2.12-1.0.0-M23-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/io_2.12-1.0.0-M11.jar" sourcepath="target/lib/io_2.12-1.0.0-M11-sources.jar"/>
 	<classpathentry kind="lib" path="target/lib/sbinary_2.12-0.4.4.jar" sourcepath="target/lib/sbinary_2.12-0.4.4-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/zinc-apiinfo_2.12-1.0.0-X14.jar" sourcepath="target/lib/zinc-apiinfo_2.12-1.0.0-X14-sources.jar"/>
-	<classpathentry kind="lib" path="target/lib/util-relation_2.12-1.0.0-M23.jar" sourcepath="target/lib/util-relation_2.12-1.0.0-M23-sources.jar"/>
 	<classpathentry kind="lib" path="target/lib/scalap-2.12.2.jar"/>
+	<classpathentry kind="lib" path="target/lib/compiler-interface-1.0.0-X18.jar" sourcepath="target/lib/compiler-interface-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc_2.12-1.0.0-X18.jar" sourcepath="target/lib/zinc_2.12-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-apiinfo_2.12-1.0.0-X18.jar" sourcepath="target/lib/zinc-apiinfo_2.12-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-classfile_2.12-1.0.0-X18.jar" sourcepath="target/lib/zinc-classfile_2.12-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-classpath_2.12-1.0.0-X18.jar" sourcepath="target/lib/zinc-classpath_2.12-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-compile-core_2.12-1.0.0-X18.jar" sourcepath="target/lib/zinc-compile-core_2.12-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-core_2.12-1.0.0-X18.jar" sourcepath="target/lib/zinc-core_2.12-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/zinc-persist_2.12-1.0.0-X18.jar" sourcepath="target/lib/zinc-persist_2.12-1.0.0-X18-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/io_2.12-1.0.0-M12.jar" sourcepath="target/lib/io_2.12-1.0.0-M12-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-control_2.12-1.0.0-M26.jar" sourcepath="target/lib/util-control_2.12-1.0.0-M26-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-interface-1.0.0-M26.jar" sourcepath="target/lib/util-interface-1.0.0-M26-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-logging_2.12-1.0.0-M26.jar" sourcepath="target/lib/util-logging_2.12-1.0.0-M26-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/util-relation_2.12-1.0.0-M26.jar" sourcepath="target/lib/util-relation_2.12-1.0.0-M26-sources.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
@@ -36,7 +36,7 @@ class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logg
   def compile(in: SbtInputs, comps: Compilers): Analysis = {
     val lookup = new PerClasspathEntryLookup {
       override def analysis(classpathEntry: File) =
-        in.analysisMap(classpathEntry)
+        SbtUtils.m2jo(in.analysisMap(classpathEntry))
 
       override def definesClass(classpathEntry: File) = {
         val dc = Locator(classpathEntry)
@@ -50,8 +50,8 @@ class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logg
         case (a, s) => (Option(a), Option(s))
       }.getOrElse((Option(SbtUtils.readAnalysis(cacheFile)), None))
     cacheAndReturnLastAnalysis(new IncrementalCompilerImpl().compile(comps.scalac, comps.javac, in.sources, in.classpath, in.output, in.cache,
-      in.scalacOptions, in.javacOptions, SbtUtils.o2m(previousAnalysis), SbtUtils.o2m(previousSetup), lookup, sbtReporter, in.order,
-      skip = false, in.progress, in.incOptions, extra = Array(), log))
+      in.scalacOptions, in.javacOptions, SbtUtils.o2jo(previousAnalysis), SbtUtils.o2jo(previousSetup), lookup, sbtReporter, in.order,
+      skip = false, SbtUtils.m2jo(in.progress), in.incOptions, extra = Array(), log))
   }
 
   private def cacheAndReturnLastAnalysis(compilationResult: CompileResult): Analysis = {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CompilerBridgeStore.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CompilerBridgeStore.scala
@@ -18,9 +18,9 @@ import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.eclipse.OSGiUtils
 
 import sbt.internal.inc.AnalyzingCompiler
-import sbt.internal.inc.ClasspathOptionsUtil
 import sbt.internal.inc.RawCompiler
 import xsbti.Logger
+import xsbti.compile.ClasspathOptionsUtil
 
 /** This class manages a store of compiler-bridge jars (as consumed by zinc). Each specific
  *  version of Scala needs a compiler-bridge jar compiled against that version.

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -28,10 +28,10 @@ import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.SbtUtils
 
 import sbt.internal.inc.Analysis
-import sbt.internal.inc.SourceInfo
 import xsbti.CompileFailed
 import xsbti.F0
 import xsbti.Logger
+import xsbti.compile.analysis.SourceInfo
 import xsbti.compile.CompileProgress
 
 /**
@@ -174,7 +174,7 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
    * Create problem markers for the given source info.
    */
   private def createMarkers(sourceInfo: SourceInfo) = {
-    for (problem <- sourceInfo.reportedProblems)
+    for (problem <- sourceInfo.getReportedProblems)
       sbtReporter.createMarker(problem.position, problem.message, problem.severity)
   }
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/SbtUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/SbtUtils.scala
@@ -13,6 +13,8 @@ object SbtUtils {
   def o2m[S](opt: Option[S]): Maybe[S] = if (opt.isEmpty) Maybe.nothing() else Maybe.just(opt.get)
   def jo2m[S](opt: Optional[S]): Maybe[S] = if (opt.isPresent()) Maybe.just(opt.get) else Maybe.nothing()
   def jo2o[S](opt: Optional[S]): Option[S] = if (opt.isPresent()) Some(opt.get) else None
+  def o2jo[S](opt: Option[S]): Optional[S] = if (opt.isEmpty) Optional.empty() else Optional.of(opt.get)
+  def m2jo[S](opt: Maybe[S]): Optional[S] = if (opt.isEmpty) Optional.empty() else Optional.of(opt.get)
 
   def readCache(cacheFile: File): Option[(Analysis, MiniSetup)] =
     FileBasedStore(cacheFile).get().map(_ match {

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
     <log4j.version>1.2.17</log4j.version>
     <json-io.version>4.1.6</json-io.version>
     <mockito.version>1.9.5</mockito.version>
-    <zinc.version>1.0.0-X14</zinc.version>
-    <sbt-util.version>1.0.0-M23</sbt-util.version>
-    <sbt-io.version>1.0.0-M11</sbt-io.version>
+    <zinc.version>1.0.0-X18</zinc.version>
+    <sbt-util.version>1.0.0-M26</sbt-util.version>
+    <sbt-io.version>1.0.0-M12</sbt-io.version>
     <sbinary.version>0.4.4</sbinary.version>
     <scala-refactoring.version>0.13.0-SNAPSHOT</scala-refactoring.version>
 


### PR DESCRIPTION
:warning: **This change is not ready for merging yet, there is 16 test failures.** :warning:

Those changes were the limited to getting the code to compile, so it is quite likely that the integration layer can be further simplidfied. @jvican PTAL.

I have a problem with debugging the tests in Eclipse, because PDE picks up old versions of  `org.scala-ide.zinc.library` and `org.scala-ide.zinc.compiler.bridge` bundles and I don't know how to nudge it doing the right thing. @sschaef maybe you have some tips?