### PR TITLE
Update to Eclipse 4.7.0 (Oxygen)

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/testsetup/SDTTestUtils.scala
@@ -271,7 +271,7 @@ object SDTTestUtils extends HasLogger {
     names map (n => internalCreateProjectInWorkspace(n, withSourceRootOnly))
 
   def deleteProjects(projects: IScalaProject*)(implicit progressMonitor: IProgressMonitor = new NullProgressMonitor): Unit = {
-    EclipseUtils.workspaceRunnableIn(EclipseUtils.workspaceRoot.getWorkspace) { _ =>
+    EclipseUtils.workspaceRunnableIn(EclipseUtils.workspaceRoot.getWorkspace, progressMonitor) { _ =>
       projects foreach (_.underlying.delete(true, progressMonitor))
     }
   }

--- a/org.scala-ide.sdt.core/plugin.xml
+++ b/org.scala-ide.sdt.core/plugin.xml
@@ -636,6 +636,7 @@
          point="org.eclipse.core.resources.builders">
       <builder hasNature="true">
          <run class="org.scalaide.core.internal.builder.ScalaBuilder"/>
+         <dynamicReference class="org.eclipse.jdt.internal.core.DynamicProjectReferences"/>
       </builder>
    </extension>
    <extension

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaToggleBreakpointAdapter.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/editor/ScalaToggleBreakpointAdapter.scala
@@ -19,6 +19,7 @@ import org.eclipse.jdt.internal.debug.ui.BreakpointUtils
 import org.eclipse.jdt.internal.debug.ui.DebugWorkingCopyManager
 import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin
 import org.eclipse.jdt.internal.debug.ui.actions.ActionMessages
+import org.eclipse.jdt.internal.debug.ui.actions.BreakpointToggleUtils
 import org.eclipse.jdt.internal.debug.ui.actions.ToggleBreakpointAdapter
 import org.eclipse.jface.text.BadLocationException
 import org.eclipse.jface.text.ITextSelection
@@ -50,7 +51,7 @@ class ScalaToggleBreakpointAdapter extends ToggleBreakpointAdapter with HasLogge
           if (monitor.isCanceled)
             return Status.CANCEL_STATUS
           try {
-            report(null, part)
+            BreakpointToggleUtils.report(null, part)
             val sel =
               if(!selection.isInstanceOf[IStructuredSelection])
                 translateToMembers(part, selection)
@@ -93,7 +94,7 @@ class ScalaToggleBreakpointAdapter extends ToggleBreakpointAdapter with HasLogge
                 }
                 JDIDebugModel.createLineBreakpoint(resource, tname, lnumber, -1, -1, 0, true, attributes)
               } else {
-                report(ActionMessages.ToggleBreakpointAdapter_3, part)
+                BreakpointToggleUtils.report(ActionMessages.ToggleBreakpointAdapter_3, part)
                 return Status.OK_STATUS
               }
             } catch {

--- a/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/repl/ReplConsoleView.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/ui/internal/repl/ReplConsoleView.scala
@@ -301,7 +301,7 @@ class ReplConsoleView extends ViewPart with InterpreterConsoleView {
       project <- ResourcesPlugin.getWorkspace().getRoot().getProjects()
       if project.isOpen && project.hasNature(org.eclipse.jdt.core.JavaCore.NATURE_ID)
     } yield project.getName()
-    projectList.setItems(scalaProjectNames)
+    projectList.setItems(scalaProjectNames: _*)
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <tycho.test.OSspecific></tycho.test.OSspecific>
     <!-- Partial workaround against JDT Weaving deadlocks. See #1000317 and the original ticket on https://issuetracker.springsource.com/browse/STS-1445 -->
     <tycho.test.weaving>-XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass -Dosgi.classloader.lock=classname</tycho.test.weaving>
-    <tycho.test.jvmArgs>-Xmx1024m -XX:MaxPermSize=256m -Dsdtcore.headless -Dsdtcore.notimeouts -DretryFlakyTests=${retryFlakyTests} ${tycho.test.weaving} ${tycho.test.OSspecific}</tycho.test.jvmArgs>
+    <tycho.test.jvmArgs>-Xmx2048m -Dsdtcore.headless -Dsdtcore.notimeouts -DretryFlakyTests=${retryFlakyTests} ${tycho.test.weaving} ${tycho.test.OSspecific}</tycho.test.jvmArgs>
 
     <!-- base versions -->
     <!-- Scala 2.10.x -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
     <!-- p2 repositories location -->
     <repo.eclipse.neon>http://download.eclipse.org/releases/neon</repo.eclipse.neon>
     <repo.ajdt.neon>http://download.eclipse.org/tools/ajdt/46/dev/update</repo.ajdt.neon>
+    <repo.eclipse.oxygen>http://download.eclipse.org/releases/oxygen</repo.eclipse.oxygen>
+    <repo.ajdt.oxygen>http://download.eclipse.org/tools/ajdt/47/dev/update</repo.ajdt.oxygen>
     <repo.equinox.launcher>http://download.scala-ide.org/plugins/equinox-weaving-launcher/releases/site</repo.equinox.launcher>
     <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
     <repo.nebula>http://download.eclipse.org/technology/nebula/snapshot</repo.nebula>
@@ -138,6 +140,17 @@
         <repo.ajdt>${repo.ajdt.neon}</repo.ajdt>
         <jdt.core.version.range>[3.10.0,4.0.0)</jdt.core.version.range>
         <weaving.hook.plugin.version>1.1.200.v20150730-1648</weaving.hook.plugin.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>eclipse-oxygen</id>
+      <properties>
+        <eclipse.codename>oxygen</eclipse.codename>
+        <repo.eclipse>${repo.eclipse.oxygen}</repo.eclipse>
+        <repo.ajdt>${repo.ajdt.oxygen}</repo.ajdt>
+        <jdt.core.version.range>[3.10.0,4.0.0)</jdt.core.version.range>
+        <weaving.hook.plugin.version>1.2.0.v20160929-1449</weaving.hook.plugin.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
Please note that Oxygen introduced binary incompatible changes. If this PR is merged as is to master, new versions of Scala IDE plugins will no longer work on Eclipse Neon and lower. Please let me know if this OK, or `platfom/oxygen` should stay as a separate branch for another Eclipse release cycle, or do we need a workaround for single sourcing the IDE for Neon and Oxygen. 