### PR TITLE
upgrade embedded scalariform

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/formatter/ScalaFormatterPreferenceInitializer.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/formatter/ScalaFormatterPreferenceInitializer.scala
@@ -1,6 +1,5 @@
 package org.scalaide.core.internal.formatter
 
-import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer
 import org.scalaide.core.IScalaPlugin
 import scalariform.formatter.preferences._
@@ -13,36 +12,14 @@ class ScalaFormatterPreferenceInitializer extends AbstractPreferenceInitializer 
     implicit val preferenceStore = IScalaPlugin().getPreferenceStore
     for (preference <- AllPreferences.preferences) {
       preference match {
-        case DoubleIndentClassDeclaration =>
-          setDefaultBoolean(DoubleIndentClassDeclaration, overrideValue = Some(true))
-        case pd: BooleanPreferenceDescriptor =>
-          setDefaultBoolean(pd)
-        case pd: IntegerPreferenceDescriptor =>
-          setDefaultInt(pd)
+        case pd: BooleanPreferenceDescriptor => preferenceStore.setDefault(pd.eclipseKey, pd.defaultValue)
+        case pd: IntegerPreferenceDescriptor => preferenceStore.setDefault(pd.eclipseKey, pd.defaultValue)
+        case pd: IntentPreferenceDescriptor =>
+          preferenceStore.setDefault(
+            pd.eclipseKey, pd.defaultValue.toString
+          )
       }
     }
 
-  }
-
-  private def setDefaultBoolean(preference: PreferenceDescriptor[Boolean],
-    overrideValue: Option[Boolean] = None)(implicit preferenceStore: IPreferenceStore) = {
-    val defaultValue = overrideValue.getOrElse(preference.defaultValue)
-    preferenceStore.setDefault(preference.eclipseKey, defaultValue)
-    preferenceStore.setDefault(preference.oldEclipseKey, defaultValue)
-    if (!preferenceStore.isDefault(preference.oldEclipseKey)) {
-      preferenceStore(preference) = preferenceStore.getBoolean(preference.oldEclipseKey)
-      preferenceStore.setToDefault(preference.oldEclipseKey)
-    }
-  }
-
-  private def setDefaultInt(preference: PreferenceDescriptor[Int],
-    overrideValue: Option[Int] = None)(implicit preferenceStore: IPreferenceStore) = {
-    val defaultValue = overrideValue.getOrElse(preference.defaultValue)
-    preferenceStore.setDefault(preference.eclipseKey, defaultValue)
-    preferenceStore.setDefault(preference.oldEclipseKey, defaultValue)
-    if (!preferenceStore.isDefault(preference.oldEclipseKey)) {
-      preferenceStore(preference) = preferenceStore.getInt(preference.oldEclipseKey)
-      preferenceStore.setToDefault(preference.oldEclipseKey)
-    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
     <!-- the repos containing the Scala dependencies -->
     <repo.scala-refactoring>https://oss.sonatype.org/content/repositories/snapshots</repo.scala-refactoring>
-    <repo.scalariform>http://downloads.typesafe.com/scalaide/scalariform-${scala.short.version}x</repo.scalariform>
+    <repo.scalariform>https://raw.githubusercontent.com/scala-ide/scalariform/master/scalariform.update/target/site</repo.scalariform>
     <repo.typesafe>https://proxy-ch.typesafe.com:8082/artifactory/ide-${scala.minor.version}</repo.typesafe>
 
   </properties>


### PR DESCRIPTION
This PR upgrades embedded `scalariform` to the latest published release, along with making Scala IDE sources compatible with the new version of `scalariform`.

Eclipse `scalariform` update site pulls in P2 repository, just `./build-all.sh` and eclipse update site should be generated accordingly.

Once this is merged the cycle will be complete: auto save in the IDE and auto format via `sbt-scalariform` will produce the same result.