### PR TITLE
Version checks for compiler plugins consistent with publisher's policy

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/CompilerUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/CompilerUtils.scala
@@ -27,32 +27,29 @@ object CompilerUtils {
   }
 
   /**
+   * String form of either full or binary ScalaVersion with an offset on the last significant position.
+   */
+  def versionString(s: ScalaVersion, full: Boolean, offset: Int) = s match {
+    case SpecificScalaVersion(major, minor, rev, _) if full =>
+      s"${major}.${minor}.${rev + offset}"
+    case SpecificScalaVersion(major, minor, _, _) =>
+      s"${major}.${minor + offset}"
+    case _ =>
+      "none"
+  }
+
+  /**
    * Short string version of the given version.
    */
-  def shortString(s: ScalaVersion) = s match {
-    case ShortScalaVersion(major, minor) => f"$major%d.$minor%d"
-    case _ => "none"
-  }
+  def shortString(s: ScalaVersion) = versionString(s, full = false, offset = 0)
 
   /**
    * Short string for the previous version of the given version.
    */
-  def previousShortString(s: ScalaVersion) = s match {
-    case ShortScalaVersion(major, minor) =>
-      val lesserMinor = minor - 1
-      f"$major%d.$lesserMinor%d"
-    case _ =>
-      "none"
-  }
+  def previousShortString(s: ScalaVersion) = versionString(s, full = false, offset = -1)
 
   /**
    * Short string for the subsequent version of the given version.
    */
-  def subsequentShortString(s: ScalaVersion) = s match {
-    case ShortScalaVersion(major, minor) =>
-      val greaterMinor = minor + 1
-      f"$major%d.$greaterMinor%d"
-    case _ =>
-      "none"
-  }
+  def subsequentShortString(s: ScalaVersion) = versionString(s, full = false, offset = +1)
 }


### PR DESCRIPTION
Certain compiler plugins like and https://github.com/non/kind-projector
https://github.com/typelevel/machinist are published with cross version
corresponding to Scala binary version (eg. 2.12) others, like
https://github.com/scalamacros/paradise use full Scala version (eg.
2.12.3)

This change makes the check performed by IDE consistent with plugin
authors policy: plugin published with binary cross version will be
considered valid for any binary compatible Scala version, while plugins
published with full cross version will be considered valid only for
identical Scala version.