### PR TITLE
Worksheet multi scala support

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/TestsSuite.scala
@@ -70,6 +70,7 @@ import org.scalaide.core.sbtbuilder.Scala210Compilation
 import org.scalaide.core.sbtbuilder.Scala211Compilation
 import org.scalaide.core.sbtbuilder.SourcePathFinderTest
 import org.scalaide.core.scalaelements.ScalaElementsNameTest
+import org.scalaide.core.compiler.ResidentCompilerTest
 
 @RunWith(classOf[Suite])
 @Suite.SuiteClasses(
@@ -141,6 +142,7 @@ import org.scalaide.core.scalaelements.ScalaElementsNameTest
     classOf[Scala210Compilation],
     classOf[SourcePathFinderTest],
     classOf[ScalaElementsNameTest],
-    classOf[Scala211Compilation]
+    classOf[Scala211Compilation],
+    classOf[ResidentCompilerTest]
 ))
 class TestsSuite

--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/ResidentCompilerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/ResidentCompilerTest.scala
@@ -1,0 +1,57 @@
+package org.scalaide.core.compiler
+
+import java.io.File
+
+import org.junit.Assert
+import org.junit.Test
+import org.scalaide.core.SdtConstants
+import org.scalaide.core.internal.builder.zinc.ResidentCompiler
+import org.scalaide.core.internal.builder.zinc.ResidentCompiler.CompilationFailed
+import org.scalaide.core.internal.builder.zinc.ResidentCompiler.CompilationSuccess
+import org.scalaide.core.testsetup.TestProjectSetup
+
+object ResidentCompilerTest extends TestProjectSetup("resident-compiler") {
+  val Dot = 1
+}
+
+class ResidentCompilerTest {
+  import ResidentCompilerTest._
+
+  @Test
+  def shouldCompileScalaSource(): Unit = {
+    val scalaSrc = project.allSourceFiles.collectFirst {
+      case file if file.getFileExtension == SdtConstants.ScalaFileExtn.drop(Dot) =>
+        new File(file.getLocationURI)
+    }.get
+    val output = project.outputFolderLocations.headOption.map(_.toFile()).get
+    val tested = ResidentCompiler(project, output, None).get
+
+    val actual = tested.compile(scalaSrc)
+
+    actual match {
+      case CompilationSuccess =>
+      // ok
+      case CompilationFailed(errors) =>
+        Assert.fail(s"Expected no errors, found ${errors.toList.size}")
+    }
+  }
+
+  @Test
+  def shouldNotCompileJavaSourceBecauseThereIsNoWorkingJavaCompiler(): Unit = {
+    val javaSrc = project.allSourceFiles.collectFirst {
+      case file if file.getFileExtension == SdtConstants.JavaFileExtn.drop(Dot) =>
+        new File(file.getLocationURI)
+    }.get
+    val output = project.outputFolderLocations.headOption.map(_.toFile()).get
+    val tested = ResidentCompiler(project, output, None).get
+
+    try {
+      tested.compile(javaSrc)
+      Assert.fail(s"Expected compilation error")
+    } catch {
+      case correct: NotImplementedError =>
+        Assert.assertTrue(correct.getMessage == "expects to be not called")
+    }
+
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/.classpath
+++ b/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/.project
+++ b/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>resident-compiler</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.scala-ide.sdt.core.scalabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.scala-ide.sdt.core.scalanature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/src/JavaFails.java
+++ b/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/src/JavaFails.java
@@ -1,0 +1,6 @@
+
+public class JavaFails {
+  public int foo(String bar) {
+	  return Integer.valueOf(bar);
+  }
+}

--- a/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/src/ScalaSucceeds.scala
+++ b/org.scala-ide.sdt.core.tests/test-workspace/resident-compiler/src/ScalaSucceeds.scala
@@ -1,0 +1,5 @@
+package org.scalaide.resident.test
+
+class ScalaSucceeds {
+  def foo(bar: String): Int = ???
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/CachingCompiler.scala
@@ -12,9 +12,7 @@ import xsbti.Logger
 import xsbti.Reporter
 import xsbti.compile.AnalysisContents
 import xsbti.compile.CompileResult
-import xsbti.compile.DefinesClass
 import xsbti.compile.JavaCompiler
-import xsbti.compile.PerClasspathEntryLookup
 import xsbti.compile.ScalaCompiler
 
 /**
@@ -36,16 +34,9 @@ class CachingCompiler private (cacheFile: File, sbtReporter: Reporter, log: Logg
    *  method which is not implemented in `IC.compile`.
    */
   def compile(in: SbtInputs, comps: Compilers): Analysis = {
-    val lookup = new PerClasspathEntryLookup {
+    val lookup = new DefaultPerClasspathEntryLookup {
       override def analysis(classpathEntry: File) =
         in.analysisMap(classpathEntry)
-
-      override def definesClass(classpathEntry: File) = {
-        val dc = Locator(classpathEntry)
-        new DefinesClass() {
-          def apply(name: String) = dc.apply(name)
-        }
-      }
     }
     val (previousAnalysis, previousSetup) = SbtUtils.readCache(cacheFile)
       .map {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/DefaultPerClasspathEntryLookup.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/DefaultPerClasspathEntryLookup.scala
@@ -1,0 +1,20 @@
+package org.scalaide.core.internal.builder.zinc
+
+import java.io.File
+import java.util.Optional
+
+import xsbti.compile.CompileAnalysis
+import xsbti.compile.DefinesClass
+import xsbti.compile.PerClasspathEntryLookup
+
+private[zinc] trait DefaultPerClasspathEntryLookup extends PerClasspathEntryLookup {
+  override def analysis(classpathEntry: File): Optional[CompileAnalysis] =
+    Optional.empty()
+
+  override def definesClass(classpathEntry: File) = {
+    val dc = Locator(classpathEntry)
+    new DefinesClass() {
+      def apply(name: String) = dc.apply(name)
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseMultipleOutput.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseMultipleOutput.scala
@@ -1,0 +1,19 @@
+package org.scalaide.core.internal.builder.zinc
+
+import java.io.File
+
+import xsbti.compile.MultipleOutput
+import xsbti.compile.OutputGroup
+
+/**
+ * This class is serialized by Zinc. Don't forget to get rid off all closure dependences
+ * in case of re-implementing it.
+ */
+class EclipseMultipleOutput(val srcOuts: Seq[(File, File)]) extends MultipleOutput {
+  override def getOutputGroups = srcOuts.map {
+    case (src, out) => new OutputGroup {
+      override def getSourceDirectory = src
+      override def getOutputDirectory = out
+    }
+  }.toArray
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/EclipseSbtBuildManager.scala
@@ -4,7 +4,6 @@ package zinc
 import java.io.File
 import java.lang.ref.SoftReference
 import java.util.concurrent.atomic.AtomicReference
-import java.util.function.Supplier
 
 import scala.collection.mutable
 import scala.tools.nsc.Settings
@@ -29,11 +28,11 @@ import org.scalaide.util.eclipse.FileUtils
 import org.scalaide.util.internal.SbtUtils
 
 import sbt.internal.inc.Analysis
+import sbt.util.InterfaceUtil.problem
 import xsbti.CompileFailed
 import xsbti.Logger
 import xsbti.compile.CompileProgress
 import xsbti.compile.analysis.SourceInfo
-import sbt.util.InterfaceUtil._
 
 /**
  * An Eclipse builder using the Sbt engine.
@@ -65,13 +64,7 @@ class EclipseSbtBuildManager(val project: IScalaProject, settings: Settings, ana
   private val tempDir = project.underlying.getFolder(".tmpBin")
   private def tempDirFile = tempDir.getLocation().toFile()
 
-  private val sbtLogger = new xsbti.Logger {
-    override def error(msg: Supplier[String]) = logger.error(msg.get)
-    override def warn(msg: Supplier[String]) = logger.warn(msg.get)
-    override def info(msg: Supplier[String]) = logger.info(msg.get)
-    override def debug(msg: Supplier[String]) = logger.debug(msg.get)
-    override def trace(exc: Supplier[Throwable]) = logger.error("", exc.get)
-  }
+  private val sbtLogger = SbtUtils.defaultSbtLogger(logger)
 
   private lazy val sbtReporter = new SbtBuildReporter(project)
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
@@ -75,8 +75,8 @@ class ResidentCompiler private (project: IScalaProject, comps: Compilers, worksh
   }
   private val worksheetLibs = libs.map(_.toFile).toSeq
 
-  def compile(worksheetSrc_ : File): CompilationResult = {
-    val worksheetSrc = worksheetSrc_.getAbsoluteFile
+  def compile(worksheetSrc : File): CompilationResult = {
+    //val worksheetSrc = ResourcesPlugin.getWorkspace.getRoot
     def sbtReporter = new SbtBuildReporter(project)
 
     def incOptions: IncOptions = {
@@ -113,14 +113,8 @@ class ResidentCompiler private (project: IScalaProject, comps: Compilers, worksh
       }
     }
 
-    def srcOutDirs = project.sourceOutputFolders.map {
-      case (src, out) => (Option(src.getLocation).map(_.toFile()), Option(out.getLocation).map(_.toFile()))
-    }.collect {
-      case (Some(src), Some(out)) => (src, out)
-      case (Some(src), None) => throw new IllegalStateException(s"Not found output folder for source $src folder. Check build configuration.")
-      case (None, Some(out)) => throw new IllegalStateException(s"Not found source folder for output $out folder. Check build configuration.")
-      // case (None, None) is correct for some project building states. Ignore it.
-    }
+    def srcOutDirs = Seq(worksheetSrc.toPath.getParent.toFile -> worksheetBinFolder)
+
     def output = new EclipseMultipleOutput(srcOutDirs)
     def cache = new FreshCompilerCache
 

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
@@ -2,59 +2,31 @@ package org.scalaide.core.internal.builder.zinc
 
 import java.io.File
 import java.util.Optional
-import java.util.function.Supplier
 
 import scala.reflect.internal.util.NoPosition
 import scala.reflect.internal.util.Position
 
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.runtime.SubMonitor
 import org.scalaide.core.IScalaProject
-import org.scalaide.core.internal.ScalaPlugin
-import org.scalaide.core.internal.project.ScalaInstallation.scalaInstanceForInstallation
 import org.scalaide.logging.HasLogger
+import org.scalaide.util.internal.SbtUtils
 
-import sbt.internal.inc.AnalyzingCompiler
 import sbt.internal.inc.FreshCompilerCache
 import sbt.internal.inc.IncrementalCompilerImpl
-import xsbti.Logger
-import xsbti.compile.ClasspathOptions
 import xsbti.compile.CompileAnalysis
-import xsbti.compile.CompilerBridgeProvider
-import xsbti.compile.DefinesClass
+import xsbti.compile.CompileOrder
+import xsbti.compile.CompileProgress
 import xsbti.compile.IncOptions
 import xsbti.compile.MiniSetup
-import xsbti.compile.PerClasspathEntryLookup
-import xsbti.compile.ScalaInstance
 
 object ResidentCompiler {
-  def apply(project: IScalaProject, worksheetBinFolder: File, worksheetLibs: Option[IPath]) = {
+  def apply(project: IScalaProject, compilationOutputFolder: File, extraLibsToCompile: Option[IPath],
+      monitor: SubMonitor = SubMonitor.convert(new NullProgressMonitor)) = {
     val installation = project.effectiveScalaInstallation
-    val scalaInstance = scalaInstanceForInstallation(installation)
-    val store = ScalaPlugin().compilerBridgeStore
-    val comps = store.compilerBridgeFor(installation)(new NullProgressMonitor).right.map {
-      compilerBridge =>
-        // prevent zinc from adding things to the (boot)classpath
-        val cpOptions = ClasspathOptions.create(false, false, false, /* autoBoot = */ false, /* filterLibrary = */ false)
-        Compilers(
-          new AnalyzingCompiler(
-            scalaInstance,
-            new CompilerBridgeProvider {
-              def fetchCompiledBridge(si: ScalaInstance, logger: Logger) = si.version match {
-                case scalaInstance.version => compilerBridge.toFile
-                case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
-              }
-              def fetchScalaInstance(scalaVersion: String, logger: Logger) = scalaVersion match {
-                case scalaInstance.version => scalaInstance
-                case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
-              }
-            },
-            cpOptions,
-            _ ⇒ (),
-            None),
-          new JavaEclipseCompiler(null, null))
-    }
-    comps.toOption.map { comps => new ResidentCompiler(project, comps, worksheetBinFolder, worksheetLibs) }
+    val comps = compilers(installation, monitor)
+    comps.toOption.map { comps => new ResidentCompiler(project, comps, compilationOutputFolder, extraLibsToCompile) }
   }
 
   sealed abstract class CompilationResult
@@ -64,44 +36,24 @@ object ResidentCompiler {
   case class CompilationError(msg: String, pos: Position)
 }
 
-class ResidentCompiler private (project: IScalaProject, comps: Compilers, worksheetBinFolder: File, libs: Option[IPath]) extends HasLogger {
+class ResidentCompiler private (project: IScalaProject, comps: Compilers, compilationOutputFolder: File,
+    extraLibsToCompile: Option[IPath]) extends HasLogger {
   import ResidentCompiler._
-  private val sbtLogger = new xsbti.Logger {
-    override def error(msg: Supplier[String]) = logger.error(msg.get)
-    override def warn(msg: Supplier[String]) = logger.warn(msg.get)
-    override def info(msg: Supplier[String]) = logger.info(msg.get)
-    override def debug(msg: Supplier[String]) = logger.debug(msg.get)
-    override def trace(exc: Supplier[Throwable]) = logger.error("", exc.get)
-  }
-  private val worksheetLibs = libs.map(_.toFile).toSeq
+  private val sbtLogger = SbtUtils.defaultSbtLogger(logger)
+  private val libs = extraLibsToCompile.map(_.toFile).toSeq
 
-  def compile(worksheetSrc: File): CompilationResult = {
+  def compile(compiledSource: File): CompilationResult = {
     def sbtReporter = new SbtBuildReporter(project)
-
     def incOptions: IncOptions = IncOptions.of()
-
-    val lookup = new PerClasspathEntryLookup {
-      override def analysis(classpathEntry: File) =
-        Optional.empty()
-
-      override def definesClass(classpathEntry: File) = {
-        val dc = Locator(classpathEntry)
-        new DefinesClass() {
-          def apply(name: String) = dc.apply(name)
-        }
-      }
-    }
-
-    def output = new EclipseMultipleOutput(Seq(worksheetSrc.toPath.getParent.toFile -> worksheetBinFolder))
+    def output = new EclipseMultipleOutput(Seq(compiledSource.toPath.getParent.toFile -> compilationOutputFolder))
     def cache = new FreshCompilerCache
+    val lookup = new DefaultPerClasspathEntryLookup {}
+    val classpath = libs ++ project.scalaClasspath.userCp.map(_.toFile)
 
-    val classpath = worksheetLibs ++ project.scalaClasspath.userCp.map(_.toFile)
-
-    import xsbti.compile.CompileOrder._
-
-    new IncrementalCompilerImpl().compile(comps.scalac, comps.javac, Array(worksheetSrc), classpath.toArray, output,
+    new IncrementalCompilerImpl().compile(comps.scalac, comps.javac, Array(compiledSource), classpath.toArray, output,
       cache, project.scalacArguments.toArray, javaOptions = Array(), Optional.empty[CompileAnalysis], Optional.empty[MiniSetup],
-      lookup, sbtReporter, ScalaThenJava, skip = false, Optional.empty() /*progress*/ , incOptions, extra = Array(), sbtLogger)
+      lookup, sbtReporter, CompileOrder.ScalaThenJava, skip = false, Optional.empty[CompileProgress], incOptions, extra = Array(),
+      sbtLogger)
 
     import xsbti.Severity._
     val errors = sbtReporter.problems.collect {

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
@@ -1,0 +1,149 @@
+package org.scalaide.core.internal.builder.zinc
+
+import java.io.File
+import java.util.Optional
+import java.util.function.Supplier
+
+import scala.reflect.internal.util.NoPosition
+import scala.reflect.internal.util.Position
+
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.scalaide.core.IScalaProject
+import org.scalaide.core.internal.ScalaPlugin
+import org.scalaide.core.internal.project.ScalaInstallation.scalaInstanceForInstallation
+import org.scalaide.logging.HasLogger
+
+import sbt.internal.inc.AnalyzingCompiler
+import sbt.internal.inc.FreshCompilerCache
+import sbt.internal.inc.IncrementalCompilerImpl
+import xsbti.Logger
+import xsbti.compile.ClasspathOptions
+import xsbti.compile.CompileAnalysis
+import xsbti.compile.CompilerBridgeProvider
+import xsbti.compile.DefinesClass
+import xsbti.compile.IncOptions
+import xsbti.compile.MiniSetup
+import xsbti.compile.PerClasspathEntryLookup
+import xsbti.compile.ScalaInstance
+import org.eclipse.core.runtime.IPath
+
+object ResidentCompiler {
+  def apply(project: IScalaProject, worksheetBinFolder: File, worksheetLibs: Option[IPath]) = {
+    val installation = project.effectiveScalaInstallation
+    val scalaInstance = scalaInstanceForInstallation(installation)
+    val store = ScalaPlugin().compilerBridgeStore
+    val comps = store.compilerBridgeFor(installation)(new NullProgressMonitor).right.map {
+      compilerBridge =>
+        // prevent zinc from adding things to the (boot)classpath
+        val cpOptions = ClasspathOptions.create(false, false, false, /* autoBoot = */ false, /* filterLibrary = */ false)
+        Compilers(
+          new AnalyzingCompiler(
+            scalaInstance,
+            new CompilerBridgeProvider {
+              def fetchCompiledBridge(si: ScalaInstance, logger: Logger) = si.version match {
+                case scalaInstance.version => compilerBridge.toFile
+                case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
+              }
+              def fetchScalaInstance(scalaVersion: String, logger: Logger) = scalaVersion match {
+                case scalaInstance.version => scalaInstance
+                case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
+              }
+            },
+            cpOptions,
+            _ ⇒ (),
+            None),
+          new JavaEclipseCompiler(null, null))
+    }
+    comps.toOption.map { comps => new ResidentCompiler(project, comps, worksheetBinFolder, worksheetLibs) }
+  }
+
+  sealed abstract class CompilationResult
+  case object CompilationSuccess extends CompilationResult
+  case class CompilationFailed(errors: Iterable[CompilationError]) extends CompilationResult
+
+  case class CompilationError(msg: String, pos: Position)
+}
+
+class ResidentCompiler private (project: IScalaProject, comps: Compilers, worksheetBinFolder: File, libs: Option[IPath]) extends HasLogger {
+  import ResidentCompiler._
+  private val sbtLogger = new xsbti.Logger {
+    override def error(msg: Supplier[String]) = logger.error(msg.get)
+    override def warn(msg: Supplier[String]) = logger.warn(msg.get)
+    override def info(msg: Supplier[String]) = logger.info(msg.get)
+    override def debug(msg: Supplier[String]) = logger.debug(msg.get)
+    override def trace(exc: Supplier[Throwable]) = logger.error("", exc.get)
+  }
+  private val worksheetLibs = libs.map(_.toFile).toSeq
+
+  def compile(worksheetSrc_ : File): CompilationResult = {
+    val worksheetSrc = worksheetSrc_.getAbsoluteFile
+    def sbtReporter = new SbtBuildReporter(project)
+
+    def incOptions: IncOptions = {
+      import xsbti.compile.IncOptions._
+      val base = of()
+      base.
+        withApiDebug(defaultApiDebug()).
+        withRelationsDebug(defaultRelationsDebug()).
+        withClassfileManagerType(Optional.empty()).
+        withApiDumpDirectory(Optional.empty()).
+        withRecompileOnMacroDef(defaultRecompileOnMacroDef()).
+        withEnabled(defaultEnabled()).
+        withStoreApis(defaultStoreApis()).
+        withApiDiffContextSize(defaultApiDiffContextSize()).
+        withExternalHooks(defaultExternal()).
+        withExtra(defaultExtra()).
+        withLogRecompileOnMacro(defaultLogRecompileOnMacro()).
+        withRecompileAllFraction(defaultRecompileAllFraction()).
+        withRelationsDebug(defaultRelationsDebug()).
+        withTransitiveStep(defaultTransitiveStep()).
+        withUseCustomizedFileManager(defaultUseCustomizedFileManager()).
+        withUseOptimizedSealed(defaultUseOptimizedSealed())
+    }
+
+    val lookup = new PerClasspathEntryLookup {
+      override def analysis(classpathEntry: File) =
+        Optional.empty()
+
+      override def definesClass(classpathEntry: File) = {
+        val dc = Locator(classpathEntry)
+        new DefinesClass() {
+          def apply(name: String) = dc.apply(name)
+        }
+      }
+    }
+
+    def srcOutDirs = project.sourceOutputFolders.map {
+      case (src, out) => (Option(src.getLocation).map(_.toFile()), Option(out.getLocation).map(_.toFile()))
+    }.collect {
+      case (Some(src), Some(out)) => (src, out)
+      case (Some(src), None) => throw new IllegalStateException(s"Not found output folder for source $src folder. Check build configuration.")
+      case (None, Some(out)) => throw new IllegalStateException(s"Not found source folder for output $out folder. Check build configuration.")
+      // case (None, None) is correct for some project building states. Ignore it.
+    }
+    def output = new EclipseMultipleOutput(srcOutDirs)
+    def cache = new FreshCompilerCache
+
+    val classpath = worksheetLibs ++ project.scalaClasspath.userCp.map(_.toFile)
+
+    import xsbti.compile.CompileOrder._
+
+    new IncrementalCompilerImpl().compile(comps.scalac, comps.javac, Array(worksheetSrc), classpath.toArray, output,
+      cache, project.scalacArguments.toArray, javaOptions = Array(), Optional.empty[CompileAnalysis], Optional.empty[MiniSetup],
+      lookup, sbtReporter, ScalaThenJava, skip = false, Optional.empty() /*progress*/ , incOptions, extra = Array(), sbtLogger)
+    import xsbti.Severity._
+    val errors = sbtReporter.problems.collect {
+      case p if p.severity() == Error =>
+        val pos = if (p.position().line().isPresent())
+          new Position {
+            override def line = p.position().line().get
+          }
+        else NoPosition
+        CompilationError(p.message(), pos)
+    }
+    if (errors.nonEmpty)
+      CompilationFailed(errors)
+    else
+      CompilationSuccess
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/SbtInputs.scala
@@ -2,7 +2,6 @@ package org.scalaide.core.internal.builder.zinc
 
 import java.io.File
 import java.util.Optional
-import java.util.zip.ZipFile
 
 import org.eclipse.core.resources.IContainer
 import org.eclipse.core.runtime.IPath
@@ -10,24 +9,14 @@ import org.eclipse.core.runtime.SubMonitor
 import org.scalaide.core.IScalaInstallation
 import org.scalaide.core.IScalaProject
 import org.scalaide.core.internal.ScalaPlugin
-import org.scalaide.core.internal.project.ScalaInstallation.scalaInstanceForInstallation
 import org.scalaide.ui.internal.preferences
 import org.scalaide.util.internal.SettingConverterUtil
 
-import sbt.internal.inc.AnalyzingCompiler
 import sbt.internal.inc.FreshCompilerCache
-import sbt.internal.inc.Locate
-import sbt.internal.inc.classpath.ClasspathUtilities
 import xsbti.Logger
-import xsbti.compile.ClasspathOptions
 import xsbti.compile.CompileAnalysis
 import xsbti.compile.CompileProgress
-import xsbti.compile.CompilerBridgeProvider
-import xsbti.compile.DefinesClass
 import xsbti.compile.IncOptions
-import xsbti.compile.MultipleOutput
-import xsbti.compile.OutputGroup
-import xsbti.compile.ScalaInstance
 import xsbti.compile.TransactionalManagerType
 
 /**
@@ -36,15 +25,16 @@ import xsbti.compile.TransactionalManagerType
  *  We return a real IncOptions instance, instead of relying on the Java interface,
  *  based on String maps. This allows us to use the transactional classfile writer.
  */
-class SbtInputs(installation: IScalaInstallation,
-    sourceFiles: Seq[File],
-    project: IScalaProject,
-    javaMonitor: SubMonitor,
-    scalaProgress: CompileProgress,
-    tempDir: File, // used to store classfiles between compilation runs to implement all-or-nothing semantics
-    logger: Logger,
-    addToClasspath: Seq[IPath] = Seq.empty,
-    srcOutputs: Seq[(IContainer, IContainer)] = Seq.empty) {
+class SbtInputs(
+  installation: IScalaInstallation,
+  sourceFiles: Seq[File],
+  project: IScalaProject,
+  javaMonitor: SubMonitor,
+  scalaProgress: CompileProgress,
+  tempDir: File, // used to store classfiles between compilation runs to implement all-or-nothing semantics
+  logger: Logger,
+  addToClasspath: Seq[IPath] = Seq.empty,
+  srcOutputs: Seq[(IContainer, IContainer)] = Seq.empty) {
 
   def cache = new FreshCompilerCache // May want to explore caching possibilities.
 
@@ -72,19 +62,7 @@ class SbtInputs(installation: IScalaInstallation,
       withApiDebug(project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.apiDiff.name))).
       withRelationsDebug(project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.relationsDebug.name))).
       withClassfileManagerType(Optional.ofNullable(TransactionalManagerType.create(tempDir, logger))).
-      withApiDumpDirectory(Optional.empty()).
-      withRecompileOnMacroDef(Optional.ofNullable(project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.recompileOnMacroDef.name)))).
-      withEnabled(defaultEnabled()).
-      withStoreApis(defaultStoreApis()).
-      withApiDiffContextSize(defaultApiDiffContextSize()).
-      withExternalHooks(defaultExternal()).
-      withExtra(defaultExtra()).
-      withLogRecompileOnMacro(defaultLogRecompileOnMacro()).
-      withRecompileAllFraction(defaultRecompileAllFraction()).
-      withRelationsDebug(defaultRelationsDebug()).
-      withTransitiveStep(defaultTransitiveStep()).
-      withUseCustomizedFileManager(defaultUseCustomizedFileManager()).
-      withUseOptimizedSealed(defaultUseOptimizedSealed())
+      withRecompileOnMacroDef(Optional.ofNullable(project.storage.getBoolean(SettingConverterUtil.convertNameToProperty(preferences.ScalaPluginSettings.recompileOnMacroDef.name))))
   }
 
   def outputFolders = srcOutputs.map {
@@ -101,13 +79,13 @@ class SbtInputs(installation: IScalaInstallation,
   def sources = sourceFiles.toArray
 
   private def srcOutDirs = (if (srcOutputs.nonEmpty) srcOutputs else project.sourceOutputFolders).map {
-      case (src, out) => (Option(src.getLocation).map(_.toFile()), Option(out.getLocation).map(_.toFile()))
-    }.collect {
-      case (Some(src), Some(out)) => (src, out)
-      case (Some(src), None) => throw new IllegalStateException(s"Not found output folder for source $src folder. Check build configuration.")
-      case (None, Some(out)) => throw new IllegalStateException(s"Not found source folder for output $out folder. Check build configuration.")
-      // case (None, None) is correct for some project building states. Ignore it.
-    }
+    case (src, out) => (Option(src.getLocation).map(_.toFile()), Option(out.getLocation).map(_.toFile()))
+  }.collect {
+    case (Some(src), Some(out)) => (src, out)
+    case (Some(src), None) => throw new IllegalStateException(s"Not found output folder for source $src folder. Check build configuration.")
+    case (None, Some(out)) => throw new IllegalStateException(s"Not found source folder for output $out folder. Check build configuration.")
+    // case (None, None) is correct for some project building states. Ignore it.
+  }
 
   def output = new EclipseMultipleOutput(srcOutDirs)
 
@@ -137,85 +115,10 @@ class SbtInputs(installation: IScalaInstallation,
   /**
    * @return Right-biased instance of Either (error message in Left, value in Right)
    */
-  def compilers: Either[String, Compilers] = {
-    val scalaInstance = scalaInstanceForInstallation(installation)
-    val store = ScalaPlugin().compilerBridgeStore
-
-    store.compilerBridgeFor(installation)(javaMonitor.newChild(10)).right.map {
-      compilerBridge =>
-        // prevent zinc from adding things to the (boot)classpath
-        val cpOptions = ClasspathOptions.create(false, false, false, /* autoBoot = */ false, /* filterLibrary = */ false)
-        Compilers(
-          new AnalyzingCompiler(scalaInstance,
-              new CompilerBridgeProvider {
-                def fetchCompiledBridge(si: ScalaInstance, logger: Logger) = si.version match {
-                  case scalaInstance.version => compilerBridge.toFile
-                  case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
-                }
-                def fetchScalaInstance(scalaVersion: String, logger: Logger) = scalaVersion match {
-                  case scalaInstance.version => scalaInstance
-                  case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
-                }
-              },
-              cpOptions,
-              _ ⇒ (),
-              None),
-          new JavaEclipseCompiler(project.underlying, javaMonitor))
-    }
-  }
-}
-
-/**
- * This class is serialized by Zinc. Don't forget to get rid off all closure dependences
- * in case of re-implementing it.
- */
-class EclipseMultipleOutput(val srcOuts: Seq[(File, File)]) extends MultipleOutput {
-  override def getOutputGroups = srcOuts.map {
-    case (src, out) => new OutputGroup {
-      override def getSourceDirectory = src
-      override def getOutputDirectory = out
-    }
-  }.toArray
-}
-
-private[zinc] object Locator {
-  val NoClass = new DefinesClass {
-    override def apply(className: String) = false
-  }
-
-  def apply(f: File): DefinesClass =
-    if (f.isDirectory)
-      new DirectoryLocator(f)
-    else if (f.exists && ClasspathUtilities.isArchive(f))
-      new JarLocator(f)
-    else
-      NoClass
-
-  class DirectoryLocator(dir: File) extends DefinesClass {
-    override def apply(className: String): Boolean = Locate.classFile(dir, className).isFile
-  }
-
-  class JarLocator(jar: File) extends DefinesClass {
-    lazy val entries: Set[String] = {
-      val zipFile = new ZipFile(jar, ZipFile.OPEN_READ)
-      try {
-        import scala.collection.JavaConverters._
-        zipFile.entries.asScala.filterNot(_.isDirectory).map { entry =>
-          toClassNameFromJarFileName(entry.getName)
-        }.toSet
-      } finally
-        zipFile.close()
-    }
-
-    private def toClassNameFromJarFileName(jarFileName: String): String = {
-      val noClassAtEnd = if (jarFileName.endsWith(".class"))
-        jarFileName.substring(0, jarFileName.lastIndexOf(".class"))
-      else
-        jarFileName
-      noClassAtEnd.replaceAll("/", ".")
-    }
-
-    override def apply(className: String): Boolean =
-      entries.contains(className)
-  }
+  import org.scalaide.core.internal.builder.zinc.{ compilers => zincCompilers }
+  def compilers: Either[String, Compilers] =
+    zincCompilers(
+      installation,
+      javaMonitor,
+      () => new JavaEclipseCompiler(project.underlying, javaMonitor))
 }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/package.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/package.scala
@@ -1,0 +1,100 @@
+package org.scalaide.core.internal.builder
+
+import java.io.File
+import java.util.zip.ZipFile
+
+import org.eclipse.core.runtime.SubMonitor
+import org.scalaide.core.IScalaInstallation
+import org.scalaide.core.internal.ScalaPlugin
+
+import sbt.internal.inc.AnalyzingCompiler
+import sbt.internal.inc.Locate
+import sbt.internal.inc.classpath.ClasspathUtilities
+import xsbti.Logger
+import xsbti.Reporter
+import xsbti.compile.ClasspathOptions
+import xsbti.compile.CompilerBridgeProvider
+import xsbti.compile.DefinesClass
+import xsbti.compile.IncToolOptions
+import xsbti.compile.JavaCompiler
+import xsbti.compile.ScalaInstance
+
+package object zinc {
+  private[zinc] object Locator {
+    val NoClass = new DefinesClass {
+      override def apply(className: String) = false
+    }
+
+    def apply(f: File): DefinesClass =
+      if (f.isDirectory)
+        new DirectoryLocator(f)
+      else if (f.exists && ClasspathUtilities.isArchive(f))
+        new JarLocator(f)
+      else
+        NoClass
+
+    class DirectoryLocator(dir: File) extends DefinesClass {
+      override def apply(className: String): Boolean = Locate.classFile(dir, className).isFile
+    }
+
+    class JarLocator(jar: File) extends DefinesClass {
+      lazy val entries: Set[String] = {
+        val zipFile = new ZipFile(jar, ZipFile.OPEN_READ)
+        try {
+          import scala.collection.JavaConverters._
+          zipFile.entries.asScala.filterNot(_.isDirectory).map { entry =>
+            toClassNameFromJarFileName(entry.getName)
+          }.toSet
+        } finally
+          zipFile.close()
+      }
+
+      private def toClassNameFromJarFileName(jarFileName: String): String = {
+        val noClassAtEnd = if (jarFileName.endsWith(".class"))
+          jarFileName.substring(0, jarFileName.lastIndexOf(".class"))
+        else
+          jarFileName
+        noClassAtEnd.replaceAll("/", ".")
+      }
+
+      override def apply(className: String): Boolean =
+        entries.contains(className)
+    }
+  }
+
+  private[zinc] object unimplementedJavaCompiler extends JavaCompiler {
+    override def run(srcs: Array[File], opts: Array[String], incOpts: IncToolOptions, reporter: Reporter, logger: Logger) =
+      throw new NotImplementedError("expects to be not called")
+  }
+
+  private[zinc] object compilers {
+    def apply(installation: IScalaInstallation, javaMonitor: SubMonitor, javaCompilerConstructor: () => JavaCompiler = () => unimplementedJavaCompiler): Either[String, Compilers] = {
+      import org.scalaide.core.internal.project.ScalaInstallation._
+      val scalaInstance = scalaInstanceForInstallation(installation)
+      val store = ScalaPlugin().compilerBridgeStore
+
+      store.compilerBridgeFor(installation)(javaMonitor.newChild(10)).right.map {
+        compilerBridge =>
+          // prevent zinc from adding things to the (boot)classpath
+          val cpOptions = ClasspathOptions.create(false, false, false, /* autoBoot = */ false, /* filterLibrary = */ false)
+          Compilers(
+            new AnalyzingCompiler(
+              scalaInstance,
+              new CompilerBridgeProvider {
+                def fetchCompiledBridge(si: ScalaInstance, logger: Logger) = si.version match {
+                  case scalaInstance.version => compilerBridge.toFile
+                  case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
+                }
+                def fetchScalaInstance(scalaVersion: String, logger: Logger) = scalaVersion match {
+                  case scalaInstance.version => scalaInstance
+                  case requested => throw new IllegalStateException(s"${scalaInstance.version} does not match requested one $requested")
+                }
+              },
+              cpOptions,
+              _ ⇒ (),
+              None),
+            javaCompilerConstructor())
+      }
+    }
+  }
+}

--- a/org.scala-ide.sdt.core/src/org/scalaide/util/internal/SbtUtils.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/util/internal/SbtUtils.scala
@@ -2,6 +2,9 @@ package org.scalaide.util.internal
 
 import java.io.File
 import java.util.Optional
+import java.util.function.Supplier
+
+import org.scalaide.logging.Logger
 
 import sbt.internal.inc.Analysis
 import sbt.internal.inc.FileAnalysisStore
@@ -31,6 +34,14 @@ object SbtUtils {
     def pointer(): Optional[Integer] = Optional.empty()
     def pointerSpace(): Optional[String] = Optional.empty()
     def sourceFile(): Optional[File] = Optional.empty()
-    def sourcePath(): Optional[String] =  Optional.empty()
+    def sourcePath(): Optional[String] = Optional.empty()
+  }
+
+  def defaultSbtLogger(logger: Logger): xsbti.Logger = new xsbti.Logger {
+    override def error(msg: Supplier[String]) = logger.error(msg.get)
+    override def warn(msg: Supplier[String]) = logger.warn(msg.get)
+    override def info(msg: Supplier[String]) = logger.info(msg.get)
+    override def debug(msg: Supplier[String]) = logger.debug(msg.get)
+    override def trace(exc: Supplier[Throwable]) = logger.error("", exc.get)
   }
 }


### PR DESCRIPTION
Adds `ResidentCompiler` used by scala worksheet for cross version compilation. Actually `ResidentCompiler` can be used by any other plugin in future.

- [x] tests for `ResidentCompiler`