### PR TITLE
Fixes premature scala project classpath initialization

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/InstallationManagement.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/project/InstallationManagement.scala
@@ -232,7 +232,7 @@ trait InstallationManagement { this: ScalaProject =>
   def usesProjectSettings: Boolean =
     projectSpecificStorage.getBoolean(SettingConverterUtil.USE_PROJECT_SETTINGS_PREFERENCE)
 
-  val compilerSettingsListener: IPropertyChangeListener = { (event: PropertyChangeEvent) =>
+  lazy val compilerSettingsListener: IPropertyChangeListener = { (event: PropertyChangeEvent) =>
     import org.scalaide.util.Utils.WithAsInstanceOfOpt
 
     if (event.getProperty() == SettingConverterUtil.SCALA_DESIRED_INSTALLATION) {


### PR DESCRIPTION
There is following exception in case of many dependent projects:
```
java.lang.IllegalArgumentException: Attempted to beginRule: P/Core Macros, does not match outer scope rule: P/Main Settings
	at org.eclipse.core.runtime.Assert.isLegal(Assert.java:63)
	at org.eclipse.core.internal.jobs.ThreadJob.illegalPush(ThreadJob.java:134)
	at org.eclipse.core.internal.jobs.ThreadJob.push(ThreadJob.java:349)
	at org.eclipse.core.internal.jobs.ImplicitJobs.begin(ImplicitJobs.java:63)
	at org.eclipse.core.internal.jobs.JobManager.beginRule(JobManager.java:308)
	at org.eclipse.core.internal.resources.WorkManager.checkIn(WorkManager.java:121)
	at org.eclipse.core.internal.resources.Workspace.prepareOperation(Workspace.java:2188)
	at org.eclipse.core.internal.resources.Project.touch(Project.java:1318)
	at org.eclipse.jdt.internal.core.SetContainerOperation.executeOperation(SetContainerOperation.java:116)
	at org.eclipse.jdt.internal.core.JavaModelOperation.run(JavaModelOperation.java:724)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2240)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2267)
	at org.eclipse.jdt.internal.core.JavaModelOperation.runOperation(JavaModelOperation.java:795)
	at org.eclipse.jdt.internal.core.JavaModelManager.getClasspathContainer(JavaModelManager.java:2064)
	at org.eclipse.jdt.core.JavaCore.getClasspathContainer(JavaCore.java:3548)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:2986)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:3150)
	at org.eclipse.jdt.internal.core.JavaProject.getResolvedClasspath(JavaProject.java:2255)
	at org.eclipse.jdt.internal.core.ExternalFolderChange.updateExternalFoldersIfNecessary(ExternalFolderChange.java:39)
	at org.eclipse.jdt.internal.core.ChangeClasspathOperation.classpathChanged(ChangeClasspathOperation.java:59)
	at org.eclipse.jdt.internal.core.SetContainerOperation.executeOperation(SetContainerOperation.java:111)
	at org.eclipse.jdt.internal.core.JavaModelOperation.run(JavaModelOperation.java:724)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2240)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2267)
	at org.eclipse.jdt.internal.core.JavaModelOperation.runOperation(JavaModelOperation.java:795)
	at org.eclipse.jdt.internal.core.JavaModelManager.getClasspathContainer(JavaModelManager.java:2064)
	at org.eclipse.jdt.internal.core.ClasspathEntry.validateClasspathEntry(ClasspathEntry.java:2134)
	at org.eclipse.jdt.internal.core.ClasspathEntry.validateClasspathEntry(ClasspathEntry.java:2085)
	at org.eclipse.jdt.internal.core.ClasspathValidation.validate(ClasspathValidation.java:72)
	at org.eclipse.jdt.internal.core.ChangeClasspathOperation.classpathChanged(ChangeClasspathOperation.java:51)
	at org.eclipse.jdt.internal.core.SetContainerOperation.executeOperation(SetContainerOperation.java:111)
	at org.eclipse.jdt.internal.core.JavaModelOperation.run(JavaModelOperation.java:724)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2240)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2267)
	at org.eclipse.jdt.internal.core.JavaModelOperation.runOperation(JavaModelOperation.java:795)
	at org.eclipse.jdt.internal.core.JavaModelManager.getClasspathContainer(JavaModelManager.java:2064)
	at org.eclipse.jdt.core.JavaCore.getClasspathContainer(JavaCore.java:3548)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:2986)
	at org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(JavaProject.java:3150)
	at org.eclipse.jdt.internal.core.JavaProject.getResolvedClasspath(JavaProject.java:2255)
	at org.eclipse.jdt.internal.core.JavaProject.computePackageFragmentRoots(JavaProject.java:724)
	at org.eclipse.jdt.internal.core.JavaProject.computePackageFragmentRoots(JavaProject.java:963)
	at org.eclipse.jdt.internal.core.JavaProject.computePackageFragmentRoots(JavaProject.java:922)
	at org.eclipse.jdt.internal.core.JavaProject.getAllPackageFragmentRoots(JavaProject.java:1702)
	at org.eclipse.jdt.internal.core.JavaProject.getAllPackageFragmentRoots(JavaProject.java:1697)
	at org.scalaide.core.internal.project.ClasspathManagement.scalaLibraries(ClasspathManagement.scala:291)
	at org.scalaide.core.internal.project.ClasspathManagement.checkClasspath(ClasspathManagement.scala:353)
	at org.scalaide.core.internal.project.ClasspathManagement.checkClasspath$(ClasspathManagement.scala:348)
	at org.scalaide.core.internal.project.ScalaProject.checkClasspath(ScalaProject.scala:150)
	at org.scalaide.core.internal.project.ClasspathManagement.classpathHasChanged(ClasspathManagement.scala:245)
	at org.scalaide.core.internal.project.ClasspathManagement.classpathHasChanged$(ClasspathManagement.scala:240)
	at org.scalaide.core.internal.project.ScalaProject.classpathHasChanged(ScalaProject.scala:150)
	at org.scalaide.core.internal.project.InstallationManagement.$anonfun$compilerSettingsListener$1(InstallationManagement.scala:247)
	at org.eclipse.ui.preferences.ScopedPreferenceStore$2.run(ScopedPreferenceStore.java:344)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.firePropertyChangeEvent(ScopedPreferenceStore.java:341)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.lambda$0(ScopedPreferenceStore.java:178)
	at org.eclipse.core.internal.preferences.EclipsePreferences$2.run(EclipsePreferences.java:848)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.core.internal.preferences.EclipsePreferences.firePreferenceEvent(EclipsePreferences.java:851)
	at org.eclipse.core.internal.preferences.EclipsePreferences.convertFromProperties(EclipsePreferences.java:259)
	at org.eclipse.core.internal.resources.ProjectPreferences.load(ProjectPreferences.java:509)
	at org.eclipse.core.internal.resources.ProjectPreferences.silentLoad(ProjectPreferences.java:682)
	at org.eclipse.core.internal.resources.ProjectPreferences.keys(ProjectPreferences.java:486)
	at org.eclipse.core.internal.preferences.PreferencesService$1.visit(PreferencesService.java:155)
	at org.eclipse.core.internal.preferences.EclipsePreferences.accept(EclipsePreferences.java:112)
	at org.eclipse.core.internal.preferences.PreferencesService.applyPreferences(PreferencesService.java:197)
	at org.eclipse.core.internal.resources.ProjectPreferences.read(ProjectPreferences.java:205)
	at org.eclipse.core.internal.resources.ProjectPreferences.updatePreferences(ProjectPreferences.java:273)
	at org.eclipse.core.internal.resources.File.updateMetadataFiles(File.java:387)
	at org.eclipse.core.internal.localstore.RefreshLocalVisitor.visit(RefreshLocalVisitor.java:288)
	at org.eclipse.core.internal.localstore.UnifiedTree.accept(UnifiedTree.java:111)
	at org.eclipse.core.internal.localstore.FileSystemResourceManager.refreshResource(FileSystemResourceManager.java:971)
	at org.eclipse.core.internal.localstore.FileSystemResourceManager.refresh(FileSystemResourceManager.java:954)
	at org.eclipse.core.internal.resources.Resource.refreshLocal(Resource.java:1560)
	at org.eclipse.core.internal.refresh.RefreshJob.runInWorkspace(RefreshJob.java:163)
	at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:39)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:56)
```