### PR TITLE
Fixes incompatibility of presentation reporter

### DIFF
--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/compiler/ScalaPresentationCompiler.scala
@@ -93,7 +93,10 @@ class ScalaPresentationCompiler(private[compiler] val name: String, _settings: S
 
   override def forScaladoc = true
 
-  def presentationReporter = reporter.asInstanceOf[ScalaPresentationCompiler.PresentationReporter]
+  def presentationReporter: ScalaPresentationCompiler.PresentationReporter = reporter match {
+    case reporter: ScalaPresentationCompiler.PresentationReporter => reporter
+    case probablyReplacedByCompilerPlugin @ _ => new ScalaPresentationCompiler.PresentationReporter(name)
+  }
   presentationReporter.compiler = this
 
   def compilationUnits: List[InteractiveCompilationUnit] = {


### PR DESCRIPTION
When `semanticdb-scalac` is used as compiler plugin then presentation
reporter is overridden. This fix recreates it in that case.