### PR TITLE
Enables worksheet macro expansion. Makes worksheet more stable.

### DIFF
--- a/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/ResidentCompilerTest.scala
+++ b/org.scala-ide.sdt.core.tests/src/org/scalaide/core/compiler/ResidentCompilerTest.scala
@@ -6,6 +6,7 @@ import org.junit.Assert
 import org.junit.Test
 import org.scalaide.core.SdtConstants
 import org.scalaide.core.internal.builder.zinc.ResidentCompiler
+import org.scalaide.core.internal.builder.zinc.ResidentCompiler.CompilationError
 import org.scalaide.core.internal.builder.zinc.ResidentCompiler.CompilationFailed
 import org.scalaide.core.internal.builder.zinc.ResidentCompiler.CompilationSuccess
 import org.scalaide.core.testsetup.TestProjectSetup
@@ -46,11 +47,15 @@ class ResidentCompilerTest {
     val tested = ResidentCompiler(project, output, None).get
 
     try {
-      tested.compile(javaSrc)
-      Assert.fail(s"Expected compilation error")
+      tested.compile(javaSrc) match {
+        case CompilationFailed(CompilationError(actual, _) :: Nil) =>
+          Assert.assertTrue(actual == "expects to be not called")
+        case fail =>
+          Assert.fail(s"Expected compilation error, got $fail")
+      }
     } catch {
-      case correct: NotImplementedError =>
-        Assert.assertTrue(correct.getMessage == "expects to be not called")
+      case fail: Throwable =>
+        Assert.fail(s"Expected compilation error, got ${fail.getMessage}")
     }
 
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
@@ -16,6 +16,7 @@ import org.scalaide.util.internal.SbtUtils
 
 import sbt.internal.inc.FreshCompilerCache
 import sbt.internal.inc.IncrementalCompilerImpl
+import xsbti.CompileFailed
 import xsbti.compile.CompileAnalysis
 import xsbti.compile.CompileOrder
 import xsbti.compile.CompileProgress
@@ -24,7 +25,7 @@ import xsbti.compile.MiniSetup
 
 object ResidentCompiler {
   def apply(project: IScalaProject, compilationOutputFolder: File, extraLibsToCompile: Option[IPath],
-      monitor: SubMonitor = SubMonitor.convert(new NullProgressMonitor)) = {
+            monitor: SubMonitor = SubMonitor.convert(new NullProgressMonitor)) = {
     val installation = project.effectiveScalaInstallation
     val comps = compilers(installation, monitor)
     comps.toOption.map { comps => new ResidentCompiler(project, comps, compilationOutputFolder, extraLibsToCompile) }
@@ -38,13 +39,16 @@ object ResidentCompiler {
 }
 
 class ResidentCompiler private (project: IScalaProject, comps: Compilers, compilationOutputFolder: File,
-    extraLibsToCompile: Option[IPath]) extends HasLogger {
+                                extraLibsToCompile: Option[IPath]) extends HasLogger {
   import ResidentCompiler._
   private val sbtLogger = SbtUtils.defaultSbtLogger(logger)
   private val libs = extraLibsToCompile.map(_.toFile).toSeq
   private val zincCompiler = new IncrementalCompilerImpl
   private val sbtReporter = new SbtBuildReporter(project)
-  private val lookup = new DefaultPerClasspathEntryLookup {}
+  private val lookup = new DefaultPerClasspathEntryLookup {
+    override def definesClass(classpathEntry: File) =
+      Locator.NoClass
+  }
   private val classpath = libs ++ project.scalaClasspath.userCp.map(_.toFile) toArray
   private val scalacOpts = (project.effectiveScalaInstallation.version match {
     case SpecificScalaVersion(2, 10, _, _) =>
@@ -52,31 +56,43 @@ class ResidentCompiler private (project: IScalaProject, comps: Compilers, compil
     case _ => project.scalacArguments
   }) toArray
 
+  val problemToCompilationError: PartialFunction[xsbti.Problem, CompilationError] = {
+    case p if p.severity == xsbti.Severity.Error =>
+      val pos = p.position.line.map[Position] { pline =>
+        new Position {
+          override def line = pline
+        }
+      }.orElse { NoPosition }
+      CompilationError(p.message, pos)
+  }
+
   def compile(compiledSource: File): CompilationResult = try {
+    import java.nio.file.Files
+    Files.lines(compiledSource.toPath).toArray.foreach(a => logger.warn(a))
     def incOptions: IncOptions = IncOptions.of()
     def output = new EclipseMultipleOutput(Seq(compiledSource.toPath.getParent.toFile -> compilationOutputFolder))
     def cache = new FreshCompilerCache
 
+    sbtReporter.reset()
     zincCompiler.compile(comps.scalac, comps.javac, Array(compiledSource), classpath, output, cache, scalacOpts,
       javaOptions = Array(), Optional.empty[CompileAnalysis], Optional.empty[MiniSetup], lookup, sbtReporter,
       CompileOrder.ScalaThenJava, skip = false, Optional.empty[CompileProgress], incOptions, extra = Array(),
       sbtLogger)
 
-    import xsbti.Severity._
-    val errors = sbtReporter.problems.collect {
-      case p if p.severity == Error =>
-        val pos = p.position.line.map[Position] { pline =>
-          new Position {
-            override def line = pline
-          }
-        }.orElse { NoPosition }
-        CompilationError(p.message, pos)
-    }
-    errors.toSeq match {
+    sbtReporter.problems.collect {
+      problemToCompilationError
+    }.toSeq match {
       case errors @ _ +: _ => CompilationFailed(errors)
-      case Nil => CompilationSuccess
+      case Nil             => CompilationSuccess
     }
   } catch {
+    case compileFailed: CompileFailed =>
+      compileFailed.problems
+        .collect(problemToCompilationError)
+        .toSeq match {
+          case errors @ _ +: _ => CompilationFailed(errors)
+          case Nil             => CompilationSuccess
+        }
     case anyException: Throwable =>
       CompilationFailed(Seq(CompilationError(anyException.getMessage, NoPosition)))
   }

--- a/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
+++ b/org.scala-ide.sdt.core/src/org/scalaide/core/internal/builder/zinc/ResidentCompiler.scala
@@ -52,7 +52,7 @@ class ResidentCompiler private (project: IScalaProject, comps: Compilers, compil
     case _ => project.scalacArguments
   }) toArray
 
-  def compile(compiledSource: File): CompilationResult = {
+  def compile(compiledSource: File): CompilationResult = try {
     def incOptions: IncOptions = IncOptions.of()
     def output = new EclipseMultipleOutput(Seq(compiledSource.toPath.getParent.toFile -> compilationOutputFolder))
     def cache = new FreshCompilerCache
@@ -76,5 +76,8 @@ class ResidentCompiler private (project: IScalaProject, comps: Compilers, compil
       case errors @ _ +: _ => CompilationFailed(errors)
       case Nil => CompilationSuccess
     }
+  } catch {
+    case anyException: Throwable =>
+      CompilationFailed(Seq(CompilationError(anyException.getMessage, NoPosition)))
   }
 }


### PR DESCRIPTION
There are 2 solved issues:
- 2.11 can expand macros so there is no reason to not do it, especially that Spark worksheets need it
- in any resident compiler's compilation exception, translate it to compilation failure